### PR TITLE
TINY-11676: fix FireFox selection for floating images

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11676-2025-04-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-11676-2025-04-17.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Now pressing enter after before a floating wrapped image doesn't cause to duplicate that image.
+time: 2025-04-17T09:09:49.451619873+02:00
+custom:
+    Issue: TINY-11676

--- a/.changes/unreleased/tinymce-TINY-11676-2025-04-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-11676-2025-04-17.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Now pressing enter after before a floating wrapped image doesn't cause to duplicate that image.
+body: Now pressing enter before a floating wrapped image doesn't cause to duplicate that image.
 time: 2025-04-17T09:09:49.451619873+02:00
 custom:
     Issue: TINY-11676

--- a/.changes/unreleased/tinymce-TINY-11676-2025-04-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-11676-2025-04-17.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Now pressing enter before a floating wrapped image doesn't cause to duplicate that image.
+body: Pressing enter before a floating image sometimes duplicated the image.
 time: 2025-04-17T09:09:49.451619873+02:00
 custom:
     Issue: TINY-11676

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -257,8 +257,7 @@ const Quirks = (editor: Editor): Quirks => {
     const isEditableImage = (node: Node): node is HTMLImageElement => node.nodeName === 'IMG' && editor.dom.isEditable(node);
 
     editor.on('mousedown', (e) => {
-      const caretPos = editor.getDoc().caretPositionFromPoint(e.clientX, e.clientY);
-
+      const caretPos = editor.getDoc().caretPositionFromPoint(Math.ceil(e.clientX), Math.ceil(e.clientY));
       if (caretPos && isEditableImage(caretPos.offsetNode)) {
         const rect = caretPos.offsetNode.getBoundingClientRect();
 

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,4 +1,4 @@
-import { Fun } from '@ephox/katamari';
+import { Fun, Optional, Optionals } from '@ephox/katamari';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -257,23 +257,25 @@ const Quirks = (editor: Editor): Quirks => {
     const isEditableImage = (node: Node): node is HTMLImageElement => node.nodeName === 'IMG' && editor.dom.isEditable(node);
 
     editor.on('mousedown', (e) => {
-      const caretPos = editor.getDoc().caretPositionFromPoint(Math.ceil(e.clientX), Math.ceil(e.clientY));
-      if (caretPos && isEditableImage(caretPos.offsetNode)) {
-        const rect = caretPos.offsetNode.getBoundingClientRect();
+      Optionals.lift2(Optional.from(e.clientX), Optional.from(e.clientY), (clientX, clientY) => {
+        const caretPos = editor.getDoc().caretPositionFromPoint(clientX, clientY);
+        if (caretPos && isEditableImage(caretPos.offsetNode)) {
+          const rect = caretPos.offsetNode.getBoundingClientRect();
 
-        e.preventDefault();
+          e.preventDefault();
 
-        if (!editor.hasFocus()) {
-          editor.focus();
+          if (!editor.hasFocus()) {
+            editor.focus();
+          }
+
+          editor.selection.select(caretPos.offsetNode);
+          if (e.clientX < rect.left || e.clientY < rect.top) {
+            editor.selection.collapse(true);
+          } else if (e.clientX > rect.right || e.clientY > rect.bottom) {
+            editor.selection.collapse(false);
+          }
         }
-
-        editor.selection.select(caretPos.offsetNode);
-        if (e.clientX < rect.left || e.clientY < rect.top) {
-          editor.selection.collapse(true);
-        } else if (e.clientX > rect.right || e.clientY > rect.bottom) {
-          editor.selection.collapse(false);
-        }
-      }
+      });
     });
   };
 

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -250,6 +250,20 @@ const Quirks = (editor: Editor): Quirks => {
   };
 
   /**
+   * Fixes a Gecko a selection bug where if there is a floating image
+   * more details here: https://bugzilla.mozilla.org/show_bug.cgi?id=1959606
+   */
+  const fixFirefoxImageSelection = () => {
+    editor.on('selectionchange', () => {
+      const rng = editor.selection.getRng();
+      if (rng.collapsed && rng.startContainer.nodeName === 'IMG') {
+        editor.selection.select(rng.startContainer);
+        editor.selection.collapse(true);
+      }
+    });
+  };
+
+  /**
    * Fixes a Gecko bug where the style attribute gets added to the wrong element when deleting between two block elements.
    *
    * Fixes do backspace/delete on this:
@@ -713,6 +727,7 @@ const Quirks = (editor: Editor): Quirks => {
 
     // Gecko
     if (isGecko) {
+      fixFirefoxImageSelection();
       removeHrOnBackspace();
       focusBody();
       removeStylesWhenDeletingAcrossBlockElements();

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -254,11 +254,26 @@ const Quirks = (editor: Editor): Quirks => {
    * more details here: https://bugzilla.mozilla.org/show_bug.cgi?id=1959606
    */
   const fixFirefoxImageSelection = () => {
-    editor.on('selectionchange', () => {
-      const rng = editor.selection.getRng();
-      if (rng.collapsed && rng.startContainer.nodeName === 'IMG') {
-        editor.selection.select(rng.startContainer);
-        editor.selection.collapse(true);
+    const isEditableImage = (node: Node): node is HTMLImageElement => node.nodeName === 'IMG' && editor.dom.isEditable(node);
+
+    editor.on('mousedown', (e) => {
+      const caretPos = editor.getDoc().caretPositionFromPoint(e.clientX, e.clientY);
+
+      if (caretPos && isEditableImage(caretPos.offsetNode)) {
+        const rect = caretPos.offsetNode.getBoundingClientRect();
+
+        e.preventDefault();
+
+        if (!editor.hasFocus()) {
+          editor.focus();
+        }
+
+        editor.selection.select(caretPos.offsetNode);
+        if (e.clientX < rect.left || e.clientY < rect.top) {
+          editor.selection.collapse(true);
+        } else if (e.clientX > rect.right || e.clientY > rect.bottom) {
+          editor.selection.collapse(false);
+        }
       }
     });
   };

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -1,4 +1,4 @@
-import { UiFinder } from '@ephox/agar';
+import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
@@ -24,7 +24,7 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
     if (point) {
       editor.selection.getSel()?.setBaseAndExtent(point.offsetNode, point.offset, point.offsetNode, point.offset);
     }
-
+    await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], 0));
     editor.execCommand('mceInsertNewLine');
     TinyAssertions.assertContent(editor, `<p>${Unicode.nbsp}</p>` + initialContent);
   });

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -22,7 +22,7 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
       }
 
       const editor = hook.editor();
-      const initialContent = '<p><strong><img style="display: block; margin-left: auto;" src="img.jpg" width="1" height="1"></strong></p>';
+      const initialContent = '<p><strong><img style="display: block; margin-left: auto; margin-right: auto;" src="img.jpg" width="1" height="1"></strong></p>';
       editor.setContent(initialContent);
       const imgElement = await UiFinder.pWaitFor<HTMLElement>('', TinyDom.body(editor), 'img');
       const pRect = imgElement.dom.getBoundingClientRect();

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { Arr, Unicode } from '@ephox/katamari';
+import { before, describe, it } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
@@ -14,30 +14,75 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
   }, []);
   const platform = PlatformDetection.detect();
 
-  Arr.each([ true, false ], (before) => {
-    it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image ' + (before ? '(before)' : '(after)'), async function () {
-      // this test is needed only for Firefox
-      if (!platform.browser.isFirefox()) {
-        this.skip();
-      }
+  before(function () {
+    // these test is needed only for Firefox
+    if (!platform.browser.isFirefox()) {
+      this.skip();
+    }
+  });
 
-      const editor = hook.editor();
-      const initialContent = '<p><strong><img style="display: block; margin-left: auto; margin-right: auto;" src="img.jpg" width="1" height="1"></strong></p>';
-      editor.setContent(initialContent);
-      const imgElement = await UiFinder.pWaitFor<HTMLElement>('', TinyDom.body(editor), 'img');
-      const pRect = imgElement.dom.getBoundingClientRect();
-      const clientX = before ? pRect.left - 2 : pRect.left + 2;
-      const clientY = pRect.top;
-      const mouseDownEvent = new MouseEvent('mousedown', {
-        bubbles: true,
-        cancelable: true,
-        clientX,
-        clientY
-      });
-      TinyDom.body(editor).dom.dispatchEvent(mouseDownEvent);
-      await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], before ? 0 : 1));
-      editor.execCommand('mceInsertNewLine');
-      TinyAssertions.assertContent(editor, before ? `<p>${Unicode.nbsp}</p>${initialContent}` : `${initialContent}<p>${Unicode.nbsp}</p>`);
+  const floatingCenterStyle = 'display: block; margin-left: auto; margin-right: auto;';
+  const floatLeftStyle = 'float: left;';
+  const floatRightStyle = 'float: right;';
+  const testSelection = async (position: 'before' | 'on' | 'after', style: string) => {
+    const editor = hook.editor();
+    const initialContent = `<p><strong><img style="${style}" src="img.jpg" width="10" height="10"></strong></p>`;
+    editor.setContent(initialContent);
+    const imgElement = await UiFinder.pWaitFor<HTMLElement>('', TinyDom.body(editor), 'img');
+    const pRect = imgElement.dom.getBoundingClientRect();
+    const clientX = pRect.left + {
+      before: -2,
+      on: 2,
+      after: 12
+    }[position];
+
+    const clientY = pRect.top;
+    const mouseDownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      clientX,
+      clientY
     });
+    TinyDom.body(editor).dom.dispatchEvent(mouseDownEvent);
+    switch (position) {
+      case 'before':
+        await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], 0));
+        break;
+      case 'on':
+        await Waiter.pTryUntil('selection now should be on the `img`', () => TinyAssertions.assertSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1));
+        break;
+      case 'after':
+        await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], 1));
+        break;
+    }
+
+    editor.execCommand('mceInsertNewLine');
+    switch (position) {
+      case 'before':
+        TinyAssertions.assertContent(editor, `<p>${Unicode.nbsp}</p>${initialContent}`);
+        break;
+      case 'after':
+        TinyAssertions.assertContent(editor, `${initialContent}<p>${Unicode.nbsp}</p>`);
+        break;
+      case 'on':
+        TinyAssertions.assertContent(editor, `<p>${Unicode.nbsp}</p><p>${Unicode.nbsp}</p>`);
+        break;
+    }
+  };
+
+  it('TINY-11676: clicking on a `p` containg a center floating `img` in FireFox before the image', async () => {
+    await testSelection('before', floatingCenterStyle);
+  });
+
+  it('TINY-11676: clicking on a `p` containg a center floating `img` in FireFox after the image', async () => {
+    await testSelection('after', floatingCenterStyle);
+  });
+
+  it('TINY-11676: clicking on a `p` containg a left floating `img` in FireFox on the image', async () => {
+    await testSelection('on', floatLeftStyle);
+  });
+
+  it('TINY-11676: clicking on a `p` containg a right floating `img` in FireFox on the image', async () => {
+    await testSelection('on', floatRightStyle);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -1,6 +1,6 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { Unicode } from '@ephox/katamari';
+import { Arr, Unicode } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
@@ -14,27 +14,30 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
   }, []);
   const platform = PlatformDetection.detect();
 
-  it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image', async function () {
-    // Safari doesn't have `caretPositionFromPoint`
-    if (platform.browser.isSafari()) {
-      this.skip();
-    }
+  Arr.each([ true, false ], (before) => {
+    it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image ' + (before ? '(before)' : '(after)'), async function () {
+      // this test is needed only for Firefox
+      if (!platform.browser.isFirefox()) {
+        this.skip();
+      }
 
-    const editor = hook.editor();
-    const initialContent = '<p><strong><img style="display: block; margin-left: auto;" src="img.jpg" width="1" height="1"></strong></p>';
-    editor.setContent(initialContent);
-    const imgElement = await UiFinder.pWaitFor<HTMLElement>('', TinyDom.body(editor), 'img');
-    const pRect = imgElement.dom.getBoundingClientRect();
-    const clientX = pRect.left + (pRect.width / 2);
-    const clientY = pRect.top + (pRect.height / 2);
-    const point = editor.getDoc().caretPositionFromPoint(clientX, clientY);
-    if (point) {
-      editor.selection.getSel()?.setBaseAndExtent(point.offsetNode, point.offset, point.offsetNode, point.offset);
-    } else {
-      throw new Error('caretPositionFromPoint returned null - coordinates may be negative or outside viewport');
-    }
-    await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], 0));
-    editor.execCommand('mceInsertNewLine');
-    TinyAssertions.assertContent(editor, `<p>${Unicode.nbsp}</p>` + initialContent);
+      const editor = hook.editor();
+      const initialContent = '<p><strong><img style="display: block; margin-left: auto;" src="img.jpg" width="1" height="1"></strong></p>';
+      editor.setContent(initialContent);
+      const imgElement = await UiFinder.pWaitFor<HTMLElement>('', TinyDom.body(editor), 'img');
+      const pRect = imgElement.dom.getBoundingClientRect();
+      const clientX = before ? pRect.left - 2 : pRect.left + 2;
+      const clientY = pRect.top;
+      const mouseDownEvent = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        clientX,
+        clientY
+      });
+      TinyDom.body(editor).dom.dispatchEvent(mouseDownEvent);
+      await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], before ? 0 : 1));
+      editor.execCommand('mceInsertNewLine');
+      TinyAssertions.assertContent(editor, before ? `<p>${Unicode.nbsp}</p>${initialContent}` : `${initialContent}<p>${Unicode.nbsp}</p>`);
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -1,7 +1,7 @@
-import { RealMouse } from '@ephox/agar';
+import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
-import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -16,7 +16,15 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
     const editor = hook.editor();
     const initialContent = '<p><strong><img style="display: block; margin-left: auto;" src="img.jpg" width="1" height="1"></strong></p>';
     editor.setContent(initialContent);
-    await RealMouse.pClickOn('iframe => body => p');
+    const imgElement = await UiFinder.pWaitFor<HTMLElement>('', TinyDom.body(editor), 'img');
+    const pRect = imgElement.dom.getBoundingClientRect();
+    const clientX = pRect.left + (pRect.width / 2);
+    const clientY = pRect.top + (pRect.height / 2);
+    const point = editor.getDoc().caretPositionFromPoint(clientX, clientY);
+    if (point) {
+      editor.selection.getSel()?.setBaseAndExtent(point.offsetNode, point.offset, point.offsetNode, point.offset);
+    }
+
     editor.execCommand('mceInsertNewLine');
     TinyAssertions.assertContent(editor, `<p>${Unicode.nbsp}</p>` + initialContent);
   });

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -30,6 +30,8 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
     const point = editor.getDoc().caretPositionFromPoint(clientX, clientY);
     if (point) {
       editor.selection.getSel()?.setBaseAndExtent(point.offsetNode, point.offset, point.offsetNode, point.offset);
+    } else {
+      throw new Error('caretPositionFromPoint returned null - coordinates may be negative or outside viewport');
     }
     await Waiter.pTryUntil('selection now should be on the `strong`', () => TinyAssertions.assertCursor(editor, [ 0, 0 ], 0));
     editor.execCommand('mceInsertNewLine');

--- a/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/QuirksSelectionTest.ts
@@ -1,6 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -11,8 +12,14 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
     entities: 'raw',
     base_url: '/project/tinymce/js/tinymce'
   }, []);
+  const platform = PlatformDetection.detect();
 
-  it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image', async () => {
+  it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image', async function () {
+    // Safari doesn't have `caretPositionFromPoint`
+    if (platform.browser.isSafari()) {
+      this.skip();
+    }
+
     const editor = hook.editor();
     const initialContent = '<p><strong><img style="display: block; margin-left: auto;" src="img.jpg" width="1" height="1"></strong></p>';
     editor.setContent(initialContent);

--- a/modules/tinymce/src/core/test/ts/webdriver/content/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/QuirksSelectionTest.ts
@@ -14,7 +14,7 @@ describe('browser.tinymce.selection.QuirksSelectionTest', () => {
 
   it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image', async () => {
     const editor = hook.editor();
-    const initialContent = '<p><strong><img style="display: block; margin-left: auto; margin-right: auto;" src="img.jpg" width="354" height="116"></strong></p>';
+    const initialContent = '<p><strong><img style="display: block; margin-left: auto;" src="img.jpg" width="1" height="1"></strong></p>';
     editor.setContent(initialContent);
     await RealMouse.pClickOn('iframe => body => p');
     editor.execCommand('mceInsertNewLine');

--- a/modules/tinymce/src/core/test/ts/webdriver/content/QuirksSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/content/QuirksSelectionTest.ts
@@ -1,0 +1,23 @@
+import { RealMouse } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Unicode } from '@ephox/katamari';
+import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.selection.QuirksSelectionTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    indent: false,
+    entities: 'raw',
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  it('TINY-11676: pressing enter after clicking on a `p` containg a floating `img` in FireFox should not duplicate the image', async () => {
+    const editor = hook.editor();
+    const initialContent = '<p><strong><img style="display: block; margin-left: auto; margin-right: auto;" src="img.jpg" width="354" height="116"></strong></p>';
+    editor.setContent(initialContent);
+    await RealMouse.pClickOn('iframe => body => p');
+    editor.execCommand('mceInsertNewLine');
+    TinyAssertions.assertContent(editor, `<p>${Unicode.nbsp}</p>` + initialContent);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-11676

Description of Changes:
this won't fix all the issues in the Jira but it's only a workaround for the duplication, to fix also the caret position we need to wait for this: https://bugzilla.mozilla.org/show_bug.cgi?id=1959606

to test it I had to add a `webdriver` test since not using the `RealMouse` it seems not possible to replicate the issue

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where pressing Enter before a floating wrapped image could duplicate the image in the editor.
  - Improved selection behavior for floating images in Firefox to prevent unintended image selection and duplication.

- **Tests**
  - Added tests to verify that pressing Enter near floating images does not result in duplication, specifically addressing Firefox behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->