### PR TITLE
TINY-12044: deprecate skipFocus

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12044-2025-04-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-12044-2025-04-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Deprecated
+body: Deprecated `skipFocus` option for ToggleToolbarDrawer command. To skip focus use `skip_focus` option.
+time: 2025-04-23T13:58:50.774276+02:00
+custom:
+  Issue: TINY-12044

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -119,9 +119,7 @@ const logWarnings = (rawOptions: RawEditorOptions, normalizedOptions: Normalized
   logDeprecatedWarnings(rawOptions, normalizedOptions);
 };
 
-// TODO: add migration URL in ToggleToolbarDrawer message #TINY-12087
 const deprecatedFeatures = {
-  skipFocus: 'ToggleToolbarDrawer skipFocus is deprecated see migration guide: ....',
   fire: 'The "fire" event api has been deprecated and will be removed in TinyMCE 9. Use "dispatch" instead.'
 };
 

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -119,6 +119,18 @@ const logWarnings = (rawOptions: RawEditorOptions, normalizedOptions: Normalized
   logDeprecatedWarnings(rawOptions, normalizedOptions);
 };
 
+// TODO: add migration URL in ToggleToolbarDrawer message #TINY-12087
+const deprecatedFeatures = {
+  skipFocus: 'ToggleToolbarDrawer skipFocus is deprecated see migration guide: ....',
+  fire: 'The "fire" event api has been deprecated and will be removed in TinyMCE 9. Use "dispatch" instead.'
+};
+
+const logFeatureDeprecationWarning = (feature: keyof typeof deprecatedFeatures): void => {
+  // eslint-disable-next-line no-console
+  console.warn(deprecatedFeatures[feature], new Error().stack);
+};
+
 export {
-  logWarnings
+  logWarnings,
+  logFeatureDeprecationWarning
 };

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -12,7 +12,7 @@ import Editor from './Editor';
  */
 
 export type EditorCommandCallback<S> = (this: S, ui: boolean, value: any, args?: ExecCommandArgs) => void;
-export type EditorCommandsCallback = (command: string, ui: boolean, value: any, args?: ExecCommandArgs) => void;
+export type EditorCommandsCallback = (command: string, ui: boolean, value?: any, args?: ExecCommandArgs) => void;
 
 interface Commands {
   state: Record<string, (command: string) => boolean>;

--- a/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/EditorCommands.ts
@@ -11,8 +11,8 @@ import Editor from './Editor';
  * @class tinymce.EditorCommands
  */
 
-export type EditorCommandCallback<S> = (this: S, ui: boolean, value: any) => void;
-export type EditorCommandsCallback = (command: string, ui: boolean, value?: any) => void;
+export type EditorCommandCallback<S> = (this: S, ui: boolean, value: any, args?: ExecCommandArgs) => void;
+export type EditorCommandsCallback = (command: string, ui: boolean, value: any, args?: ExecCommandArgs) => void;
 
 interface Commands {
   state: Record<string, (command: string) => boolean>;
@@ -78,8 +78,8 @@ class EditorCommands {
 
     const func = this.commands.exec[lowerCaseCommand];
     if (Type.isFunction(func)) {
-      func(lowerCaseCommand, ui, value);
-      editor.dispatch('ExecCommand', { command, ui, value });
+      func(lowerCaseCommand, ui, value, args);
+      editor.dispatch('ExecCommand', { command, ui, value, args });
       return true;
     }
 
@@ -151,7 +151,7 @@ class EditorCommands {
   public addCommand(command: string, callback: EditorCommandCallback<Editor>): void;
   public addCommand(command: string, callback: EditorCommandCallback<any>, scope?: any): void {
     const lowerCaseCommand = command.toLowerCase();
-    this.commands.exec[lowerCaseCommand] = (_command, ui, value) => callback.call(scope ?? this.editor, ui, value);
+    this.commands.exec[lowerCaseCommand] = (_command, ui, value, args) => callback.call(scope ?? this.editor, ui, value, args);
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/util/Observable.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Observable.ts
@@ -1,3 +1,4 @@
+import * as Deprecations from '../../Deprecations';
 import * as EventUtils from '../../events/EventUtils';
 import EventDispatcher, { EditorEvent, MappedEvent } from './EventDispatcher';
 
@@ -59,8 +60,7 @@ const Observable: Observable<any> = {
    * instance.fire('event', {...});
    */
   fire<K extends string, U extends MappedEvent<any, K>>(name: K, args?: U, bubble?: boolean) {
-    // eslint-disable-next-line no-console
-    console.warn('The "fire" event api has been deprecated and will be removed in TinyMCE 9. Use "dispatch" instead.', new Error().stack);
+    Deprecations.logFeatureDeprecationWarning('fire');
     return this.dispatch(name, args, bubble);
   },
 

--- a/modules/tinymce/src/themes/silver/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Deprecations.ts
@@ -1,0 +1,13 @@
+// TODO: add migration URL in ToggleToolbarDrawer message #TINY-12087
+const deprecatedFeatures = {
+  skipFocus: 'ToggleToolbarDrawer skipFocus is deprecated see migration guide: ....',
+};
+
+const logFeatureDeprecationWarning = (feature: keyof typeof deprecatedFeatures): void => {
+  // eslint-disable-next-line no-console
+  console.warn(deprecatedFeatures[feature], new Error().stack);
+};
+
+export {
+  logFeatureDeprecationWarning
+};

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -10,10 +10,10 @@ import { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
 
-import * as Deprecations from '../../../../core/main/ts/Deprecations';
 import * as Events from './api/Events';
 import * as Options from './api/Options';
 import * as Backstage from './backstage/Backstage';
+import * as Deprecations from './Deprecations';
 import * as DomEvents from './Events';
 import * as Iframe from './modes/Iframe';
 import * as Inline from './modes/Inline';

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -9,6 +9,7 @@ import Editor from 'tinymce/core/api/Editor';
 import { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
+import * as Deprecations from 'tinymce/core/Deprecations';
 
 import * as Events from './api/Events';
 import * as Options from './api/Options';
@@ -478,8 +479,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
 
     editor.addCommand('ToggleToolbarDrawer', (_ui, options?: { skipFocus: boolean }, args?: ExecCommandArgs) => {
       if (options?.skipFocus) {
-        // eslint-disable-next-line no-console
-        console.warn('ToggleToolbarDrawer skipFocus is deprecated see migration guide: ....');
+        Deprecations.logFeatureDeprecationWarning('skipFocus');
         OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);
       } else if (args?.skip_focus) {
         OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -9,8 +9,8 @@ import Editor from 'tinymce/core/api/Editor';
 import { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
-import * as Deprecations from 'tinymce/core/Deprecations';
 
+import * as Deprecations from '../../../../core/main/ts/Deprecations';
 import * as Events from './api/Events';
 import * as Options from './api/Options';
 import * as Backstage from './backstage/Backstage';

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -6,6 +6,7 @@ import { PlatformDetection } from '@ephox/sand';
 import { Compare, Css, SugarBody, SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
+import { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
 import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
 
@@ -475,8 +476,12 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       OuterContainer.focusToolbar(outerContainer);
     });
 
-    editor.addCommand('ToggleToolbarDrawer', (_ui, options?: { skipFocus: boolean }) => {
+    editor.addCommand('ToggleToolbarDrawer', (_ui, options?: { skipFocus: boolean }, args?: ExecCommandArgs) => {
       if (options?.skipFocus) {
+        // eslint-disable-next-line no-console
+        console.warn('ToggleToolbarDrawer skipFocus is deprecated see migration guide: ....');
+        OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);
+      } else if (args?.skip_focus) {
         OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);
       } else {
         OuterContainer.toggleToolbarDrawer(outerContainer);


### PR DESCRIPTION
Related Ticket: TINY-12044

Description of Changes:
* Added `args` parameter to `EditorCommandCallback` and `EditorCommandsCallback` types
* Updated `execCommand` to pass `args` to command callbacks and include it in the dispatched event
* Modified `addCommand` to pass `args` to the callback function
* Added support for `skip_focus` parameter in `ToggleToolbarDrawer` command
* Added deprecation warning for the old `skipFocus` option in `ToggleToolbarDrawer`

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced command execution to support passing additional arguments, allowing for more flexible command handling.
  - Updated toolbar drawer toggle command to accept a new way of skipping focus via an additional argument, while maintaining backward compatibility with a warning for deprecated usage.

- **Bug Fixes**
  - Ensured improved handling of optional command arguments in relevant commands.

- **Chores**
  - Introduced centralized deprecation warnings for specific features to improve consistency in logging and user notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->