### PR TITLE
TINY-11629: Upgrade agar to use eslint V9

### DIFF
--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock --testdirs src/test/ts/browser src/test/ts/atomic",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
   },
   "keywords": [
     "testing",

--- a/modules/agar/src/main/ts/ephox/agar/api/Arbitraries.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Arbitraries.ts
@@ -4,6 +4,7 @@ import * as fc from 'fast-check';
 import * as ArbContent from '../arbitrary/ArbContent';
 import { SchemaDetail } from '../arbitrary/ArbSchemaTypes';
 import { SelectionExclusions } from '../arbitrary/GenSelection';
+
 import * as Generators from './Generators';
 
 const scenario = (

--- a/modules/agar/src/main/ts/ephox/agar/api/Assertions.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Assertions.ts
@@ -5,6 +5,7 @@ import { Compare, SugarElement, Truncate } from '@ephox/sugar';
 
 import { elementQueue, StructAssert } from '../assertions/ApproxStructures';
 import * as Differ from '../assertions/Differ';
+
 import * as ApproxStructure from './ApproxStructure';
 import { Chain } from './Chain';
 import * as Logger from './Logger';

--- a/modules/agar/src/main/ts/ephox/agar/api/Chain.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Chain.ts
@@ -4,6 +4,7 @@ import { Arr, Fun, Result } from '@ephox/katamari';
 import * as AsyncActions from '../pipe/AsyncActions';
 import * as GeneralActions from '../pipe/GeneralActions';
 import { DieFn, NextFn, Pipe, RunFn } from '../pipe/Pipe';
+
 import { addLogging, GuardFn } from './Guard';
 import { Pipeline } from './Pipeline';
 import { Step } from './Step';

--- a/modules/agar/src/main/ts/ephox/agar/api/ChainSequence.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/ChainSequence.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { DieFn, NextFn } from '../pipe/Pipe';
+
 import { Chain } from './Chain';
 import { TestLogs } from './TestLogs';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Clipboard.ts
@@ -5,6 +5,7 @@ import { createCopyEvent, createCutEvent, createPasteEvent } from '../clipboard/
 import { createDataTransfer } from '../datatransfer/DataTransfer';
 import { getWindowFromElement } from '../dragndrop/DndEvents';
 import * as BlobReader from '../file/BlobReader';
+
 import { Chain } from './Chain';
 import * as ChainSequence from './ChainSequence';
 import { Step } from './Step';

--- a/modules/agar/src/main/ts/ephox/agar/api/DragnDrop.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/DragnDrop.ts
@@ -6,6 +6,7 @@ import {
   createDragendEvent, createDragenterEvent, createDragEvent, createDragoverEvent, createDragstartEvent, createDropEvent, dispatchDndEvent,
   getWindowFromElement, isDefaultPrevented
 } from '../dragndrop/DndEvents';
+
 import { Chain } from './Chain';
 import { NamedChain } from './NamedChain';
 import { Step } from './Step';

--- a/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FocusTools.ts
@@ -2,6 +2,7 @@ import { Result } from '@ephox/katamari';
 import { Compare, Focus, SugarElement, SugarShadowDom, Truncate } from '@ephox/sugar';
 
 import * as SizzleFind from '../alien/SizzleFind';
+
 import { Chain } from './Chain';
 import * as Guard from './Guard';
 import * as Logger from './Logger';

--- a/modules/agar/src/main/ts/ephox/agar/api/GeneralSteps.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/GeneralSteps.ts
@@ -1,4 +1,5 @@
 import { DieFn, NextFn } from '../pipe/Pipe';
+
 import { Pipeline } from './Pipeline';
 import { Step } from './Step';
 import { TestLogs } from './TestLogs';

--- a/modules/agar/src/main/ts/ephox/agar/api/Guard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Guard.ts
@@ -1,5 +1,6 @@
 import * as ErrorTypes from '../alien/ErrorTypes';
 import { DieFn, NextFn, RunFn } from '../pipe/Pipe';
+
 import * as Logger from './Logger';
 import { addLogEntry, TestLogs } from './TestLogs';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/Keyboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Keyboard.ts
@@ -3,6 +3,7 @@ import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
 import { keyevent, MixedKeyModifiers } from '../keyboard/FakeKeys';
 import * as TypeInInput from '../keyboard/TypeInInput';
+
 import { Step } from './Step';
 
 export type KeyModifiers = MixedKeyModifiers;

--- a/modules/agar/src/main/ts/ephox/agar/api/Logger.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Logger.ts
@@ -3,6 +3,7 @@ import { Arr } from '@ephox/katamari';
 
 import * as ErrorTypes from '../alien/ErrorTypes';
 import { DieFn, NextFn } from '../pipe/Pipe';
+
 import { Step } from './Step';
 import { addLogEntry, popLogLevel, pushLogLevel, TestLogs } from './TestLogs';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/Main.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Main.ts
@@ -1,4 +1,5 @@
 import { ArrayAssert, StringAssert, StructAssert, StructAssertAdv, StructAssertBasic } from '../assertions/ApproxStructures';
+
 import * as ApproxStructure from './ApproxStructure';
 import * as Arbitraries from './Arbitraries';
 import * as Assertions from './Assertions';

--- a/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
@@ -2,6 +2,7 @@ import { Fun } from '@ephox/katamari';
 import { Focus, SugarElement } from '@ephox/sugar';
 
 import * as Clicks from '../mouse/Clicks';
+
 import { Chain } from './Chain';
 import { Step } from './Step';
 import * as UiFinder from './UiFinder';

--- a/modules/agar/src/main/ts/ephox/agar/api/NamedChain.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/NamedChain.ts
@@ -1,6 +1,7 @@
 import { Arr, Fun, Id, Obj, Result } from '@ephox/katamari';
 
 import { DieFn, NextFn } from '../pipe/Pipe';
+
 import { Chain } from './Chain';
 import { TestLogs } from './TestLogs';
 
@@ -30,9 +31,9 @@ const asChain = <T>(chains: NamedChain[]): Chain<T, any> =>
 const write = (name: string, chain: Chain<NamedData, any>): Chain<NamedData, NamedData> =>
   Chain.on((input, next, die, initLogs) => {
     chain.runChain(input, (output, newLogs) => {
-      const self = wrapSingle(name, output);
+      const data = wrapSingle(name, output);
       return next(
-        { ...input, ...self },
+        { ...input, ...data },
         newLogs
       );
     }, die, initLogs);
@@ -43,8 +44,8 @@ const write = (name: string, chain: Chain<NamedData, any>): Chain<NamedData, Nam
 const partialWrite = <T>(name: string, chain: Chain<T, any>): Chain<T, NamedData> =>
   Chain.on((input, next, die, initLogs) => {
     chain.runChain(input, (output, newLogs) => {
-      const self = wrapSingle(name, output);
-      return next(self, newLogs);
+      const data = wrapSingle(name, output);
+      return next(data, newLogs);
     }, die, initLogs);
   });
 
@@ -127,6 +128,5 @@ export const NamedChain = {
   bundle,
   output,
   outputInput,
-
   pipeline
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/Pipeline.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pipeline.ts
@@ -1,6 +1,7 @@
 import { Arr, Type } from '@ephox/katamari';
 
 import { DieFn, NextFn } from '../pipe/Pipe';
+
 import { Step } from './Step';
 import { TestLogs } from './TestLogs';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/RealClipboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealClipboard.ts
@@ -1,6 +1,7 @@
 import { PlatformDetection } from '@ephox/sand';
 
 import { KeyModifiers } from '../keyboard/FakeKeys';
+
 import { RealKeys } from './RealKeys';
 import { Step } from './Step';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealKeys.ts
@@ -2,6 +2,7 @@ import { Adt, Arr, Optional } from '@ephox/katamari';
 
 import { KeyModifiers, MixedKeyModifiers, newModifiers } from '../keyboard/FakeKeys';
 import * as SeleniumAction from '../server/SeleniumAction';
+
 import { Step } from './Step';
 
 export interface KeyPressAdt {

--- a/modules/agar/src/main/ts/ephox/agar/api/RealMouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RealMouse.ts
@@ -2,6 +2,7 @@ import { Fun, Id } from '@ephox/katamari';
 import { Attribute, SugarElement } from '@ephox/sugar';
 
 import * as SeleniumAction from '../server/SeleniumAction';
+
 import { Chain } from './Chain';
 import { Step } from './Step';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/Step.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Step.ts
@@ -3,6 +3,7 @@ import { Failure } from '@ephox/bedrock-common';
 import * as AsyncActions from '../pipe/AsyncActions';
 import * as GeneralActions from '../pipe/GeneralActions';
 import { DieFn, NextFn, Pipe, RunFn } from '../pipe/Pipe';
+
 import { addLogging, GuardFn } from './Guard';
 import { addLogEntry, TestLogs } from './TestLogs';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/StepSequence.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/StepSequence.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { DieFn, NextFn } from '../pipe/Pipe';
+
 import { Step } from './Step';
 import { TestLogs } from './TestLogs';
 

--- a/modules/agar/src/main/ts/ephox/agar/api/Touch.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Touch.ts
@@ -1,6 +1,7 @@
 import { Focus, SugarElement } from '@ephox/sugar';
 
 import * as Touches from '../touch/Touches';
+
 import { Chain } from './Chain';
 import { Step } from './Step';
 import * as UiFinder from './UiFinder';

--- a/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/UiFinder.ts
@@ -2,6 +2,7 @@ import { Fun, Result } from '@ephox/katamari';
 import { SugarElement, Truncate, Visibility } from '@ephox/sugar';
 
 import * as UiSearcher from '../find/UiSearcher';
+
 import { Chain } from './Chain';
 import * as Guard from './Guard';
 import { Step } from './Step';

--- a/modules/agar/src/main/ts/ephox/agar/arbitrary/GenSelection.ts
+++ b/modules/agar/src/main/ts/ephox/agar/arbitrary/GenSelection.ts
@@ -21,8 +21,8 @@ const gChooseIn = <T extends Node>(target: SugarElement<T>): fc.Arbitrary<{ elem
 };
 
 const gChooseFrom = (root: SugarElement<Node>, exclusions: SelectionExclusions) => {
-  const self = exclusions.containers(root) ? [] : [ root ];
-  const everything = PredicateFilter.descendants(root, Fun.not(exclusions.containers)).concat(self);
+  const rootArray = exclusions.containers(root) ? [] : [ root ];
+  const everything = PredicateFilter.descendants(root, Fun.not(exclusions.containers)).concat(rootArray);
   return fc.constantFrom(...(everything.length > 0 ? everything : [ root ])).chain(gChooseIn);
 };
 

--- a/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
+++ b/modules/agar/src/main/ts/ephox/agar/assertions/ApproxStructures.ts
@@ -20,7 +20,7 @@ export interface ElementQueue {
   peek(): Optional<SugarElement<Node>>;
   take(): Optional<SugarElement<Node>>;
   mark(): {
-    reset: () => void ;
+    reset: () => void;
     atMark: () => boolean;
   };
 }

--- a/modules/agar/src/main/ts/ephox/agar/datatransfer/DataTransfer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/datatransfer/DataTransfer.ts
@@ -1,6 +1,7 @@
 import { Arr, Id, Optional, Type } from '@ephox/katamari';
 
 import { createFileList } from '../file/FileList';
+
 import { getData } from './DataTransferItem';
 import { createDataTransferItemList } from './DataTransferItemList';
 import { isInProtectedMode, isInReadWriteMode, setReadWriteMode } from './Mode';

--- a/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
@@ -3,6 +3,7 @@ import { Singleton } from '@ephox/katamari';
 import { Chain } from '../api/Chain';
 import * as GeneralSteps from '../api/GeneralSteps';
 import { Step } from '../api/Step';
+
 import { createFileList } from './FileList';
 
 interface Props {
@@ -28,6 +29,8 @@ const createChangeEvent = (win: Window): Event => {
 
   return event;
 };
+
+const HTMLInputElement = window.HTMLInputElement;
 
 const cPatchInputElement = (files: File[]) => Chain.op<any>(() => {
   const currentProps = {

--- a/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
+++ b/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
@@ -30,9 +30,8 @@ const createChangeEvent = (win: Window): Event => {
   return event;
 };
 
-const HTMLInputElement = window.HTMLInputElement;
-
 const cPatchInputElement = (files: File[]) => Chain.op<any>(() => {
+  const HTMLInputElement = window.HTMLInputElement;
   const currentProps = {
     files: Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'files'),
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -51,6 +50,7 @@ const cPatchInputElement = (files: File[]) => Chain.op<any>(() => {
 });
 
 const cUnpatchInputElement = Chain.op<any>(() => {
+  const HTMLInputElement = window.HTMLInputElement;
   inputPrototypeState.on((props) => {
     Object.defineProperty(HTMLInputElement.prototype, 'files', props.files);
     HTMLInputElement.prototype.click = props.click;

--- a/modules/agar/src/main/ts/ephox/agar/keyboard/TypeInInput.ts
+++ b/modules/agar/src/main/ts/ephox/agar/keyboard/TypeInInput.ts
@@ -2,6 +2,7 @@ import { Type } from '@ephox/katamari';
 import { SugarElement, Value } from '@ephox/sugar';
 
 import * as Waiter from '../api/Waiter';
+
 import { getKeyEventFromData } from './Keycodes';
 
 const typeCharInInput = (input: SugarElement<HTMLInputElement | HTMLTextAreaElement>, chr: string) => {
@@ -47,4 +48,3 @@ export const pTypeTextInInput = async (input: SugarElement<HTMLInputElement | HT
     await (speed === 0 ? Promise.resolve() : Waiter.pWait(speed));
   }
 };
-

--- a/modules/agar/src/test/ts/browser/ArbitrariesTest.ts
+++ b/modules/agar/src/test/ts/browser/ArbitrariesTest.ts
@@ -13,8 +13,8 @@ UnitTest.test('Arbitraries Test', () => {
   const assertProperty = (label: string, element: SugarElement<Node>, assertion: (node: SugarElement<Node>) => boolean): boolean => {
     Insert.append(SugarBody.body(), element);
 
-    const self = SugarNode.isElement(element) ? [ element ] : [];
-    const descendants = SelectorFilter.descendants(element, '*').concat(self);
+    const elementArray = SugarNode.isElement(element) ? [ element ] : [];
+    const descendants = SelectorFilter.descendants(element, '*').concat(elementArray);
     const failing = Arr.filter(descendants, assertion);
     Remove.remove(element);
     if (failing.length > 0) {


### PR DESCRIPTION
# Update ESLint Configuration Path and Code Formatting

Related Ticket: 

Description of Changes:
* Updated ESLint configuration path from `.eslintrc.json` to `eslint.config.ts` in package.json
* Added consistent blank lines between imports across multiple files for better code organization
* Renamed some variables for clarity (e.g., `self` to `data` in NamedChain, `self` to `rootArray` and `elementArray` in various files)
* Fixed spacing in type definition in ApproxStructures.ts
* Added explicit `HTMLInputElement` reference in PatchInputFiles.ts
* Removed extra blank line in NamedChain.ts

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):