### PR TITLE
TINY-11629: Upgrade alloy to use eslint V9

### DIFF
--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless --testdirs src/test/ts/atomic src/test/ts/browser src/test/ts/webdriver",
     "test-manual": "bedrock --testdirs src/test/ts/atomic src/test/ts/browser src/test/ts/webdriver",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "start": "grunt dev",
     "prepublishOnly": "tsc -b",
     "build": "tsc"

--- a/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/alien/Boxes.ts
@@ -2,6 +2,7 @@ import { Arr } from '@ephox/katamari';
 import { Height, SugarElement, SugarLocation, Width, WindowVisualViewport } from '@ephox/sugar';
 
 import * as OuterPosition from '../frame/OuterPosition';
+
 import { CssPositionAdt } from './CssPosition';
 
 const pointed = (point: CssPositionAdt, width: number, height: number): BoxByPoint => ({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/Main.ts
@@ -35,6 +35,7 @@ import * as SliderTypes from '../ui/types/SliderTypes';
 import * as SlotContainerTypes from '../ui/types/SlotContainerTypes';
 import * as TabbarTypes from '../ui/types/TabbarTypes';
 import * as TieredMenuTypes from '../ui/types/TieredMenuTypes';
+
 import * as TooltippingTypes from './../behaviour/tooltipping/TooltippingTypes';
 import * as AddEventsBehaviour from './behaviour/AddEventsBehaviour';
 import { AllowBubbling } from './behaviour/AllowBubbling';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/AddEventsBehaviour.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/AddEventsBehaviour.ts
@@ -3,6 +3,7 @@ import { Fun } from '@ephox/katamari';
 
 import { NoState } from '../../behaviour/common/BehaviourState';
 import { AlloyEventKeyAndHandler, AlloyEventRecord, derive } from '../events/AlloyEvents';
+
 import { AlloyBehaviour, create as createBehaviour, NamedConfiguredBehaviour } from './Behaviour';
 
 // AlloyEventKeyAndHandler type argument needs to be any here to satisfy an array of handlers

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/AllowBubbling.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/AllowBubbling.ts
@@ -4,6 +4,7 @@ import * as ActiveAllowBubbling from '../../behaviour/allowbubbling/ActiveAllowB
 import AllowBubblingSchema from '../../behaviour/allowbubbling/AllowBubblingSchema';
 import { AllowBubblingBehavior } from '../../behaviour/allowbubbling/AllowBubblingTypes';
 import { SetupBehaviourCellState } from '../../behaviour/common/BehaviourCellState';
+
 import * as Behaviour from './Behaviour';
 
 const AllowBubbling: AllowBubblingBehavior = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Blocking.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Blocking.ts
@@ -2,6 +2,7 @@ import * as BlockingApis from '../../behaviour/blocking/BlockingApis';
 import BlockingSchema from '../../behaviour/blocking/BlockingSchema';
 import * as BlockingState from '../../behaviour/blocking/BlockingState';
 import { BlockingBehaviour } from '../../behaviour/blocking/BlockingTypes';
+
 import * as Behaviour from './Behaviour';
 
 // Mark a component as able to be "Blocked" or able to enter a busy state. See

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Composing.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Composing.ts
@@ -1,6 +1,7 @@
 import * as ComposeApis from '../../behaviour/composing/ComposeApis';
 import { ComposeSchema } from '../../behaviour/composing/ComposeSchema';
 import { ComposingBehaviour } from '../../behaviour/composing/ComposingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Composing: ComposingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Coupling.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Coupling.ts
@@ -2,6 +2,7 @@ import * as CouplingApis from '../../behaviour/coupling/CouplingApis';
 import CouplingSchema from '../../behaviour/coupling/CouplingSchema';
 import * as CouplingState from '../../behaviour/coupling/CouplingState';
 import { CouplingBehaviour } from '../../behaviour/coupling/CouplingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Coupling: CouplingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Disabling.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Disabling.ts
@@ -2,6 +2,7 @@ import * as ActiveDisable from '../../behaviour/disabling/ActiveDisable';
 import * as DisableApis from '../../behaviour/disabling/DisableApis';
 import DisableSchema from '../../behaviour/disabling/DisableSchema';
 import { DisableBehaviour } from '../../behaviour/disabling/DisableTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Disabling: DisableBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Docking.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Docking.ts
@@ -3,6 +3,7 @@ import * as DockingApis from '../../behaviour/docking/DockingApis';
 import DockingSchema from '../../behaviour/docking/DockingSchema';
 import * as DockingState from '../../behaviour/docking/DockingState';
 import { DockingBehaviour } from '../../behaviour/docking/DockingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Docking: DockingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Dragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Dragging.ts
@@ -5,6 +5,7 @@ import * as DraggingApis from '../../behaviour/dragging/DraggingApis';
 import * as DraggingBranches from '../../behaviour/dragging/DraggingBranches';
 import { DraggingBehaviour, DraggingConfig, DraggingState, SnapConfig, SnapConfigSpec } from '../../dragging/common/DraggingTypes';
 import * as DragState from '../../dragging/common/DragState';
+
 import * as Behaviour from './Behaviour';
 
 const Dragging: DraggingBehaviour<any> = Behaviour.createModes({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/DragnDrop.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/DragnDrop.ts
@@ -1,5 +1,6 @@
 import DragnDropBranches from '../../behaviour/dragndrop/DragnDropBranches';
 import { DragnDropBehaviour } from '../../dragging/dragndrop/DragnDropTypes';
+
 import * as Behaviour from './Behaviour';
 
 const DragnDrop: DragnDropBehaviour = Behaviour.createModes({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Focusing.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Focusing.ts
@@ -2,6 +2,7 @@ import * as ActiveFocus from '../../behaviour/focusing/ActiveFocus';
 import * as FocusApis from '../../behaviour/focusing/FocusApis';
 import { FocusingBehaviour } from '../../behaviour/focusing/FocusingTypes';
 import FocusSchema from '../../behaviour/focusing/FocusSchema';
+
 import * as Behaviour from './Behaviour';
 
 const Focusing: FocusingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Highlighting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Highlighting.ts
@@ -1,6 +1,7 @@
 import * as HighlightApis from '../../behaviour/highlighting/HighlightApis';
 import { HighlightingBehaviour } from '../../behaviour/highlighting/HighlightingTypes';
 import HighlightSchema from '../../behaviour/highlighting/HighlightSchema';
+
 import * as Behaviour from './Behaviour';
 
 const Highlighting: HighlightingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Invalidating.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Invalidating.ts
@@ -5,6 +5,7 @@ import * as InvalidateApis from '../../behaviour/invalidating/InvalidateApis';
 import InvalidateSchema from '../../behaviour/invalidating/InvalidateSchema';
 import { InvalidatingBehaviour } from '../../behaviour/invalidating/InvalidateTypes';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import * as Behaviour from './Behaviour';
 import { Representing } from './Representing';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Keying.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Keying.ts
@@ -8,6 +8,7 @@ import {
   MenuConfigSpec, SpecialConfigSpec
 } from '../../keying/KeyingModeTypes';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import * as Behaviour from './Behaviour';
 
 export interface KeyingBehaviour<D extends GeneralKeyingConfig> extends Behaviour.AlloyBehaviour<KeyingConfigSpec, D> {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Pinching.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Pinching.ts
@@ -2,6 +2,7 @@ import * as ActivePinching from '../../behaviour/pinching/ActivePinching';
 import PinchingSchema from '../../behaviour/pinching/PinchingSchema';
 import { PinchingBehaviour } from '../../behaviour/pinching/PinchingTypes';
 import * as DragState from '../../dragging/common/DragState';
+
 import * as Behaviour from './Behaviour';
 
 const Pinching: PinchingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Positioning.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Positioning.ts
@@ -3,6 +3,7 @@ import * as PositionApis from '../../behaviour/positioning/PositionApis';
 import * as PositioningState from '../../behaviour/positioning/PositioningState';
 import { PositioningBehaviour } from '../../behaviour/positioning/PositioningTypes';
 import { PositionSchema } from '../../behaviour/positioning/PositionSchema';
+
 import * as Behaviour from './Behaviour';
 
 const Positioning: PositioningBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Receiving.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Receiving.ts
@@ -1,6 +1,7 @@
 import * as ActiveReceiving from '../../behaviour/receiving/ActiveReceiving';
 import ReceivingSchema from '../../behaviour/receiving/ReceivingSchema';
 import { ReceivingBehaviour } from '../../behaviour/receiving/ReceivingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Receiving: ReceivingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Reflecting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Reflecting.ts
@@ -3,6 +3,7 @@ import * as ReflectingApis from '../../behaviour/reflecting/ReflectingApis';
 import ReflectingSchema from '../../behaviour/reflecting/ReflectingSchema';
 import * as ReflectingState from '../../behaviour/reflecting/ReflectingState';
 import { ReflectingBehaviour } from '../../behaviour/reflecting/ReflectingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Reflecting: ReflectingBehaviour<any, any> = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Replacing.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Replacing.ts
@@ -2,6 +2,7 @@ import { FieldSchema } from '@ephox/boulder';
 
 import * as ReplaceApis from '../../behaviour/replacing/ReplaceApis';
 import { ReplacingBehaviour } from '../../behaviour/replacing/ReplacingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Replacing: ReplacingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Representing.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Representing.ts
@@ -4,6 +4,7 @@ import { RepresentingBehaviour } from '../../behaviour/representing/Representing
 import RepresentSchema from '../../behaviour/representing/RepresentSchema';
 import * as RepresentState from '../../behaviour/representing/RepresentState';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import * as Behaviour from './Behaviour';
 
 // The self-reference is clumsy.

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Sandboxing.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Sandboxing.ts
@@ -3,6 +3,7 @@ import * as SandboxApis from '../../behaviour/sandboxing/SandboxApis';
 import { SandboxingBehaviour } from '../../behaviour/sandboxing/SandboxingTypes';
 import SandboxSchema from '../../behaviour/sandboxing/SandboxSchema';
 import * as SandboxState from '../../behaviour/sandboxing/SandboxState';
+
 import * as Behaviour from './Behaviour';
 
 const Sandboxing: SandboxingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Sliding.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Sliding.ts
@@ -3,6 +3,7 @@ import * as SlidingApis from '../../behaviour/sliding/SlidingApis';
 import SlidingSchema from '../../behaviour/sliding/SlidingSchema';
 import * as SlidingState from '../../behaviour/sliding/SlidingState';
 import { SlidingBehaviour } from '../../behaviour/sliding/SlidingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Sliding: SlidingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Streaming.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Streaming.ts
@@ -2,6 +2,7 @@ import * as ActiveStreaming from '../../behaviour/streaming/ActiveStreaming';
 import StreamingSchema from '../../behaviour/streaming/StreamingSchema';
 import * as StreamingState from '../../behaviour/streaming/StreamingState';
 import { StreamingBehaviour } from '../../behaviour/streaming/StreamingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Streaming: StreamingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Swapping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Swapping.ts
@@ -1,6 +1,7 @@
 import * as SwapApis from '../../behaviour/swapping/SwapApis';
 import { SwappingBehaviour } from '../../behaviour/swapping/SwappingTypes';
 import SwapSchema from '../../behaviour/swapping/SwapSchema';
+
 import * as Behaviour from './Behaviour';
 
 const Swapping: SwappingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Tabstopping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Tabstopping.ts
@@ -1,6 +1,7 @@
 import * as ActiveTabstopping from '../../behaviour/tabstopping/ActiveTabstopping';
 import { TabstoppingBehaviour } from '../../behaviour/tabstopping/TabstoppingTypes';
 import TabstopSchema from '../../behaviour/tabstopping/TabstopSchema';
+
 import * as Behaviour from './Behaviour';
 
 const Tabstopping: TabstoppingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Toggling.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Toggling.ts
@@ -3,6 +3,7 @@ import * as ActiveToggle from '../../behaviour/toggling/ActiveToggle';
 import * as ToggleApis from '../../behaviour/toggling/ToggleApis';
 import ToggleSchema from '../../behaviour/toggling/ToggleSchema';
 import { TogglingBehaviour } from '../../behaviour/toggling/TogglingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Toggling: TogglingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Tooltipping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Tooltipping.ts
@@ -3,6 +3,7 @@ import * as TooltippingApis from '../../behaviour/tooltipping/TooltippingApis';
 import TooltippingSchema from '../../behaviour/tooltipping/TooltippingSchema';
 import * as TooltippingState from '../../behaviour/tooltipping/TooltippingState';
 import { TooltippingBehaviour } from '../../behaviour/tooltipping/TooltippingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Tooltipping: TooltippingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Transitioning.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Transitioning.ts
@@ -5,6 +5,7 @@ import * as ActiveTransitioning from '../../behaviour/transitioning/ActiveTransi
 import * as TransitionApis from '../../behaviour/transitioning/TransitionApis';
 import { TransitioningBehaviour, TransitionPropertiesSpec, TransitioningConfigSpec } from '../../behaviour/transitioning/TransitioningTypes';
 import TransitionSchema from '../../behaviour/transitioning/TransitionSchema';
+
 import * as Behaviour from './Behaviour';
 
 const createRoutes = (routes: Record<string, TransitionPropertiesSpec>): TransitioningConfigSpec['routes'] => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Unselecting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/behaviour/Unselecting.ts
@@ -1,5 +1,6 @@
 import * as ActiveUnselecting from '../../behaviour/unselecting/ActiveUnselecting';
 import { UnselectingBehaviour } from '../../behaviour/unselecting/UnselectingTypes';
+
 import * as Behaviour from './Behaviour';
 
 const Unselecting: UnselectingBehaviour = Behaviour.create({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/Component.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/Component.ts
@@ -14,6 +14,7 @@ import { UncurriedHandler } from '../../events/EventRegistry';
 import { AlloyBehaviour } from '../behaviour/Behaviour';
 import { NoContextApi, singleton } from '../system/NoContextApi';
 import { AlloySystemApi } from '../system/SystemApi';
+
 import * as CompBehaviours from './CompBehaviours';
 import { AlloyComponent } from './ComponentApi';
 import { ComponentDetail } from './SpecTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/GuiFactory.ts
@@ -8,6 +8,7 @@ import * as CustomSpec from '../../spec/CustomSpec';
 import { NoContextApi } from '../system/NoContextApi';
 import { AlloySystemApi } from '../system/SystemApi';
 import * as GuiTypes from '../ui/GuiTypes';
+
 import * as Component from './Component';
 import { AlloyComponent } from './ComponentApi';
 import { AlloySpec, PremadeSpec, SimpleOrSketchSpec, SketchSpec } from './SpecTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/Memento.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/Memento.ts
@@ -2,6 +2,7 @@ import { Obj, Optional } from '@ephox/katamari';
 
 import * as Tagger from '../../registry/Tagger';
 import { isSketchSpec } from '../ui/Sketcher';
+
 import { AlloyComponent } from './ComponentApi';
 import { SimpleOrSketchSpec } from './SpecTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/component/SpecTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/component/SpecTypes.ts
@@ -4,6 +4,7 @@ import { DomModification } from '../../dom/DomModification';
 import { ConfiguredPart } from '../../parts/AlloyParts';
 import { AlloyBehaviourRecord } from '../behaviour/Behaviour';
 import { AlloyEventRecord } from '../events/AlloyEvents';
+
 import { AlloyComponent } from './ComponentApi';
 
 export type AlloySpec = SimpleOrSketchSpec | PremadeSpec | ConfiguredPart;

--- a/modules/alloy/src/main/ts/ephox/alloy/api/data/DragCoord.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/data/DragCoord.ts
@@ -92,7 +92,7 @@ const toString = (coord: CoordAdt<number>): string => coord.fold(
 const withinRange = (coord1: CoordAdt<number>, coord2: CoordAdt<number>, xRange: number, yRange: number, scroll: SugarPosition, origin: SugarPosition): boolean => {
   const a1 = asAbsolute(coord1, scroll, origin);
   const a2 = asAbsolute(coord2, scroll, origin);
-  // eslint-disable-next-line no-console
+
   // console.log(`a1.left: ${a1.left}, a2.left: ${a2.left}, leftDelta: ${a1.left - a2.left}, xRange: ${xRange}, lD <= xRange: ${Math.abs(a1.left - a2.left) <= xRange}`);
   // console.log(`a1.top: ${a1.top}, a2.top: ${a2.top}, topDelta: ${a1.top - a2.top}, yRange: ${yRange}, lD <= xRange: ${Math.abs(a1.top - a2.top) <= yRange}`);
   return Math.abs(a1.left - a2.left) <= xRange &&

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyEvents.ts
@@ -7,6 +7,7 @@ import * as EventHandler from '../../construct/EventHandler';
 import { EventFormat, SimulatedEvent } from '../../events/SimulatedEvent';
 import { AlloyComponent } from '../component/ComponentApi';
 import { CompositeSketchDetail } from '../ui/Sketcher';
+
 import * as AlloyTriggers from './AlloyTriggers';
 import * as SystemEvents from './SystemEvents';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyTriggers.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/AlloyTriggers.ts
@@ -2,6 +2,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { EventFormat, SimulatedEvent } from '../../events/SimulatedEvent';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import * as SystemEvents from './SystemEvents';
 
 const emit = (component: AlloyComponent, event: string): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/events/SystemEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/events/SystemEvents.ts
@@ -4,6 +4,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import { CustomEvent } from '../../events/SimulatedEvent';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import * as NativeEvents from './NativeEvents';
 
 const prefixName = (name: string) => Fun.constant('alloy.' + name);

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/Attachment.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/Attachment.ts
@@ -3,6 +3,7 @@ import { Insert, Remove, SugarBody, SugarElement, Traverse } from '@ephox/sugar'
 
 import * as InternalAttachment from '../../system/InternalAttachment';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import { GuiSystem } from './Gui';
 
 const attach = (parent: AlloyComponent, child: AlloyComponent): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/ForeignGui.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/ForeignGui.ts
@@ -10,6 +10,7 @@ import { AlloyBehaviourRecord } from '../behaviour/Behaviour';
 import { AlloyComponent } from '../component/ComponentApi';
 import * as GuiFactory from '../component/GuiFactory';
 import { AlloyEventRecord } from '../events/AlloyEvents';
+
 import * as Gui from './Gui';
 
 export interface ForeignGuiSpec {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/Gui.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/Gui.ts
@@ -12,6 +12,7 @@ import { AlloyComponent } from '../component/ComponentApi';
 import * as GuiFactory from '../component/GuiFactory';
 import * as SystemEvents from '../events/SystemEvents';
 import { Container } from '../ui/Container';
+
 import * as Attachment from './Attachment';
 import { AlloySystemApi } from './SystemApi';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/system/NoContextApi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/system/NoContextApi.ts
@@ -2,6 +2,7 @@ import { Fun } from '@ephox/katamari';
 
 import * as AlloyLogger from '../../log/AlloyLogger';
 import { AlloyComponent } from '../component/ComponentApi';
+
 import { AlloySystemApi } from './SystemApi';
 
 const NoContextApi = (getComp?: () => AlloyComponent): AlloySystemApi => {

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Button.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Button.ts
@@ -7,6 +7,7 @@ import { Focusing } from '../behaviour/Focusing';
 import { Keying } from '../behaviour/Keying';
 import { SketchBehaviours } from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Container.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Container.ts
@@ -3,6 +3,7 @@ import { FieldSchema } from '@ephox/boulder';
 import { ContainerDetail, ContainerSketcher, ContainerSpec } from '../../ui/types/ContainerTypes';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/CustomList.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/CustomList.ts
@@ -8,6 +8,7 @@ import { Replacing } from '../behaviour/Replacing';
 import { AlloyComponent } from '../component/ComponentApi';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec } from '../component/SpecTypes';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/DataField.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/DataField.ts
@@ -7,6 +7,7 @@ import { Representing } from '../behaviour/Representing';
 import { SketchBehaviours } from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
 import * as AlloyEvents from '../events/AlloyEvents';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Dropdown.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Dropdown.ts
@@ -17,6 +17,7 @@ import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
 import * as AlloyTriggers from '../events/AlloyTriggers';
 import * as SystemEvents from '../events/SystemEvents';
+
 import * as Sketcher from './Sketcher';
 import * as TieredMenu from './TieredMenu';
 import { CompositeSketchFactory } from './UiSketcher';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ExpandableForm.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ExpandableForm.ts
@@ -6,6 +6,7 @@ import { Sliding } from '../behaviour/Sliding';
 import { AlloyComponent } from '../component/ComponentApi';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
+
 import { Form } from './Form';
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FloatingToolbarButton.ts
@@ -21,6 +21,7 @@ import { Toggling } from '../behaviour/Toggling';
 import { AlloyComponent } from '../component/ComponentApi';
 import { SketchBehaviours } from '../component/SketchBehaviours';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
+
 import { Button } from './Button';
 import * as Sketcher from './Sketcher';
 import { Toolbar } from './Toolbar';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Form.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Form.ts
@@ -9,6 +9,7 @@ import { Representing } from '../behaviour/Representing';
 import { AlloyComponent } from '../component/ComponentApi';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec, SimpleOrSketchSpec, SketchSpec } from '../component/SpecTypes';
+
 import * as GuiTypes from './GuiTypes';
 import * as UiSketcher from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormChooser.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormChooser.ts
@@ -12,6 +12,7 @@ import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
 import * as AlloyEvents from '../events/AlloyEvents';
 import * as SystemEvents from '../events/SystemEvents';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormCoupledInputs.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormCoupledInputs.ts
@@ -10,6 +10,7 @@ import { Representing } from '../behaviour/Representing';
 import { AlloyComponent } from '../component/ComponentApi';
 import { SketchBehaviours } from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormField.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/FormField.ts
@@ -10,6 +10,7 @@ import { AlloyComponent } from '../component/ComponentApi';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
 import * as AlloyEvents from '../events/AlloyEvents';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/HtmlSelect.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/HtmlSelect.ts
@@ -7,6 +7,7 @@ import { Focusing } from '../behaviour/Focusing';
 import { Representing } from '../behaviour/Representing';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { SketchSpec } from '../component/SpecTypes';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/InlineView.ts
@@ -19,6 +19,7 @@ import { AlloyComponent } from '../component/ComponentApi';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
 import * as SystemEvents from '../events/SystemEvents';
+
 import * as Sketcher from './Sketcher';
 import { tieredMenu as TieredMenu } from './TieredMenu';
 import { SingleSketchFactory } from './UiSketcher';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Input.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Input.ts
@@ -1,6 +1,7 @@
 import * as InputBase from '../../ui/common/InputBase';
 import { InputDetail, InputSketcher, InputSpec } from '../../ui/types/InputTypes';
 import { SketchSpec } from '../component/SpecTypes';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Menu.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Menu.ts
@@ -1,6 +1,7 @@
 import * as MenuSchema from '../../ui/schema/MenuSchema';
 import { make as makeMenuSpec } from '../../ui/single/MenuSpec';
 import { MenuSketcher } from '../../ui/types/MenuTypes';
+
 import * as Sketcher from './Sketcher';
 
 const Menu: MenuSketcher = Sketcher.composite({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ModalDialog.ts
@@ -19,6 +19,7 @@ import * as AlloyEvents from '../events/AlloyEvents';
 import * as NativeEvents from '../events/NativeEvents';
 import * as SystemEvents from '../events/SystemEvents';
 import * as Attachment from '../system/Attachment';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Sketcher.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Sketcher.ts
@@ -7,6 +7,7 @@ import { PartTypeAdt } from '../../parts/PartType';
 import { BaseSketchDetail, BaseSketchSpec } from '../../spec/SpecSchema';
 import { AlloyComponent } from '../component/ComponentApi';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
+
 import * as GuiTypes from './GuiTypes';
 import * as UiSketcher from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Slider.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Slider.ts
@@ -2,6 +2,7 @@ import SliderParts from '../../ui/slider/SliderParts';
 import { SliderSchema } from '../../ui/slider/SliderSchema';
 import * as SliderUi from '../../ui/slider/SliderUi';
 import { SliderApis, SliderDetail, SliderSketcher, SliderSpec } from '../../ui/types/SliderTypes';
+
 import * as Sketcher from './Sketcher';
 
 const Slider: SliderSketcher = Sketcher.composite<SliderSpec, SliderDetail, SliderApis>({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SlotContainer.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SlotContainer.ts
@@ -9,6 +9,7 @@ import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
 import * as AlloyTriggers from '../events/AlloyTriggers';
 import * as SystemEvents from '../events/SystemEvents';
+
 import * as GuiTypes from './GuiTypes';
 import * as UiSketcher from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitDropdown.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitDropdown.ts
@@ -18,6 +18,7 @@ import * as SketchBehaviours from '../component/SketchBehaviours';
 import * as AlloyEvents from '../events/AlloyEvents';
 import * as AlloyTriggers from '../events/AlloyTriggers';
 import * as SystemEvents from '../events/SystemEvents';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitFloatingToolbar.ts
@@ -12,6 +12,7 @@ import * as GuiFactory from '../component/GuiFactory';
 import * as Memento from '../component/Memento';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec } from '../component/SpecTypes';
+
 import { FloatingToolbarButton } from './FloatingToolbarButton';
 import * as Sketcher from './Sketcher';
 import { ToolbarGroup } from './ToolbarGroup';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/SplitSlidingToolbar.ts
@@ -18,6 +18,7 @@ import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec } from '../component/SpecTypes';
 import * as AlloyEvents from '../events/AlloyEvents';
 import * as AlloyTriggers from '../events/AlloyTriggers';
+
 import { Button } from './Button';
 import * as Sketcher from './Sketcher';
 import { Toolbar } from './Toolbar';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/TabButton.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/TabButton.ts
@@ -7,6 +7,7 @@ import { Focusing } from '../behaviour/Focusing';
 import { Keying } from '../behaviour/Keying';
 import { Representing } from '../behaviour/Representing';
 import * as SketchBehaviours from '../component/SketchBehaviours';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/TabSection.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/TabSection.ts
@@ -12,6 +12,7 @@ import * as SketchBehaviours from '../component/SketchBehaviours';
 import * as AlloyEvents from '../events/AlloyEvents';
 import * as AlloyTriggers from '../events/AlloyTriggers';
 import * as SystemEvents from '../events/SystemEvents';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Tabbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Tabbar.ts
@@ -5,6 +5,7 @@ import { TabbarDetail, TabbarSketcher, TabbarSpec } from '../../ui/types/TabbarT
 import { Highlighting } from '../behaviour/Highlighting';
 import { Keying } from '../behaviour/Keying';
 import * as SketchBehaviours from '../component/SketchBehaviours';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Tabview.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Tabview.ts
@@ -1,6 +1,7 @@
 import { TabviewDetail, TabviewSketcher, TabviewSpec } from '../../ui/types/TabviewTypes';
 import { Replacing } from '../behaviour/Replacing';
 import * as SketchBehaviours from '../component/SketchBehaviours';
+
 import * as Sketcher from './Sketcher';
 import { SingleSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/TieredMenu.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/TieredMenu.ts
@@ -10,6 +10,7 @@ import { Highlighting } from '../behaviour/Highlighting';
 import { Keying } from '../behaviour/Keying';
 import { Replacing } from '../behaviour/Replacing';
 import * as SketchBehaviours from '../component/SketchBehaviours';
+
 import { single } from './Sketcher';
 
 const tieredData = (primary: string, menus: TieredMenuRecord, expansions: Record<string, string>): TieredData => ({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Toolbar.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Toolbar.ts
@@ -8,6 +8,7 @@ import { Replacing } from '../behaviour/Replacing';
 import { AlloyComponent } from '../component/ComponentApi';
 import * as SketchBehaviours from '../component/SketchBehaviours';
 import { AlloySpec } from '../component/SpecTypes';
+
 import { composite } from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/ToolbarGroup.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/ToolbarGroup.ts
@@ -2,6 +2,7 @@ import * as ToolbarGroupSchema from '../../ui/schema/ToolbarGroupSchema';
 import { ToolbarGroupDetail, ToolbarGroupSketcher, ToolbarGroupSpec } from '../../ui/types/ToolbarGroupTypes';
 import { Keying } from '../behaviour/Keying';
 import * as SketchBehaviours from '../component/SketchBehaviours';
+
 import * as Sketcher from './Sketcher';
 import { CompositeSketchFactory } from './UiSketcher';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/TouchMenu.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/TouchMenu.ts
@@ -21,6 +21,7 @@ import * as AlloyEvents from '../events/AlloyEvents';
 import * as AlloyTriggers from '../events/AlloyTriggers';
 import * as NativeEvents from '../events/NativeEvents';
 import * as SystemEvents from '../events/SystemEvents';
+
 import { InlineView } from './InlineView';
 import { Menu } from './Menu';
 import * as Sketcher from './Sketcher';

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/Typeahead.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/Typeahead.ts
@@ -1,6 +1,7 @@
 import * as TypeaheadSpec from '../../ui/composite/TypeaheadSpec';
 import * as TypeaheadSchema from '../../ui/schema/TypeaheadSchema';
 import { TypeaheadSketcher } from '../../ui/types/TypeaheadTypes';
+
 import * as Sketcher from './Sketcher';
 
 const Typeahead: TypeaheadSketcher = Sketcher.composite({

--- a/modules/alloy/src/main/ts/ephox/alloy/api/ui/UiSketcher.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/ui/UiSketcher.ts
@@ -6,6 +6,7 @@ import { PartTypeAdt } from '../../parts/PartType';
 import * as Tagger from '../../registry/Tagger';
 import * as SpecSchema from '../../spec/SpecSchema';
 import { AlloySpec, SketchSpec } from '../component/SpecTypes';
+
 import { CompositeSketchDetail, CompositeSketchSpec, SingleSketchDetail, SingleSketchSpec } from './Sketcher';
 
 export type SingleSketchFactory<D extends SingleSketchDetail, S extends SingleSketchSpec> = (detail: D, specWithUid: S) => SketchSpec;

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/allowbubbling/ActiveAllowBubbling.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/allowbubbling/ActiveAllowBubbling.ts
@@ -3,6 +3,7 @@ import { DomEvent } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
+
 import { AllowBubblingConfig, AllowBubblingState } from './AllowBubblingTypes';
 
 const unbind = (bubblingState: AllowBubblingState) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingApis.ts
@@ -7,6 +7,7 @@ import { Keying } from '../../api/behaviour/Keying';
 import { Replacing } from '../../api/behaviour/Replacing';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as GuiFactory from '../../api/component/GuiFactory';
+
 import { BlockFn, BlockingConfig, BlockingState, UnblockFn } from './BlockingTypes';
 
 // Mark this component as busy, or blocked.

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/blocking/BlockingState.ts
@@ -1,6 +1,7 @@
 import { Singleton } from '@ephox/katamari';
 
 import { nuState } from '../common/BehaviourState';
+
 import { BlockingState } from './BlockingTypes';
 
 export const init = (): BlockingState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/Behaviour.ts
@@ -7,6 +7,7 @@ import * as FunctionAnnotator from '../../debugging/FunctionAnnotator';
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
 import { CustomEvent } from '../../events/SimulatedEvent';
+
 import { BehaviourConfigAndState } from './BehaviourBlob';
 import { BehaviourState, BehaviourStateInitialiser } from './BehaviourState';
 import {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/common/BehaviourTypes.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloyEventRecord } from '../../api/events/AlloyEvents';
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import { DomModification } from '../../dom/DomModification';
+
 import { BehaviourConfigAndState } from './BehaviourBlob';
 import { BehaviourState, BehaviourStateInitialiser } from './BehaviourState';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/coupling/CouplingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/coupling/CouplingApis.ts
@@ -1,6 +1,7 @@
 import { Optional } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { CouplingState, CouplingConfig } from './CouplingTypes';
 
 const getCoupled = (component: AlloyComponent, coupleConfig: CouplingConfig, coupleState: CouplingState, name: string): AlloyComponent =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/coupling/CouplingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/coupling/CouplingState.ts
@@ -2,6 +2,7 @@ import { Fun, Obj, Optional } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { nuState } from '../common/BehaviourState';
+
 import { CouplingConfig, CouplingState } from './CouplingTypes';
 
 // Unfortunately, the Coupling APIs currently throw errors when the coupled name

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/ActiveDisable.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/ActiveDisable.ts
@@ -4,6 +4,7 @@ import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
 import * as Behaviour from '../common/Behaviour';
 import { Stateless } from '../common/BehaviourState';
+
 import * as DisableApis from './DisableApis';
 import { DisableConfig } from './DisableTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/disabling/DisableApis.ts
@@ -3,6 +3,7 @@ import { Attribute, Class, SugarNode } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { Stateless } from '../../behaviour/common/BehaviourState';
+
 import { DisableConfig } from './DisableTypes';
 
 // Just use "disabled" attribute for these, not "aria-disabled"

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/ActiveDocking.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/ActiveDocking.ts
@@ -3,6 +3,7 @@ import { Class, Classes } from '@ephox/sugar';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
+
 import * as DockingApis from './DockingApis';
 import { DockingConfig, DockingState } from './DockingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/Dockables.ts
@@ -5,6 +5,7 @@ import * as Boxes from '../../alien/Boxes';
 import * as OffsetOrigin from '../../alien/OffsetOrigin';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { NuPositionCss, PositionCss } from '../../positioning/view/PositionCss';
+
 import { DockingContext, DockingDecision, DockingMode, DockingState, DockingViewport, DockToBottomDecision, DockToTopDecision, InitialDockingPosition } from './DockingTypes';
 
 export interface StaticMorph {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingApis.ts
@@ -4,6 +4,7 @@ import { Classes, Css } from '@ephox/sugar';
 import * as Boxes from '../../alien/Boxes';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { applyPositionCss, PositionCss } from '../../positioning/view/PositionCss';
+
 import * as Dockables from './Dockables';
 import { DockingConfig, DockingDecision, DockingMode, DockingState, DockingViewport } from './DockingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingSchema.ts
@@ -3,6 +3,7 @@ import { Optional } from '@ephox/katamari';
 
 import * as Boxes from '../../alien/Boxes';
 import * as Fields from '../../data/Fields';
+
 import { DockingViewport } from './DockingTypes';
 
 export default [

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/docking/DockingState.ts
@@ -1,6 +1,7 @@
 import { Cell, Singleton } from '@ephox/katamari';
 
 import { nuState } from '../common/BehaviourState';
+
 import { DockingConfig, DockingMode, DockingState, InitialDockingPosition } from './DockingTypes';
 
 const init = (spec: DockingConfig): DockingState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/focusing/ActiveFocus.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/focusing/ActiveFocus.ts
@@ -3,6 +3,7 @@ import * as NativeEvents from '../../api/events/NativeEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
+
 import * as FocusApis from './FocusApis';
 import { FocusingConfig } from './FocusingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/focusing/FocusApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/focusing/FocusApis.ts
@@ -1,6 +1,7 @@
 import { Focus } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { FocusingConfig } from './FocusingTypes';
 
 const focus = (component: AlloyComponent, focusConfig: FocusingConfig): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/highlighting/HighlightApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/highlighting/HighlightApis.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import * as SystemEvents from '../../api/events/SystemEvents';
 import { Stateless } from '../common/BehaviourState';
+
 import { HighlightingConfig } from './HighlightingTypes';
 
 // THIS IS NOT API YET

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/ActiveInvalidate.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/ActiveInvalidate.ts
@@ -2,6 +2,7 @@ import { Fun } from '@ephox/katamari';
 
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import { Stateless } from '../common/BehaviourState';
+
 import * as InvalidateApis from './InvalidateApis';
 import { InvalidatingConfig } from './InvalidateTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/invalidating/InvalidateApis.ts
@@ -3,6 +3,7 @@ import { Attribute, Class, Html, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { Stateless } from '../common/BehaviourState';
+
 import { InvalidatingConfig } from './InvalidateTypes';
 
 const ariaElements = [

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/pinching/ActivePinching.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/pinching/ActivePinching.ts
@@ -4,6 +4,7 @@ import { EventArgs } from '@ephox/sugar';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { DragModeDeltas } from '../../dragging/common/DraggingTypes';
+
 import { PinchDragData, PinchingConfig, PinchingState } from './PinchingTypes';
 
 const mode: DragModeDeltas<TouchEvent, PinchDragData> = {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/ActivePosition.ts
@@ -1,5 +1,6 @@
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
+
 import { PositioningConfig } from './PositioningTypes';
 
 const exhibit = (base: DomDefinitionDetail, posConfig: PositioningConfig): DomModification.DomModification =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositionApis.ts
@@ -12,6 +12,7 @@ import * as Placement from '../../positioning/layout/Placement';
 import * as SimpleLayout from '../../positioning/layout/SimpleLayout';
 import { Anchoring } from '../../positioning/mode/Anchoring';
 import { Transition } from '../../positioning/view/Transitions';
+
 import { PlacementDetail, PlacementSpec, PositioningConfig, PositioningState } from './PositioningTypes';
 import { PlacementSchema } from './PositionSchema';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/positioning/PositioningState.ts
@@ -2,6 +2,7 @@ import { Obj, Optional, Type } from '@ephox/katamari';
 
 import { PlacerResult } from '../../positioning/layout/LayoutTypes';
 import { nuState } from '../common/BehaviourState';
+
 import { PositioningState } from './PositioningTypes';
 
 export const init = (): PositioningState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/receiving/ActiveReceiving.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/receiving/ActiveReceiving.ts
@@ -5,6 +5,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
 import { ReceivingEvent, ReceivingInternalEvent } from '../../events/SimulatedEvent';
 import * as AlloyLogger from '../../log/AlloyLogger';
+
 import { ReceivingConfig } from './ReceivingTypes';
 
 const chooseChannels = (channels: string[], message: ReceivingInternalEvent): string[] =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ActiveReflecting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ActiveReflecting.ts
@@ -5,6 +5,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
 import { ReceivingEvent, ReceivingInternalEvent } from '../../events/SimulatedEvent';
 import { withoutReuse, withReuse } from '../replacing/ReplacingAll';
+
 import { ReflectingConfig, ReflectingState } from './ReflectingTypes';
 
 const events = <I, S>(reflectingConfig: ReflectingConfig<I, S>, reflectingState: ReflectingState<S>): AlloyEvents.AlloyEventRecord => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ReflectingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/reflecting/ReflectingApis.ts
@@ -1,4 +1,5 @@
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { ReflectingConfig, ReflectingState } from './ReflectingTypes';
 
 const getState = <I, S>(component: AlloyComponent, replaceConfig: ReflectingConfig<I, S>, reflectState: ReflectingState<S>): ReflectingState<S> =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplaceApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/replacing/ReplaceApis.ts
@@ -7,6 +7,7 @@ import * as Attachment from '../../api/system/Attachment';
 import * as Patching from '../../dom/Patching';
 import * as InternalAttachment from '../../system/InternalAttachment';
 import { Stateless } from '../common/BehaviourState';
+
 import { withoutReuse, withReuse } from './ReplacingAll';
 import { ReplacingConfig } from './ReplacingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/ActiveRepresenting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/ActiveRepresenting.ts
@@ -1,5 +1,6 @@
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as Behaviour from '../common/Behaviour';
+
 import * as RepresentApis from './RepresentApis';
 import { RepresentingConfig, RepresentingState } from './RepresentingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/DatasetStore.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/DatasetStore.ts
@@ -2,6 +2,7 @@ import { FieldSchema } from '@ephox/boulder';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
+
 import { DatasetRepresentingState, DatasetStoreConfig, RepresentingConfig } from './RepresentingTypes';
 import { dataset as datasetState } from './RepresentState';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/ManualStore.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/ManualStore.ts
@@ -4,6 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
 import { NoState } from '../common/BehaviourState';
+
 import { ManualRepresentingState, ManualStoreConfig, RepresentingConfig } from './RepresentingTypes';
 
 interface ManualRepresentingConfig extends RepresentingConfig {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/MemoryStore.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/MemoryStore.ts
@@ -2,6 +2,7 @@ import { FieldSchema } from '@ephox/boulder';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
+
 import { MemoryRepresentingState, MemoryStoreConfig, RepresentingConfig } from './RepresentingTypes';
 import { memory } from './RepresentState';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentApis.ts
@@ -1,4 +1,5 @@
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { RepresentingConfig, RepresentingState } from './RepresentingTypes';
 
 const onLoad = (component: AlloyComponent, repConfig: RepresentingConfig, repState: RepresentingState): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentSchema.ts
@@ -1,6 +1,7 @@
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 
 import * as Fields from '../../data/Fields';
+
 import DatasetStore from './DatasetStore';
 import ManualStore from './ManualStore';
 import MemoryStore from './MemoryStore';

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/representing/RepresentState.ts
@@ -2,6 +2,7 @@ import { Arr, Cell, Fun, Obj, Optional } from '@ephox/katamari';
 
 import { ItemDataTuple } from '../../ui/types/ItemTypes';
 import { nuState } from '../common/BehaviourState';
+
 import {
   DatasetRepresentingState, ManualRepresentingState, MemoryRepresentingState, RepresentingConfig, RepresentingState
 } from './RepresentingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/ActiveSandbox.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/ActiveSandbox.ts
@@ -1,5 +1,6 @@
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
+
 import * as SandboxApis from './SandboxApis';
 import { SandboxingConfig, SandboxingState } from './SandboxingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxApis.ts
@@ -5,6 +5,7 @@ import { Positioning } from '../../api/behaviour/Positioning';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloySpec } from '../../api/component/SpecTypes';
 import * as Attachment from '../../api/system/Attachment';
+
 import { SandboxingConfig, SandboxingState } from './SandboxingTypes';
 
 // NOTE: A sandbox should not start as part of the world. It is expected to be

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sandboxing/SandboxState.ts
@@ -2,6 +2,7 @@ import { Fun, Singleton } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { nuState } from '../common/BehaviourState';
+
 import { SandboxingState } from './SandboxingTypes';
 
 const init = (): SandboxingState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/ActiveSliding.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/ActiveSliding.ts
@@ -5,6 +5,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
+
 import * as SlidingApis from './SlidingApis';
 import { SlidingConfig, SlidingState } from './SlidingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingApis.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 import { Class, Classes, Css, SugarElement } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { SlidingConfig, SlidingState } from './SlidingTypes';
 import { getAnimationRoot } from './SlidingUtils';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingState.ts
@@ -1,6 +1,7 @@
 import { Cell, Fun } from '@ephox/katamari';
 
 import { nuState } from '../common/BehaviourState';
+
 import { SlidingConfig, SlidingState } from './SlidingTypes';
 
 const init = (spec: SlidingConfig): SlidingState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/sliding/SlidingUtils.ts
@@ -1,6 +1,7 @@
 import { SugarElement } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { SlidingConfig } from './SlidingTypes';
 
 export const getAnimationRoot = (component: AlloyComponent, slideConfig: SlidingConfig): SugarElement<Element> =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/ActiveStreaming.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/ActiveStreaming.ts
@@ -1,4 +1,5 @@
 import * as AlloyEvents from '../../api/events/AlloyEvents';
+
 import { StreamingConfig, StreamingState } from './StreamingTypes';
 
 const events = (streamConfig: StreamingConfig, streamState: StreamingState): AlloyEvents.AlloyEventRecord => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/StreamingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/StreamingSchema.ts
@@ -4,6 +4,7 @@ import { Throttler } from '@ephox/katamari';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
 import { EventFormat, SimulatedEvent } from '../../events/SimulatedEvent';
+
 import * as StreamingState from './StreamingState';
 import { StreamingConfig, StreamingState as StreamingStateType, ThrottleStreamingConfig } from './StreamingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/StreamingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/streaming/StreamingState.ts
@@ -1,6 +1,7 @@
 import { Cell } from '@ephox/katamari';
 
 import { nuState } from '../common/BehaviourState';
+
 import { CancellableStreamer, StreamingConfig, StreamingState } from './StreamingTypes';
 
 const throttle = (_config: StreamingConfig): StreamingState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/swapping/SwapApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/swapping/SwapApis.ts
@@ -2,6 +2,7 @@ import { Class, SugarElement } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { Stateless } from '../common/BehaviourState';
+
 import { SwappingConfig } from './SwappingTypes';
 
 const swap = (element: SugarElement<Element>, addCls: string, removeCls: string): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tabstopping/ActiveTabstopping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tabstopping/ActiveTabstopping.ts
@@ -2,6 +2,7 @@ import { Objects } from '@ephox/boulder';
 
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import * as DomModification from '../../dom/DomModification';
+
 import { TabstoppingConfig } from './TabstoppingTypes';
 
 const exhibit = (base: DomDefinitionDetail, tabConfig: TabstoppingConfig): DomModification.DomModification =>

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ActiveToggle.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ActiveToggle.ts
@@ -3,6 +3,7 @@ import { Arr } from '@ephox/katamari';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as DomModification from '../../dom/DomModification';
 import * as Behaviour from '../common/Behaviour';
+
 import * as ToggleApis from './ToggleApis';
 import { TogglingConfig, TogglingState } from './TogglingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleApis.ts
@@ -1,6 +1,7 @@
 import { Class } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { TogglingConfig, TogglingState } from './TogglingTypes';
 
 const updateAriaState = (component: AlloyComponent, toggleConfig: TogglingConfig, toggleState: TogglingState): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleModes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleModes.ts
@@ -2,6 +2,7 @@ import { Arr, Obj, Optional } from '@ephox/katamari';
 import { Attribute, SugarNode } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { AriaTogglingConfig } from './TogglingTypes';
 
 const updatePressed = (component: AlloyComponent, ariaInfo: AriaTogglingConfig, status: boolean): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/toggling/ToggleSchema.ts
@@ -2,6 +2,7 @@ import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Fun } from '@ephox/katamari';
 
 import * as Fields from '../../data/Fields';
+
 import * as ToggleModes from './ToggleModes';
 
 export default [

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
@@ -12,6 +12,7 @@ import * as NativeEvents from '../../api/events/NativeEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
 import * as Attachment from '../../api/system/Attachment';
 import { ReceivingInternalEvent } from '../../events/SimulatedEvent';
+
 import * as TooltippingApis from './TooltippingApis';
 import { ExclusivityChannel, HideTooltipEvent, ImmediateHideTooltipEvent, ImmediateShowTooltipEvent, ShowTooltipEvent } from './TooltippingCommunication';
 import { TooltippingConfig, TooltippingState } from './TooltippingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingApis.ts
@@ -2,6 +2,7 @@ import { Replacing } from '../../api/behaviour/Replacing';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloySpec } from '../../api/component/SpecTypes';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
+
 import { ExclusivityChannel, ImmediateHideTooltipEvent, ImmediateShowTooltipEvent } from './TooltippingCommunication';
 import { TooltippingConfig, TooltippingState } from './TooltippingTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/TooltippingState.ts
@@ -2,6 +2,7 @@ import { Cell, Fun, Singleton } from '@ephox/katamari';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { nuState } from '../common/BehaviourState';
+
 import { TooltippingState } from './TooltippingTypes';
 
 const init = (): TooltippingState => {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/ActiveTransitioning.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/ActiveTransitioning.ts
@@ -3,6 +3,7 @@ import { EventArgs } from '@ephox/sugar';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { Stateless } from '../common/BehaviourState';
+
 import * as TransitionApis from './TransitionApis';
 import { TransitioningConfig } from './TransitioningTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitionApis.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitionApis.ts
@@ -3,6 +3,7 @@ import { Attribute, Class } from '@ephox/sugar';
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { Stateless } from '../common/BehaviourState';
+
 import { TransitioningConfig, TransitionProperties } from './TransitioningTypes';
 
 export interface TransitionRoute {

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitioningTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/transitioning/TransitioningTypes.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 
 import * as Behaviour from '../../api/behaviour/Behaviour';
 import { AlloyComponent } from '../../api/component/ComponentApi';
+
 import { TransitionRoute } from './TransitionApis';
 
 export interface TransitioningBehaviour extends Behaviour.AlloyBehaviour<TransitioningConfigSpec, TransitioningConfig> {

--- a/modules/alloy/src/main/ts/ephox/alloy/construct/ComponentEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/construct/ComponentEvents.ts
@@ -11,6 +11,7 @@ import { BehaviourState } from '../behaviour/common/BehaviourState';
 import * as DescribedHandler from '../events/DescribedHandler';
 import { UncurriedHandler } from '../events/EventRegistry';
 import { EventFormat, SimulatedEvent } from '../events/SimulatedEvent';
+
 import * as EventHandler from './EventHandler';
 
 /*

--- a/modules/alloy/src/main/ts/ephox/alloy/dom/DomRender.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dom/DomRender.ts
@@ -3,6 +3,7 @@ import { Attribute, Classes, Css, Html, InsertAll, SugarElement, SugarNode, Valu
 
 import { isPremade } from '../api/ui/GuiTypes';
 import * as Tagger from '../registry/Tagger';
+
 import * as DomDefinition from './DomDefinition';
 import { reconcileToDom } from './Reconcile';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragMovement.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragMovement.ts
@@ -5,6 +5,7 @@ import * as OffsetOrigin from '../../alien/OffsetOrigin';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as DragCoord from '../../api/data/DragCoord';
 import * as Snappables from '../snap/Snappables';
+
 import { DraggingConfig, DragStartData, SnapsConfig } from './DraggingTypes';
 
 const getCurrentCoord = (target: SugarElement<HTMLElement>): DragCoord.CoordAdt =>

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragState.ts
@@ -2,6 +2,7 @@ import { Fun, Optional } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
 
 import { nuState } from '../../behaviour/common/BehaviourState';
+
 import { BaseDraggingState, DragModeDeltas, DragStartData } from './DraggingTypes';
 
 // NOTE: mode refers to the way that information is retrieved from

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DragUtils.ts
@@ -6,6 +6,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
 import { EventFormat } from '../../events/SimulatedEvent';
 import * as Snappables from '../snap/Snappables';
+
 import * as BlockerUtils from './BlockerUtils';
 import { DraggingConfig, DraggingState, DragModeDeltas, DragStartData } from './DraggingTypes';
 import * as DragMovement from './DragMovement';

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DraggingSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/common/DraggingSchema.ts
@@ -2,6 +2,7 @@ import { FieldProcessor, FieldSchema } from '@ephox/boulder';
 import { Fun } from '@ephox/katamari';
 
 import * as Boxes from '../../alien/Boxes';
+
 import SnapSchema from './SnapSchema';
 
 const schema: FieldProcessor[] = [

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragStarting.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragStarting.ts
@@ -6,6 +6,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import * as DomModification from '../../dom/DomModification';
+
 import * as DataTransfers from './DataTransfers';
 import { DragStartingConfig } from './DragnDropTypes';
 import { setImageClone } from './ImageClone';

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragnDropTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DragnDropTypes.ts
@@ -7,6 +7,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import { DomDefinitionDetail } from '../../dom/DomDefinition';
 import { DomModification } from '../../dom/DomModification';
 import { EventFormat, NativeSimulatedEvent } from '../../events/SimulatedEvent';
+
 import { DropEvent } from './DropEvent';
 import { DragnDropImageClone } from './ImageClone';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DropEvent.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/DropEvent.ts
@@ -1,6 +1,7 @@
 import { EventArgs } from '@ephox/sugar';
 
 import { SimulatedEvent } from '../../events/SimulatedEvent';
+
 import * as DataTransfers from './DataTransfers';
 import { DroppingConfig } from './DragnDropTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/Dropping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/dragndrop/Dropping.ts
@@ -5,6 +5,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import * as Fields from '../../data/Fields';
 import * as DomModification from '../../dom/DomModification';
+
 import * as DataTransfers from './DataTransfers';
 import { DroppingConfig } from './DragnDropTypes';
 import { createDropEventDetails } from './DropEvent';

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/mouse/MouseDragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/mouse/MouseDragging.ts
@@ -12,6 +12,7 @@ import * as BlockerUtils from '../common/BlockerUtils';
 import * as DraggingSchema from '../common/DraggingSchema';
 import { DraggingState } from '../common/DraggingTypes';
 import * as DragUtils from '../common/DragUtils';
+
 import * as MouseBlockerEvents from './MouseBlockerEvents';
 import * as MouseData from './MouseData';
 import { MouseDraggingConfig } from './MouseDraggingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/mouseortouch/MouseOrTouchDragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/mouseortouch/MouseOrTouchDragging.ts
@@ -9,6 +9,7 @@ import { DraggingState } from '../common/DraggingTypes';
 import * as DragUtils from '../common/DragUtils';
 import * as MouseDragging from '../mouse/MouseDragging';
 import * as TouchDragging from '../touch/TouchDragging';
+
 import { MouseOrTouchDraggingConfig } from './MouseOrTouchDraggingTypes';
 
 const events = <E>(dragConfig: MouseOrTouchDraggingConfig<E>, dragState: DraggingState, updateStartState: (comp: AlloyComponent) => void) => [

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/snap/Snappables.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/snap/Snappables.ts
@@ -4,6 +4,7 @@ import { SugarPosition } from '@ephox/sugar';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as DragCoord from '../../api/data/DragCoord';
 import { SnapConfig, SnapOutput, SnapPin, SnapsConfig } from '../common/DraggingTypes';
+
 import * as Presnaps from './Presnaps';
 
 // Types of coordinates

--- a/modules/alloy/src/main/ts/ephox/alloy/dragging/touch/TouchDragging.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/dragging/touch/TouchDragging.ts
@@ -11,6 +11,7 @@ import * as BlockerUtils from '../common/BlockerUtils';
 import * as DraggingSchema from '../common/DraggingSchema';
 import { DraggingState } from '../common/DraggingTypes';
 import * as DragUtils from '../common/DragUtils';
+
 import * as TouchBlockerEvents from './TouchBlockerEvents';
 import * as TouchData from './TouchData';
 import { TouchDraggingConfig } from './TouchDraggingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/events/DefaultEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/DefaultEvents.ts
@@ -4,6 +4,7 @@ import { AlloyComponent } from '../api/component/ComponentApi';
 import * as AlloyEvents from '../api/events/AlloyEvents';
 import * as SystemEvents from '../api/events/SystemEvents';
 import * as AlloyLogger from '../log/AlloyLogger';
+
 import { FocusingEvent } from './SimulatedEvent';
 
 // The purpose of this check is to ensure that a simulated focus call is not going

--- a/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/EventRegistry.ts
@@ -2,6 +2,7 @@ import { Obj, Optional } from '@ephox/katamari';
 import { SugarElement, TransformFind } from '@ephox/sugar';
 
 import * as Tagger from '../registry/Tagger';
+
 import * as DescribedHandler from './DescribedHandler';
 
 export interface ElementAndHandler {

--- a/modules/alloy/src/main/ts/ephox/alloy/events/GuiEvents.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/GuiEvents.ts
@@ -3,6 +3,7 @@ import { DomEvent, EventArgs, SelectorExists, SugarElement, SugarNode } from '@e
 
 import * as Keys from '../alien/Keys';
 import * as SystemEvents from '../api/events/SystemEvents';
+
 import * as TapEvent from './TapEvent';
 
 const isDangerous = (event: EventArgs<KeyboardEvent>): boolean => {

--- a/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/TapEvent.ts
@@ -5,6 +5,7 @@ import { Compare, EventArgs, SugarElement } from '@ephox/sugar';
 import { DelayedFunction } from '../alien/DelayedFunction';
 import * as NativeEvents from '../api/events/NativeEvents';
 import * as SystemEvents from '../api/events/SystemEvents';
+
 import { GuiEventSettings } from './GuiEvents';
 
 type EventHandler = (event: EventArgs<Event>) => Optional<boolean>;

--- a/modules/alloy/src/main/ts/ephox/alloy/events/Triggers.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/events/Triggers.ts
@@ -2,6 +2,7 @@ import { Adt, Arr, Cell, Fun, Optional } from '@ephox/katamari';
 import { SugarElement, Traverse } from '@ephox/sugar';
 
 import { DebuggerLogger } from '../debugging/Debugging';
+
 import * as DescribedHandler from './DescribedHandler';
 import { ElementAndHandler, UidAndHandler } from './EventRegistry';
 import * as EventSource from './EventSource';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/EscapingType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/EscapingType.ts
@@ -5,6 +5,7 @@ import { NoState, Stateless } from '../behaviour/common/BehaviourState';
 import * as Fields from '../data/Fields';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { EscapingConfig, KeyRuleHandler } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/ExecutionType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/ExecutionType.ts
@@ -8,6 +8,7 @@ import { NoState, Stateless } from '../behaviour/common/BehaviourState';
 import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { ExecutingConfig, KeyRuleHandler } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import * as KeyingTypes from './KeyingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/FlatgridType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/FlatgridType.ts
@@ -12,6 +12,7 @@ import * as DomPinpoint from '../navigation/DomPinpoint';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
 import * as WrapArrNavigation from '../navigation/WrapArrNavigation';
+
 import { FlatgridConfig, FlatgridState, KeyRuleHandler } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import * as KeyingTypes from './KeyingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/FlowType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/FlowType.ts
@@ -11,6 +11,7 @@ import * as DomMovement from '../navigation/DomMovement';
 import * as DomNavigation from '../navigation/DomNavigation';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { FlowConfig, KeyRuleHandler } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import * as KeyingTypes from './KeyingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingType.ts
@@ -14,6 +14,7 @@ import * as Fields from '../data/Fields';
 import { EventFormat, NativeSimulatedEvent, SimulatedEvent } from '../events/SimulatedEvent';
 import { inSet } from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { FocusInsideModes, GeneralKeyingConfig } from './KeyingModeTypes';
 
 type GetRulesFunc<C extends GeneralKeyingConfig, S extends BehaviourState> = (component: AlloyComponent, simulatedEvent: SimulatedEvent<EventArgs>, keyingConfig: C, keyingState: S) => Array<KeyRules.KeyRule<C, S>>;

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/KeyingTypes.ts
@@ -8,6 +8,7 @@ import * as AlloyTriggers from '../api/events/AlloyTriggers';
 import * as SystemEvents from '../api/events/SystemEvents';
 import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import * as KeyMatch from '../navigation/KeyMatch';
+
 import { GeneralKeyingConfig, KeyRuleHandler } from './KeyingModeTypes';
 
 const doDefaultExecute = (

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/MatrixType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/MatrixType.ts
@@ -10,6 +10,7 @@ import * as DomPinpoint from '../navigation/DomPinpoint';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
 import * as MatrixNavigation from '../navigation/MatrixNavigation';
+
 import { KeyRuleHandler, MatrixConfig } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import * as KeyingTypes from './KeyingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/MenuType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/MenuType.ts
@@ -9,6 +9,7 @@ import * as DomMovement from '../navigation/DomMovement';
 import * as DomNavigation from '../navigation/DomNavigation';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { KeyRuleHandler, MenuConfig } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import * as KeyingTypes from './KeyingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/SpecialType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/SpecialType.ts
@@ -7,6 +7,7 @@ import * as Fields from '../data/Fields';
 import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { SpecialConfig } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import { stopEventForFirefox } from './KeyingTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
@@ -9,6 +9,7 @@ import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import * as ArrNavigation from '../navigation/ArrNavigation';
 import * as KeyMatch from '../navigation/KeyMatch';
 import * as KeyRules from '../navigation/KeyRules';
+
 import { KeyRuleStatelessHandler, TabbingConfig } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetType.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/build/WidgetType.ts
@@ -16,6 +16,7 @@ import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
 import * as AlloyParts from '../../parts/AlloyParts';
 import { WidgetItemDetail } from '../../ui/types/ItemTypes';
 import * as ItemEvents from '../util/ItemEvents';
+
 import * as WidgetParts from './WidgetParts';
 
 const builder = (detail: WidgetItemDetail) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/menu/layered/LayeredState.ts
@@ -2,6 +2,7 @@ import { Arr, Cell, Obj, Optional, Optionals, Singleton } from '@ephox/katamari'
 
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { MenuPreparation } from '../../ui/single/TieredMenuSpec';
+
 import * as MenuPathing from './MenuPathing';
 
 // Object indexed by menu value. Each entry has a list of item values.

--- a/modules/alloy/src/main/ts/ephox/alloy/navigation/KeyRules.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/navigation/KeyRules.ts
@@ -2,6 +2,7 @@ import { Arr, Optional } from '@ephox/katamari';
 import { EventArgs } from '@ephox/sugar';
 
 import { KeyRuleHandler } from '../keying/KeyingModeTypes';
+
 import * as KeyMatch from './KeyMatch';
 
 export interface KeyRule<C, S> {

--- a/modules/alloy/src/main/ts/ephox/alloy/parts/AlloyParts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/parts/AlloyParts.ts
@@ -6,6 +6,7 @@ import { AlloySpec, SimpleOrSketchSpec, SketchSpec } from '../api/component/Spec
 import { CompositeSketchDetail } from '../api/ui/Sketcher';
 import * as Fields from '../data/Fields';
 import * as UiSubstitutes from '../spec/UiSubstitutes';
+
 import * as PartSubstitutes from './PartSubstitutes';
 import * as PartType from './PartType';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/parts/InternalSink.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/parts/InternalSink.ts
@@ -4,6 +4,7 @@ import * as Behaviour from '../api/behaviour/Behaviour';
 import { Positioning } from '../api/behaviour/Positioning';
 import * as AlloyEvents from '../api/events/AlloyEvents';
 import * as NativeEvents from '../api/events/NativeEvents';
+
 import * as PartType from './PartType';
 
 const suffix = Fun.constant('sink');

--- a/modules/alloy/src/main/ts/ephox/alloy/parts/PartSubstitutes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/parts/PartSubstitutes.ts
@@ -3,6 +3,7 @@ import { Arr, Fun, Merger } from '@ephox/katamari';
 import { AlloySpec } from '../api/component/SpecTypes';
 import { CompositeSketchDetail, CompositeSketchSpec } from '../api/ui/Sketcher';
 import * as UiSubstitutes from '../spec/UiSubstitutes';
+
 import { Substitutions } from './AlloyParts';
 import * as PartType from './PartType';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Layout.ts
@@ -1,4 +1,5 @@
 import { nu as NuSpotInfo } from '../view/SpotInfo';
+
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
 import { boundsRestriction, AnchorBoxBounds } from './LayoutBounds';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutBounds.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutBounds.ts
@@ -2,6 +2,7 @@ import { Arr, Num, Obj, Optional } from '@ephox/katamari';
 import { SugarPosition } from '@ephox/sugar';
 
 import * as Boxes from '../../alien/Boxes';
+
 import { AnchorBox } from './LayoutTypes';
 
 export interface BoundsRestriction {

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInset.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutInset.ts
@@ -1,4 +1,5 @@
 import { nu as NuSpotInfo } from '../view/SpotInfo';
+
 import { Bubble } from './Bubble';
 import * as Direction from './Direction';
 import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LayoutTypes.ts
@@ -2,6 +2,7 @@ import { SugarElement } from '@ephox/sugar';
 
 import * as Boxes from '../../alien/Boxes';
 import { SpotInfo } from '../view/SpotInfo';
+
 import { Bubble } from './Bubble';
 import { Placement } from './Placement';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/LinkedLayout.ts
@@ -1,4 +1,5 @@
 import { nu as NuSpotInfo } from '../view/SpotInfo';
+
 import * as Direction from './Direction';
 import { AnchorBoxBounds, boundsRestriction } from './LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from './LayoutTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/Origins.ts
@@ -5,6 +5,7 @@ import * as Boxes from '../../alien/Boxes';
 import * as OuterPosition from '../../frame/OuterPosition';
 import { NuPositionCss, PositionCss } from '../view/PositionCss';
 import { RepositionDecision } from '../view/Reposition';
+
 import * as Direction from './Direction';
 
 type NoneOrigin<T> = () => T;

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/layout/SimpleLayout.ts
@@ -5,6 +5,7 @@ import { Bounds } from '../../alien/Boxes';
 import { AnchorOverrides, MaxHeightFunction, MaxWidthFunction } from '../mode/Anchoring';
 import * as Callouts from '../view/Callouts';
 import { Transition } from '../view/Transitions';
+
 import { Anchor } from './Anchor';
 import { Bubble } from './Bubble';
 import { PlacerResult } from './LayoutTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/AnchorLayouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/AnchorLayouts.ts
@@ -3,6 +3,7 @@ import { Optional } from '@ephox/katamari';
 import { Direction, SugarElement } from '@ephox/sugar';
 
 import { AnchorLayout } from '../layout/LayoutTypes';
+
 import { HasLayoutAnchor } from './Anchoring';
 import { isBottomToTopDir } from './VerticalDir';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContainerOffsets.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContainerOffsets.ts
@@ -4,6 +4,7 @@ import { Compare, Scroll, SugarElement, SugarLocation, SugarPosition, Traverse }
 import * as CssPosition from '../../alien/CssPosition';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { OriginAdt } from '../layout/Origins';
+
 import { NodeAnchor, SelectionAnchor } from './Anchoring';
 
 // In one mode, the window is inside an iframe. If that iframe is in the

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/ContentAnchorCommon.ts
@@ -6,6 +6,7 @@ import * as CssPosition from '../../alien/CssPosition';
 import * as Bubble from '../layout/Bubble';
 import * as Layout from '../layout/Layout';
 import * as Origins from '../layout/Origins';
+
 import { Anchoring, NodeAnchor, nu as NuAnchor, SelectionAnchor } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/HotspotAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/HotspotAnchor.ts
@@ -6,6 +6,7 @@ import * as Fields from '../../data/Fields';
 import * as Bubble from '../layout/Bubble';
 import * as Layout from '../layout/Layout';
 import * as Origins from '../layout/Origins';
+
 import { Anchoring, HotspotAnchor, nu as NuAnchor } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/MakeshiftAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/MakeshiftAnchor.ts
@@ -7,6 +7,7 @@ import * as Fields from '../../data/Fields';
 import * as Bubble from '../layout/Bubble';
 import * as Layout from '../layout/Layout';
 import * as Origins from '../layout/Origins';
+
 import { MakeshiftAnchor, nu as NuAnchoring } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/NodeAnchor.ts
@@ -5,6 +5,7 @@ import { SugarBody } from '@ephox/sugar';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
 import * as Origins from '../layout/Origins';
+
 import { Anchoring, NodeAnchor } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 import * as ContainerOffsets from './ContainerOffsets';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -6,6 +6,7 @@ import * as Descend from '../../alien/Descend';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as Fields from '../../data/Fields';
 import * as Origins from '../layout/Origins';
+
 import { Anchoring, SelectionAnchor, SelectionTableCellRange } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 import * as ContainerOffsets from './ContainerOffsets';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SubmenuAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SubmenuAnchor.ts
@@ -6,6 +6,7 @@ import * as Fields from '../../data/Fields';
 import * as Bubble from '../layout/Bubble';
 import * as LinkedLayout from '../layout/LinkedLayout';
 import * as Origins from '../layout/Origins';
+
 import { Anchoring, nu as NuAnchoring, SubmenuAnchor } from './Anchoring';
 import * as AnchorLayouts from './AnchorLayouts';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Bounder.ts
@@ -7,6 +7,7 @@ import * as Direction from '../layout/Direction';
 import * as LayoutBounds from '../layout/LayoutBounds';
 import { AnchorBox, AnchorElement, AnchorLayout } from '../layout/LayoutTypes';
 import { Placement } from '../layout/Placement';
+
 import { RepositionDecision } from './Reposition';
 import { SpotInfo } from './SpotInfo';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -5,6 +5,7 @@ import { AnchorBox, AnchorElement } from '../layout/LayoutTypes';
 import * as Origins from '../layout/Origins';
 import * as Placement from '../layout/Placement';
 import { ReparteeOptions } from '../layout/SimpleLayout';
+
 import * as Bounder from './Bounder';
 import { applyPositionCss } from './PositionCss';
 import { RepositionDecision } from './Reposition';

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Transitions.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Transitions.ts
@@ -4,6 +4,7 @@ import { Attribute, Classes, Compare, Css, DomEvent, EventArgs, SugarElement } f
 import * as NativeEvents from '../../api/events/NativeEvents';
 import { PlacerResult } from '../layout/LayoutTypes';
 import * as Origins from '../layout/Origins';
+
 import { PositionCss } from './PositionCss';
 import { RepositionDecision } from './Reposition';
 
@@ -103,7 +104,7 @@ const setupTransitionListeners = (element: SugarElement<HTMLElement>, transition
   // Request the next animation frame so we can roughly determine when the transition starts and then ensure
   // the transition is cleaned up. In addition add ~17ms to the delay as that's about about 1 frame at 60fps
   const duration = getTransitionDuration(element);
-  requestAnimationFrame(() => {
+  window.requestAnimationFrame(() => {
     timer = setTimeout(transitionDone, duration + 17);
     Attribute.set(element, timerAttr, timer);
   });

--- a/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/registry/Registry.ts
@@ -4,6 +4,7 @@ import { SugarBody, SugarElement } from '@ephox/sugar';
 import { AlloyComponent } from '../api/component/ComponentApi';
 import { ElementAndHandler, EventRegistry, UidAndHandler } from '../events/EventRegistry';
 import * as AlloyLogger from '../log/AlloyLogger';
+
 import * as Tagger from './Tagger';
 
 export interface Registry {

--- a/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/toolbar/SplitToolbarUtils.ts
@@ -9,6 +9,7 @@ import * as GuiFactory from '../api/component/GuiFactory';
 import { Toolbar } from '../api/ui/Toolbar';
 import * as AlloyParts from '../parts/AlloyParts';
 import { SplitToolbarBaseDetail } from '../ui/types/SplitToolbarBaseTypes';
+
 import * as Overflows from './Overflows';
 
 const setGroups = (toolbar: AlloyComponent, storedGroups: AlloyComponent[]): void => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/composite/TypeaheadSpec.ts
@@ -26,6 +26,7 @@ import { NormalItemSpec } from '../../ui/types/ItemTypes';
 import { HighlightOnOpen, TieredData } from '../../ui/types/TieredMenuTypes';
 import { TypeaheadData, TypeaheadDetail, TypeaheadSpec } from '../../ui/types/TypeaheadTypes';
 import * as InputBase from '../common/InputBase';
+
 import * as TypeaheadEvents from './TypeaheadEvents';
 
 interface ItemExecuteEvent extends CustomEvent {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FloatingToolbarButtonSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/FloatingToolbarButtonSchema.ts
@@ -14,6 +14,7 @@ import * as AnchorLayouts from '../../positioning/mode/AnchorLayouts';
 import { ButtonSpec } from '../types/ButtonTypes';
 import { FloatingToolbarButtonDetail } from '../types/FloatingToolbarButtonTypes';
 import { ToolbarSpec } from '../types/ToolbarTypes';
+
 import * as ToolbarSchema from './ToolbarSchema';
 
 const schema = Fun.constant([

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitFloatingToolbarSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitFloatingToolbarSchema.ts
@@ -7,6 +7,7 @@ import * as PartType from '../../parts/PartType';
 import * as SplitToolbarBase from '../common/SplitToolbarBase';
 import { SplitFloatingToolbarDetail } from '../types/SplitFloatingToolbarTypes';
 import { ToolbarSpec } from '../types/ToolbarTypes';
+
 import * as ToolbarSchema from './ToolbarSchema';
 
 const schema = Fun.constant([

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/schema/SplitSlidingToolbarSchema.ts
@@ -13,6 +13,7 @@ import * as SplitToolbarBase from '../common/SplitToolbarBase';
 import { ButtonSpec } from '../types/ButtonTypes';
 import { SplitSlidingToolbarDetail } from '../types/SplitSlidingToolbarTypes';
 import { ToolbarSpec } from '../types/ToolbarTypes';
+
 import * as ToolbarSchema from './ToolbarSchema';
 
 const schema = Fun.constant([

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/EdgeActions.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/EdgeActions.ts
@@ -1,6 +1,7 @@
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import { SliderValue, SliderValueXY, TwoDSliderDetail } from '../types/SliderTypes';
+
 import * as ModelCommon from './ModelCommon';
 import { halfX, halfY, max1X, max1Y, min1X, min1Y } from './SliderValues';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/HorizontalModel.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
 import { HorizontalSliderDetail, SliderValueX } from '../types/SliderTypes';
+
 import * as EdgeActions from './EdgeActions';
 import * as ModelCommon from './ModelCommon';
 import * as SliderModel from './SliderModel';

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderSchema.ts
@@ -5,6 +5,7 @@ import { Keying } from '../../api/behaviour/Keying';
 import { Representing } from '../../api/behaviour/Representing';
 import * as SketchBehaviours from '../../api/component/SketchBehaviours';
 import * as Fields from '../../data/Fields';
+
 import * as HorizontalModel from './HorizontalModel';
 import * as TwoDModel from './TwoDModel';
 import * as VerticalModel from './VerticalModel';

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/SliderUi.ts
@@ -13,6 +13,7 @@ import { CompositeSketchFactory } from '../../api/ui/UiSketcher';
 import { EventFormat, NativeSimulatedEvent } from '../../events/SimulatedEvent';
 import * as AlloyParts from '../../parts/AlloyParts';
 import { SliderDetail, SliderSpec, SliderUpdateEvent, SliderValue } from '../types/SliderTypes';
+
 import * as ModelCommon from './ModelCommon';
 
 const sketch: CompositeSketchFactory<SliderDetail, SliderSpec> = (detail: SliderDetail, components: AlloySpec[], _spec: SliderSpec, _externals) => {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/TwoDModel.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
 import { SliderModelDetailParts, SliderValueXY, TwoDSliderDetail } from '../types/SliderTypes';
+
 import * as EdgeActions from './EdgeActions';
 import * as HorizontalModel from './HorizontalModel';
 import * as ModelCommon from './ModelCommon';

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/slider/VerticalModel.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import { NativeSimulatedEvent } from '../../events/SimulatedEvent';
 import { SliderValueY, VerticalSliderDetail } from '../types/SliderTypes';
+
 import * as EdgeActions from './EdgeActions';
 import * as ModelCommon from './ModelCommon';
 import * as SliderModel from './SliderModel';

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/DropdownTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/DropdownTypes.ts
@@ -7,6 +7,7 @@ import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
 import { AnchorOverrides, AnchorSpec, HasLayoutAnchor, HasLayoutAnchorSpec } from '../../positioning/mode/Anchoring';
+
 import { TieredData, TieredMenuSpec } from './TieredMenuTypes';
 
 // F is the fetched data

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/FloatingToolbarButtonTypes.ts
@@ -6,6 +6,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import { AlloySpec, SimpleOrSketchSpec } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
 import { HasLayoutAnchor, HasLayoutAnchorSpec } from '../../positioning/mode/Anchoring';
+
 import { ToolbarSpec } from './ToolbarTypes';
 
 export interface FloatingToolbarButtonDetail extends CompositeSketchDetail, HasLayoutAnchor {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/InlineViewTypes.ts
@@ -9,6 +9,7 @@ import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema } from '../../api/component/SpecTypes';
 import { SingleSketch, SingleSketchDetail, SingleSketchSpec } from '../../api/ui/Sketcher';
 import { PlacementSpec } from '../../behaviour/positioning/PositioningTypes';
+
 import { TieredData, TieredMenuSpec } from './TieredMenuTypes';
 
 export interface InlineViewDetail extends SingleSketchDetail {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/MenuTypes.ts
@@ -9,6 +9,7 @@ import { FocusManager } from '../../api/focus/FocusManagers';
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
 import { CustomEvent } from '../../events/SimulatedEvent';
 import { FlatgridConfigSpec, MatrixConfigSpec, MenuConfigSpec } from '../../keying/KeyingModeTypes';
+
 import { ItemSpec } from './ItemTypes';
 
 export interface MenuGridMovementSpec {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitDropdownTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitDropdownTypes.ts
@@ -6,6 +6,7 @@ import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchSpec } from '../../api/ui/Sketcher';
 import { AnchorOverrides, AnchorSpec, HasLayoutAnchorSpec } from '../../positioning/mode/Anchoring';
+
 import { CommonDropdownDetail } from './DropdownTypes';
 import { TieredData, TieredMenuSpec } from './TieredMenuTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitFloatingToolbarTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitFloatingToolbarTypes.ts
@@ -4,6 +4,7 @@ import { Bounds } from '../../alien/Boxes';
 import { LazySink } from '../../api/component/CommonTypes';
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SimpleOrSketchSpec } from '../../api/component/SpecTypes';
+
 import { SplitToolbarBaseApis, SplitToolbarBaseDetail, SplitToolbarBaseSketcher, SplitToolbarBaseSpec } from './SplitToolbarBaseTypes';
 import { ToolbarGroupSpec } from './ToolbarGroupTypes';
 import { ToolbarSpec } from './ToolbarTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitSlidingToolbarTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitSlidingToolbarTypes.ts
@@ -1,5 +1,6 @@
 import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SimpleOrSketchSpec } from '../../api/component/SpecTypes';
+
 import { SplitToolbarBaseApis, SplitToolbarBaseDetail, SplitToolbarBaseSketcher, SplitToolbarBaseSpec } from './SplitToolbarBaseTypes';
 import { ToolbarGroupSpec } from './ToolbarGroupTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/SplitToolbarBaseTypes.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema, SimpleOrSketchSpec, SketchSpec } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
+
 import { ToolbarGroupSpec } from './ToolbarGroupTypes';
 
 export interface SplitToolbarBaseDetail extends CompositeSketchDetail {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TabSectionTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TabSectionTypes.ts
@@ -3,6 +3,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
+
 import { TabButtonWithViewSpec } from './TabbarTypes';
 
 export interface TabSectionDetail extends CompositeSketchDetail {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TabbarTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TabbarTypes.ts
@@ -2,6 +2,7 @@ import { AlloyBehaviourRecord } from '../../api/behaviour/Behaviour';
 import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
+
 import { TabButtonSpec } from './TabButtonTypes';
 
 export interface TabbarDetail extends CompositeSketchDetail {

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TieredMenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TieredMenuTypes.ts
@@ -6,6 +6,7 @@ import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec, RawDomSchema } from '../../api/component/SpecTypes';
 import { SingleSketch, SingleSketchDetail, SingleSketchSpec } from '../../api/ui/Sketcher';
 import { LayeredItemTrigger } from '../../menu/layered/LayeredState';
+
 import { ItemDataTuple } from './ItemTypes';
 import { MenuSpec } from './MenuTypes';
 

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TouchMenuTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TouchMenuTypes.ts
@@ -8,6 +8,7 @@ import { AlloySpec, RawDomSchema, SimpleOrSketchSpec } from '../../api/component
 import { CompositeSketch, CompositeSketchDetail, CompositeSketchSpec } from '../../api/ui/Sketcher';
 import { TransitionProperties } from '../../behaviour/transitioning/TransitioningTypes';
 import { AnchorSpec } from '../../positioning/mode/Anchoring';
+
 import { CommonDropdownDetail } from './DropdownTypes';
 import { ItemDataTuple, ItemSpec } from './ItemTypes';
 import { TabviewSpec } from './TabviewTypes';

--- a/modules/alloy/src/main/ts/ephox/alloy/ui/types/TypeaheadTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/ui/types/TypeaheadTypes.ts
@@ -5,6 +5,7 @@ import { AlloyComponent } from '../../api/component/ComponentApi';
 import { SketchBehaviours } from '../../api/component/SketchBehaviours';
 import { AlloySpec } from '../../api/component/SpecTypes';
 import { CompositeSketch, CompositeSketchSpec } from '../../api/ui/Sketcher';
+
 import { CommonDropdownDetail } from './DropdownTypes';
 import { InputDetail, InputSpec } from './InputTypes';
 import { ItemDataTuple } from './ItemTypes';

--- a/modules/tinymce/src/themes/silver/test/ts/module/GuiSetup.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/GuiSetup.ts
@@ -145,10 +145,10 @@ const bddSetup = <T = string>(
   createComponent: (store: TestStore<T>, doc: SugarElement<Document>, body: SugarElement<Node>) => AlloyComponent,
   createGui?: () => Gui.GuiSystem
 ): Hook<SugarElement<Document>, T> =>
-  bddSetupIn(() => ({
-    root: SugarDocument.getDocument(),
-    teardown: Fun.noop
-  }), createComponent, createGui);
+    bddSetupIn(() => ({
+      root: SugarDocument.getDocument(),
+      teardown: Fun.noop
+    }), createComponent, createGui);
 
 /**
  * Setup in a Shadow Root, run list of untyped Steps, then tear down.


### PR DESCRIPTION
# Update ESLint Configuration Path and Add Blank Lines for Better Code Organization

## Description of Changes:
* Updated the ESLint configuration path in `modules/alloy/package.json` from `.eslintrc.json` to `eslint.config.ts`
* Added blank lines between import groups across multiple files in the Alloy module to improve code readability and organization
* Fixed a commented-out eslint-disable comment in `DragCoord.ts`
* Replaced direct `requestAnimationFrame` call with `window.requestAnimationFrame` in `Transitions.ts` for better clarity

## Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

## Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~