### PR TITLE
TINY-11629: Upgrade darwin to use eslint V9

### DIFF
--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -34,7 +34,7 @@
   "types": "./lib/main/ts/ephox/darwin/api/Main.d.ts",
   "scripts": {
     "test": "tsc -b",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   }

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -7,6 +7,7 @@ import { MouseSelection } from '../mouse/MouseSelection';
 import * as KeyDirection from '../navigation/KeyDirection';
 import * as CellSelection from '../selection/CellSelection';
 import { Response } from '../selection/Response';
+
 import { SelectionAnnotation } from './SelectionAnnotation';
 import * as SelectionKeys from './SelectionKeys';
 import { WindowBridge } from './WindowBridge';

--- a/modules/darwin/src/main/ts/ephox/darwin/api/Main.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/Main.ts
@@ -1,6 +1,7 @@
 import * as CellOpSelection from '../queries/CellOpSelection';
 import { Response } from '../selection/Response';
 import { Selections } from '../selection/Selections';
+
 import { Ephemera } from './Ephemera';
 import * as InputHandlers from './InputHandlers';
 import { SelectionAnnotation } from './SelectionAnnotation';

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 import { Awareness, RawRect, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { WindowBridge } from '../api/WindowBridge';
+
 import * as Carets from './Carets';
 
 type Carets = Carets.Carets;

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
@@ -5,6 +5,7 @@ import { PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
 import { WindowBridge } from '../api/WindowBridge';
 import { Situs } from '../selection/Situs';
+
 import * as Carets from './Carets';
 import * as Rectangles from './Rectangles';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
@@ -8,6 +8,7 @@ import { BeforeAfter } from '../navigation/BeforeAfter';
 import * as BrTags from '../navigation/BrTags';
 import { KeyDirection } from '../navigation/KeyDirection';
 import { Situs } from '../selection/Situs';
+
 import * as Carets from './Carets';
 import * as Rectangles from './Rectangles';
 import { Retries } from './Retries';

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/VerticalMovement.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/VerticalMovement.ts
@@ -6,6 +6,7 @@ import { WindowBridge } from '../api/WindowBridge';
 import { KeyDirection } from '../navigation/KeyDirection';
 import { Response } from '../selection/Response';
 import * as Util from '../selection/Util';
+
 import * as KeySelection from './KeySelection';
 import * as TableKeys from './TableKeys';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/BrTags.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/BrTags.ts
@@ -3,6 +3,7 @@ import { Spot, SpotPoint } from '@ephox/phoenix';
 import { Awareness, ElementAddress, Situ, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
 
 import { Situs } from '../selection/Situs';
+
 import { BeforeAfter } from './BeforeAfter';
 import { KeyDirection } from './KeyDirection';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
@@ -6,6 +6,7 @@ import { WindowBridge } from '../api/WindowBridge';
 import { Carets } from '../keyboard/Carets';
 import { Retries } from '../keyboard/Retries';
 import { Situs } from '../selection/Situs';
+
 import { BeforeAfter, BeforeAfterFailureConstructor } from './BeforeAfter';
 
 export interface KeyDirection {


### PR DESCRIPTION
# Update ESLint Configuration Path and Fix Import Spacing

Related Ticket: TINY-11629

Description of Changes:
* Updated ESLint configuration path from `.eslintrc.json` to `eslint.config.ts` in package.json
* Added consistent blank lines between import groups across multiple files to improve code readability

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):