### PR TITLE
TINY-11629: Upgrade dragster to use eslint V9

### DIFF
--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test",
     "test-manual": "bedrock -d src/test",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/dragster/src/main/ts/ephox/dragster/api/Dragger.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/Dragger.ts
@@ -1,5 +1,6 @@
 import * as Dragging from '../core/Dragging';
 import { BlockerOptions } from '../detect/Blocker';
+
 import { DragMode, DragMutation } from './DragApis';
 import MouseDrag from './MouseDrag';
 

--- a/modules/dragster/src/main/ts/ephox/dragster/api/Main.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/Main.ts
@@ -1,4 +1,5 @@
 import { DragImageData } from '../datatransfer/DragImage';
+
 import * as DataTransfer from './DataTransfer';
 import * as DataTransferContent from './DataTransferContent';
 import * as DataTransferEvent from './DataTransferEvent';

--- a/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 import { DomEvent, EventArgs, Insert, Remove, SugarElement, SugarPosition } from '@ephox/sugar';
 
 import { Blocker, BlockerOptions } from '../detect/Blocker';
+
 import { DragApi, DragMode, DragMutation, DragSink } from './DragApis';
 
 const compare = (old: SugarPosition, nu: SugarPosition) => {

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
@@ -3,6 +3,7 @@ import { Event, Events } from '@ephox/porkbun';
 import { EventArgs, SugarPosition } from '@ephox/sugar';
 
 import { DragMode } from '../api/DragApis';
+
 import { DragEvents, DragState } from './DragTypes';
 
 export const InDrag = (): DragState => {

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/Movement.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/Movement.ts
@@ -1,6 +1,7 @@
 import { EventArgs } from '@ephox/sugar';
 
 import { DragMode } from '../api/DragApis';
+
 import { DragEvents, DragState } from './DragTypes';
 import { InDrag } from './InDrag';
 import { NoDrag } from './NoDrag';


### PR DESCRIPTION
# Update ESLint Configuration Path and Fix Import Spacing

Related Ticket: TINY-11629

Description of Changes:
* Updated ESLint configuration path in `package.json` from `.eslintrc.json` to `eslint.config.ts`
* Added consistent blank lines between import groups in multiple files to improve code readability

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):