### PR TITLE
TINY-11629: Upgrade katamari to use eslint V9

### DIFF
--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "prepublishOnly": "yarn run lint && yarn run build",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "build": "tsc -b",
     "test": "bedrock-auto -b chrome-headless --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",
     "test-manual": "bedrock --customRoutes --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -9,11 +9,9 @@ type ArrayGuardPredicate<T, U extends T> = (x: T, i: number) => x is U;
 type ArrayPredicate<T> = ArrayMorphism<T, boolean>;
 type Comparator<T> = (a: T, b: T) => number;
 
-/* eslint-disable @typescript-eslint/unbound-method */
 const nativeSlice = Array.prototype.slice;
 const nativeIndexOf = Array.prototype.indexOf;
 const nativePush = Array.prototype.push;
-/* eslint-enable */
 
 const rawIndexOf = <T> (ts: ArrayLike<T>, t: T): number =>
   nativeIndexOf.call(ts, t);

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Contracts.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Contracts.ts
@@ -1,4 +1,5 @@
 import * as BagUtils from '../util/BagUtils';
+
 import * as Arr from './Arr';
 import * as Fun from './Fun';
 import * as Obj from './Obj';

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Fun.ts
@@ -42,7 +42,6 @@ function curry <A, B, C, D, E, F, G, REST extends any[], OUT>(fn: (a: A, b: B, c
 function curry <A, B, C, D, E, F, G, H, REST extends any[], OUT>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, ...restArgs: REST) => OUT, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H): (...restArgs: REST) => OUT;
 function curry <A, B, C, D, E, F, G, H, I, REST extends any[], OUT>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, ...restArgs: REST) => OUT, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I): (...restArgs: REST) => OUT;
 function curry <A, B, C, D, E, F, G, H, I, J, REST extends any[], OUT>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, ...restArgs: REST) => OUT, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J): (...restArgs: REST) => OUT;
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function curry <OUT>(fn: (...allArgs: any[]) => OUT, ...initialArgs: any[]): (...restArgs: any[]) => OUT {
   return (...restArgs: any[]) => {
     const all = initialArgs.concat(restArgs);

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Futures.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Futures.ts
@@ -1,4 +1,5 @@
 import * as AsyncValues from '../async/AsyncValues';
+
 import * as Arr from './Arr';
 import { Future } from './Future';
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/LazyValues.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/LazyValues.ts
@@ -1,4 +1,5 @@
 import * as AsyncValues from '../async/AsyncValues';
+
 import * as Fun from './Fun';
 import { LazyValue } from './LazyValue';
 import { Optional } from './Optional';

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Obj.ts
@@ -15,7 +15,6 @@ type ObjPredicate<T extends {}> = (value: T[keyof T], key: ObjKeys<T>) => boolea
 // Use the native keys if it is available (IE9+), otherwise fall back to manually filtering
 export const keys = Object.keys;
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
 export const hasOwnProperty = Object.hasOwnProperty;
 
 export const each = <T extends {}>(obj: T, f: ObjCallback<T>): void => {

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Strings.ts
@@ -1,4 +1,5 @@
 import * as StrAppend from '../str/StrAppend';
+
 import { Optional } from './Optional';
 import * as Type from './Type';
 

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrFromTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrFromTest.ts
@@ -6,8 +6,7 @@ import * as Arr from 'ephox/katamari/api/Arr';
 describe('atomic.katamari.api.arr.ArrFromTest', () => {
   it('works with arguments values', () => {
 
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions,@typescript-eslint/no-unused-vars
-    const func = function (...args: number[]) {
+    const func = function (..._args: number[]) {
       assert.deepEqual(Arr.from(arguments), [ 1, 2, 3 ]);
     };
     func(1, 2, 3);

--- a/modules/katamari/src/test/ts/atomic/api/struct/AdtTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/struct/AdtTest.ts
@@ -63,7 +63,6 @@ describe('atomic.katamari.api.struct.AdtTest', () => {
     const targetStr = 'target';
     const blockStr = 'block';
 
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     const tag = function (target: string, block: string) {
       assert.equal(arguments.length, 2);
       assert.equal(target, targetStr);

--- a/modules/katamari/src/test/ts/module/ephox/katamari/test/AsyncProps.ts
+++ b/modules/katamari/src/test/ts/module/ephox/katamari/test/AsyncProps.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @tinymce/no-unimported-promise */
 import { Assert } from '@ephox/bedrock-client';
 import { Testable } from '@ephox/dispute';
 


### PR DESCRIPTION
# Update ESLint Configuration and Fix Linting Issues

Related Ticket: TINY-11629

Description of Changes:
* Updated ESLint configuration path from `.eslintrc.json` to `eslint.config.ts` in package.json files
* Removed unnecessary ESLint disable comments throughout the codebase
* Fixed linting issues in various files:
  * Removed `@typescript-eslint/unbound-method` disables in Arr.ts and Obj.ts
  * Removed `prefer-arrow/prefer-arrow-functions` disable in Fun.ts
  * Renamed unused parameter in ArrFromTest.ts to use underscore prefix
  * Fixed spacing issues in import statements
  * Removed `@tinymce/no-unimported-promise` disable in AsyncProps.ts

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):