### PR TITLE
TINY-11629: Upgrade phoenix and mcagar to use eslint V9

### DIFF
--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ApiChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ApiChains.ts
@@ -4,6 +4,7 @@ import { Editor } from '../../alien/EditorTypes';
 import * as Options from '../../alien/Options';
 import * as TinyAssertions from '../bdd/TinyAssertions';
 import * as TinySelections from '../bdd/TinySelections';
+
 import { Presence } from './TinyApis';
 
 export interface ApiChains {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -3,6 +3,7 @@ import { Arr, Fun, FutureResult, Global, Id, Optional, Result } from '@ephox/kat
 import { Attribute, DomEvent, Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarHead, SugarShadowDom } from '@ephox/sugar';
 
 import { Editor } from '../alien/EditorTypes';
+
 import { detectTinymceBaseUrl } from './Urls';
 
 export type SuccessCallback = (v?: any, logs?: TestLogs) => void;

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/Main.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/Main.ts
@@ -1,4 +1,5 @@
 import * as Seeker from '../gather/Seeker'; // robin is using this directly
+
 import { Focus } from './data/Focus';
 import { GatherResult } from './data/GatherResult';
 import { InjectPosition } from './data/InjectPosition';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/Extract.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/Extract.ts
@@ -4,6 +4,7 @@ import { Arr } from '@ephox/katamari';
 import * as Spot from '../api/data/Spot';
 import { TypedItem } from '../api/data/TypedItem';
 import { SpotPoint } from '../api/data/Types';
+
 import * as TypedList from './TypedList';
 
 /**

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/Find.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/Find.ts
@@ -4,6 +4,7 @@ import { PositionArray } from '@ephox/polaris';
 
 import * as Spot from '../api/data/Spot';
 import { SpotPoint } from '../api/data/Types';
+
 import * as Extract from './Extract';
 import * as TypedList from './TypedList';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/family/Range.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/family/Range.ts
@@ -3,6 +3,7 @@ import { Arr, Fun } from '@ephox/katamari';
 
 import * as Extract from '../api/general/Extract';
 import { OrphanText } from '../wrap/OrphanText';
+
 import * as Parents from './Parents';
 
 const index = <E, D>(universe: Universe<E, D>, items: E[], item: E) => {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/gather/Seeker.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/gather/Seeker.ts
@@ -2,6 +2,7 @@ import { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
 import { Direction, Transition } from '../api/data/Types';
+
 import * as Walker from './Walker';
 import { Walkers } from './Walkers';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/MatchSplitter.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/MatchSplitter.ts
@@ -3,6 +3,7 @@ import { Arr } from '@ephox/katamari';
 import { PositionArray, PRange } from '@ephox/polaris';
 
 import { SearchResult, SpotRange } from '../api/data/Types';
+
 import * as Splitter from './Splitter';
 
 /**

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/Searcher.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/Searcher.ts
@@ -8,6 +8,7 @@ import { TypedItem } from '../api/data/TypedItem';
 import { SearchResult, SpotRange } from '../api/data/Types';
 import * as Family from '../api/general/Family';
 import * as TypedList from '../extract/TypedList';
+
 import * as MatchSplitter from './MatchSplitter';
 
 const gen = <E, D>(universe: Universe<E, D>, input: E[]): SpotRange<E>[] => {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/split/Range.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/split/Range.ts
@@ -2,6 +2,7 @@ import { Universe } from '@ephox/boss';
 
 import * as Spot from '../api/data/Spot';
 import * as Family from '../api/general/Family';
+
 import * as Split from './Split';
 
 /**

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/SpanWrap.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/SpanWrap.ts
@@ -4,6 +4,7 @@ import { Fun, Optional, Unicode } from '@ephox/katamari';
 import * as Spot from '../api/data/Spot';
 import { SpanWrapRange, SpotPoint } from '../api/data/Types';
 import * as Injection from '../api/general/Injection';
+
 import * as Wrapper from './Wrapper';
 import { Wraps } from './Wraps';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Wrapper.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Wrapper.ts
@@ -5,6 +5,7 @@ import * as Spot from '../api/data/Spot';
 import { SpotPoints, Wrapter } from '../api/data/Types';
 import * as Split from '../api/general/Split';
 import * as Contiguous from '../util/Contiguous';
+
 import * as Navigation from './Navigation';
 
 type Group<E> = Contiguous.Group<E>;


### PR DESCRIPTION
# Update ESLint Configuration Path

Related Ticket: TINY-11629

## Description of Changes:
* Updated ESLint configuration path from `.eslintrc.json` to `eslint.config.ts` in package.json files for katamari-assertions, mcagar, and phoenix modules
* Added blank lines between imports in various files to improve code organization and readability

## Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

## Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)