### PR TITLE
TINY-11629: Upgrade robin and polaris to use eslint V9

### DIFF
--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -30,7 +30,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Arrays.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Arrays.ts
@@ -1,6 +1,7 @@
 import * as Boundaries from '../array/Boundaries';
 import * as Slice from '../array/Slice';
 import * as Split from '../array/Split';
+
 import { Splitting } from './Splitting';
 
 type BoundAtApi = <T, T2>(xs: T[], left: T2, right: T2, comparator: (a: T2, b: T) => boolean) => T[];

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Main.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Main.ts
@@ -1,5 +1,6 @@
 import { PRange, PRegExp } from '../pattern/Types';
 import { WordOptions } from '../words/Words';
+
 import * as Arrays from './Arrays';
 import * as Pattern from './Pattern';
 import * as PositionArray from './PositionArray';

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Split.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Split.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { PRange } from '../pattern/Types';
+
 import * as Query from './Query';
 import * as Translate from './Translate';
 

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { PRange, PRegExp } from '../pattern/Types';
+
 import * as Find from './Find';
 
 const sort = <T extends PRange>(array: T[]): T[] => Arr.sort(array, (a, b) => a.start - b.start);

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test",
     "test-manual": "bedrock -d src/test",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   }

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextZones.ts
@@ -3,6 +3,7 @@ import { Descent } from '@ephox/phoenix';
 
 import * as TextZones from '../../zone/TextZones';
 import { Zones, Zone } from '../../zone/Zones';
+
 import { ZoneViewports } from './ZoneViewports';
 
 /*

--- a/modules/robin/src/main/ts/ephox/robin/smartselect/Selection.ts
+++ b/modules/robin/src/main/ts/ephox/robin/smartselect/Selection.ts
@@ -3,6 +3,7 @@ import { Optional } from '@ephox/katamari';
 
 import { WordRange } from '../data/WordRange';
 import * as CurrentWord from '../util/CurrentWord';
+
 import * as EndofWord from './EndofWord';
 
 /*  Given an initial position (item, offset), identify the optional selection range which represents the

--- a/modules/robin/src/main/ts/ephox/robin/util/CurrentWord.ts
+++ b/modules/robin/src/main/ts/ephox/robin/util/CurrentWord.ts
@@ -1,6 +1,7 @@
 import { Optional, Optionals } from '@ephox/katamari';
 
 import { BeforeAfter } from '../data/BeforeAfter';
+
 import * as WordUtil from './WordUtil';
 
 /*

--- a/modules/robin/src/main/ts/ephox/robin/words/Clustering.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/Clustering.ts
@@ -2,6 +2,7 @@ import { Universe } from '@ephox/boss';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import { LanguageZones } from '../zone/LanguageZones';
+
 import * as ClusterSearch from './ClusterSearch';
 import { WordDecision, WordDecisionItem } from './WordDecision';
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
@@ -5,6 +5,7 @@ import { Descent } from '@ephox/phoenix';
 import { ZoneViewports } from '../api/general/ZoneViewports';
 import * as Clustering from '../words/Clustering';
 import { WordDecision, WordDecisionItem } from '../words/WordDecision';
+
 import { LanguageZones } from './LanguageZones';
 import * as TextZones from './TextZones';
 import { Zone } from './Zones';

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
@@ -5,6 +5,7 @@ import * as Parent from '../api/general/Parent';
 import { ZoneViewports } from '../api/general/ZoneViewports';
 import * as Clustering from '../words/Clustering';
 import { WordDecision, WordDecisionItem } from '../words/WordDecision';
+
 import { LanguageZones, ZoneDetails } from './LanguageZones';
 import * as Zones from './Zones';
 import * as ZoneWalker from './ZoneWalker';

--- a/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
@@ -5,6 +5,7 @@ import { Gather, Traverse } from '@ephox/phoenix';
 import { ZonePosition } from '../api/general/ZonePosition';
 import { ZoneViewports } from '../api/general/ZoneViewports';
 import { WordDecisionItem } from '../words/WordDecision';
+
 import { LanguageZones, ZoneDetails } from './LanguageZones';
 
 // Figure out which direction to take the next step in. Returns None if the traversal should stop.

--- a/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
@@ -3,6 +3,7 @@ import { Arr } from '@ephox/katamari';
 
 import { WordScope } from '../data/WordScope';
 import * as Identify from '../words/Identify';
+
 import { ZoneDetails } from './LanguageZones';
 
 export interface Zone<E> {

--- a/modules/robin/src/test/ts/module/ephox/robin/test/Arbitraries.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/Arbitraries.ts
@@ -22,8 +22,8 @@ const getIds = (item: Gene, predicate: (g: Gene) => boolean): string[] => {
   const rest = Arr.bind(item.children || [], (id) => {
     return getIds(id, predicate);
   });
-  const self = predicate(item) && item.id !== 'root' ? [ item.id ] : [];
-  return self.concat(rest);
+  const itemIdArray = predicate(item) && item.id !== 'root' ? [ item.id ] : [];
+  return itemIdArray.concat(rest);
 };
 
 const textIds = (universe: TestUniverse) => {


### PR DESCRIPTION
# Update ESLint configuration path and improve code formatting

Related Ticket: TINY-11629

## Description of Changes:
* Updated ESLint configuration path from `.eslintrc.json` to `eslint.config.ts` in package.json files for polaris, porkbun, and robin modules
* Added blank lines between import groups to improve code organization and readability
* Renamed variable `self` to `itemIdArray` in Arbitraries.ts to better reflect its purpose

## Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

## Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)