### PR TITLE
TINY-11629: Upgrade sugar to use eslint V9

### DIFF
--- a/modules/acid/package.json
+++ b/modules/acid/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "prepublishOnly": "tsc -b",
     "build": "tsc",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts"
   }

--- a/modules/agar/package.json
+++ b/modules/agar/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock --testdirs src/test/ts/browser src/test/ts/atomic",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "keywords": [
     "testing",

--- a/modules/alloy/package.json
+++ b/modules/alloy/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless --testdirs src/test/ts/atomic src/test/ts/browser src/test/ts/webdriver",
     "test-manual": "bedrock --testdirs src/test/ts/atomic src/test/ts/browser src/test/ts/webdriver",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "start": "grunt dev",
     "prepublishOnly": "tsc -b",
     "build": "tsc"

--- a/modules/boss/package.json
+++ b/modules/boss/package.json
@@ -31,7 +31,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/boulder/package.json
+++ b/modules/boulder/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/boulder/src/main/ts/ephox/boulder/combine/ResultCombine.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/combine/ResultCombine.ts
@@ -2,12 +2,14 @@ import { Arr, Fun, Merger } from '@ephox/katamari';
 
 import { SimpleResult } from '../alien/SimpleResult';
 
-const mergeValues = <E, T>(values: T[], base: Record<string, T>): SimpleResult<E[], T> => values.length > 0 ? SimpleResult.svalue(
-  Merger.deepMerge(
-    base,
-    Merger.merge.apply(undefined, values)
-  )
-) : SimpleResult.svalue(base);
+const mergeValues = <E, T>(values: T[], base: Record<string, T>): SimpleResult<E[], T> => {
+  return SimpleResult.svalue(
+    Merger.deepMerge(
+      base,
+      Merger.merge.apply(undefined, values)
+    )
+  );
+};
 
 const mergeErrors = <E, T>(errors: E[][]): SimpleResult<E[], T> =>
   Fun.compose<any, any, any>(SimpleResult.serror, Arr.flatten)(errors);

--- a/modules/bridge/package.json
+++ b/modules/bridge/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepublishOnly": "tsc -b",
     "build": "tsc",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "dependencies": {
     "@ephox/boulder": "^8.0.0",

--- a/modules/darwin/package.json
+++ b/modules/darwin/package.json
@@ -34,7 +34,7 @@
   "types": "./lib/main/ts/ephox/darwin/api/Main.d.ts",
   "scripts": {
     "test": "tsc -b",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   }

--- a/modules/dragster/package.json
+++ b/modules/dragster/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test",
     "test-manual": "bedrock -d src/test",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/jax/package.json
+++ b/modules/jax/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "prepublishOnly": "yarn run lint && yarn run build",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "build": "tsc -b",
     "test": "bedrock-auto -b chrome-headless --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",
     "test-manual": "bedrock --customRoutes --customRoutes ../tinymce/src/core/test/json/routes.json -d src/test/ts/",

--- a/modules/katamari-assertions/package.json
+++ b/modules/katamari-assertions/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/katamari/package.json
+++ b/modules/katamari/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/mcagar/package.json
+++ b/modules/mcagar/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/phoenix/package.json
+++ b/modules/phoenix/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "test-manual": "bedrock -d src/test",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/polaris/package.json
+++ b/modules/polaris/package.json
@@ -30,7 +30,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",

--- a/modules/porkbun/package.json
+++ b/modules/porkbun/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   },

--- a/modules/robin/package.json
+++ b/modules/robin/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "test": "bedrock-auto -b chrome-headless -d src/test",
     "test-manual": "bedrock -d src/test",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts",
+    "lint": "eslint --max-warnings=0 src/**/*.ts",
     "prepublishOnly": "tsc -b",
     "build": "tsc"
   }

--- a/modules/sand/package.json
+++ b/modules/sand/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "keywords": [
     "platform"

--- a/modules/snooker/package.json
+++ b/modules/snooker/package.json
@@ -39,6 +39,6 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless -d src/test/ts",
     "test-manual": "bedrock -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   }
 }

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless --stopOnFailure -d src/test/ts",
     "test-manual": "bedrock --stopOnFailure -d src/test/ts",
-    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --max-warnings=0 src/**/*.ts"
   },
   "keywords": [
     "DOM",

--- a/modules/sugar/package.json
+++ b/modules/sugar/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "test": "bedrock-auto -b chrome-headless --stopOnFailure -d src/test/ts",
     "test-manual": "bedrock --stopOnFailure -d src/test/ts",
-    "lint": "eslint --config ../../.eslintrc.json --max-warnings=0 src/**/*.ts"
+    "lint": "eslint --config ../../eslint.config.ts --max-warnings=0 src/**/*.ts"
   },
   "keywords": [
     "DOM",

--- a/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
@@ -1,4 +1,5 @@
 import * as SelectionDirection from '../selection/core/SelectionDirection'; // Used directly by dawin
+
 import * as Compare from './dom/Compare';
 import * as DocumentPosition from './dom/DocumentPosition';
 import * as DomFuture from './dom/DomFuture';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/DocumentPosition.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/DocumentPosition.ts
@@ -1,5 +1,6 @@
 import { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
+
 import * as Compare from './Compare';
 
 const makeRange = (start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number): Range => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
@@ -2,6 +2,7 @@ import { Fun, Optional } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
+
 import * as Compare from './Compare';
 
 /*

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
+
 import * as Insert from './Insert';
 
 const before = (marker: SugarElement<Node>, elements: SugarElement<Node>[]): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Link.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Link.ts
@@ -2,6 +2,7 @@ import { SugarElement } from '../node/SugarElement';
 import * as SugarHead from '../node/SugarHead';
 import * as Attribute from '../properties/Attribute';
 import * as Platform from '../view/Platform';
+
 import * as Insert from './Insert';
 
 const addToHead = (doc: SugarElement<Document>, tag: SugarElement<Node>): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
@@ -2,6 +2,7 @@ import { Arr } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
+
 import * as InsertAll from './InsertAll';
 
 const empty = (element: SugarElement<Node>): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
@@ -2,6 +2,7 @@ import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 import { SugarElement } from '../node/SugarElement';
 import * as Attribute from '../properties/Attribute';
 import * as Traverse from '../search/Traverse';
+
 import * as Insert from './Insert';
 import * as InsertAll from './InsertAll';
 import * as Remove from './Remove';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
@@ -1,6 +1,7 @@
 import { SugarElement } from '../node/SugarElement';
 import * as SugarShadowDom from '../node/SugarShadowDom';
 import * as Html from '../properties/Html';
+
 import * as Replication from './Replication';
 
 const getHtml = (element: SugarElement<Node>): string => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/DomEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/DomEvent.ts
@@ -2,6 +2,7 @@ import { Fun } from '@ephox/katamari';
 
 import * as FilteredEvent from '../../impl/FilteredEvent';
 import { SugarElement } from '../node/SugarElement';
+
 import { EventHandler, EventUnbinder } from './Types';
 
 const filter = Fun.always; // no filter on plain DomEvents

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvents.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvents.ts
@@ -1,5 +1,6 @@
 import * as FilteredEvent from '../../impl/FilteredEvent';
 import { SugarElement } from '../node/SugarElement';
+
 import { EventFilter, EventHandler } from './Types';
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Ready.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Ready.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
+
 import * as DomEvent from './DomEvent';
 
 const documentReady = (f: () => void): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Resize.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Resize.ts
@@ -6,6 +6,7 @@ import { SugarElement } from '../node/SugarElement';
 import * as Height from '../view/Height';
 import * as Visibility from '../view/Visibility';
 import * as Width from '../view/Width';
+
 import * as DomEvent from './DomEvent';
 import { EventUnbinder } from './Types';
 import * as Viewable from './Viewable';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
@@ -1,6 +1,7 @@
 import { SugarElement } from '../node/SugarElement';
 import * as Scroll from '../view/Scroll';
 import { SugarPosition } from '../view/SugarPosition';
+
 import * as DomEvent from './DomEvent';
 import { EventUnbinder } from './Types';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarComment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarComment.ts
@@ -1,6 +1,7 @@
 import { Optional } from '@ephox/katamari';
 
 import { NodeValue } from '../../impl/NodeValue';
+
 import { SugarElement } from './SugarElement';
 import * as SugarNode from './SugarNode';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElementInstances.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElementInstances.ts
@@ -1,6 +1,7 @@
 import { Eq, Pnode, Pprint, Testable } from '@ephox/dispute';
 
 import * as Html from '../properties/Html';
+
 import { SugarElement } from './SugarElement';
 
 type EqType<A> = Eq.Eq<A>;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElements.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElements.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import * as Traverse from '../search/Traverse';
+
 import { SugarElement } from './SugarElement';
 
 type ElementTuple<T> = { [K in keyof T]: SugarElement<T[K]> };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarNode.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarNode.ts
@@ -1,6 +1,7 @@
 import { SandHTMLElement } from '@ephox/sand';
 
 import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
+
 import * as NodeTypes from './NodeTypes';
 import { SugarElement } from './SugarElement';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -2,6 +2,7 @@ import { Arr, Optional, Type } from '@ephox/katamari';
 
 import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 import * as Traverse from '../search/Traverse';
+
 import { SugarElement } from './SugarElement';
 import * as SugarHead from './SugarHead';
 import * as SugarNode from './SugarNode';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarText.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarText.ts
@@ -1,6 +1,7 @@
 import { Optional } from '@ephox/katamari';
 
 import { NodeValue } from '../../impl/NodeValue';
+
 import { SugarElement } from './SugarElement';
 import * as SugarNode from './SugarNode';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
@@ -2,6 +2,7 @@ import { Obj } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
 import * as Node from '../node/SugarNode';
+
 import * as Css from './Css';
 import * as Direction from './Direction';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttrList.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttrList.ts
@@ -1,6 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
+
 import * as Attribute from './Attribute';
 
 // Methods for handling attributes that contain a list of values <div foo="alpha beta theta">

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as Attribute from './Attribute';
 
 export interface AttributeProperty {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
@@ -1,5 +1,6 @@
 import * as ClassList from '../../impl/ClassList';
 import { SugarElement } from '../node/SugarElement';
+
 import * as Attribute from './Attribute';
 import { Toggler } from './Toggler';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
@@ -2,6 +2,7 @@ import { Arr } from '@ephox/katamari';
 
 import * as ClassList from '../../impl/ClassList';
 import { SugarElement } from '../node/SugarElement';
+
 import * as Class from './Class';
 
 /*

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Css.ts
@@ -4,6 +4,7 @@ import * as Style from '../../impl/Style';
 import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
 import * as SugarNode from '../node/SugarNode';
+
 import * as Attribute from './Attribute';
 
 const internalSet = (dom: Node, property: string, value: string): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as Css from './Css';
 
 export interface CssProperty {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as Css from './Css';
 
 const onDirection = <T = any> (isLtr: T, isRtl: T) => (element: SugarElement<Element>): T =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 
 import * as Style from '../../impl/Style';
 import { SugarElement } from '../node/SugarElement';
+
 import * as Css from './Css';
 
 const isCentered = (element: SugarElement<Node>): boolean => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as Class from './Class';
 import * as Classes from './Classes';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/ElementAddress.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/ElementAddress.ts
@@ -2,6 +2,7 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import * as Compare from '../dom/Compare';
 import { SugarElement } from '../node/SugarElement';
+
 import * as PredicateFind from './PredicateFind';
 import * as SelectorFilter from './SelectorFilter';
 import * as SelectorFind from './SelectorFind';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
@@ -2,6 +2,7 @@ import { Arr, Fun } from '@ephox/katamari';
 
 import * as Compare from '../dom/Compare';
 import { SugarElement } from '../node/SugarElement';
+
 import * as PredicateExists from './PredicateExists';
 
 const ancestor = (element: SugarElement<Node>, target: SugarElement<Node>): boolean =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as PredicateFind from './PredicateFind';
 
 const any = (predicate: (e: SugarElement<Node>) => boolean): boolean =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateFilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateFilter.ts
@@ -2,6 +2,7 @@ import { Arr } from '@ephox/katamari';
 
 import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
+
 import * as Traverse from './Traverse';
 
 // maybe TraverseWith, similar to traverse but with a predicate?

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as SelectorFind from './SelectorFind';
 
 const any = (selector: string): boolean =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
@@ -1,4 +1,5 @@
 import { SugarElement } from '../node/SugarElement';
+
 import * as PredicateFilter from './PredicateFilter';
 import * as Selectors from './Selectors';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
@@ -2,6 +2,7 @@ import { Optional } from '@ephox/katamari';
 
 import ClosestOrAncestor from '../../impl/ClosestOrAncestor';
 import { SugarElement } from '../node/SugarElement';
+
 import * as PredicateFind from './PredicateFind';
 import * as Selectors from './Selectors';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/CursorPosition.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/CursorPosition.ts
@@ -3,6 +3,7 @@ import { Optional } from '@ephox/katamari';
 import { SugarElement } from '../node/SugarElement';
 import * as PredicateFind from '../search/PredicateFind';
 import * as Traverse from '../search/Traverse';
+
 import * as Awareness from './Awareness';
 
 const first = (element: SugarElement<Node>): Optional<SugarElement<Node & ChildNode>> =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
@@ -2,6 +2,7 @@ import { Fun, Optional } from '@ephox/katamari';
 
 import * as Compare from '../dom/Compare';
 import { SugarElement } from '../node/SugarElement';
+
 import * as Awareness from './Awareness';
 import * as CursorPosition from './CursorPosition';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimSelection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimSelection.ts
@@ -2,6 +2,7 @@ import { Adt } from '@ephox/katamari';
 
 import { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
+
 import { SimRange } from './SimRange';
 import { Situ } from './Situ';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
@@ -9,6 +9,7 @@ import * as Compare from '../dom/Compare';
 import * as DocumentPosition from '../dom/DocumentPosition';
 import { SugarElement } from '../node/SugarElement';
 import * as SugarFragment from '../node/SugarFragment';
+
 import { RawRect } from './Rect';
 import { SimRange } from './SimRange';
 import { SimSelection } from './SimSelection';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Scroll.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Scroll.ts
@@ -5,6 +5,7 @@ import * as Insert from '../dom/Insert';
 import * as Remove from '../dom/Remove';
 import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
+
 import * as SugarLocation from './SugarLocation';
 import { SugarPosition } from './SugarPosition';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/SugarLocation.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/SugarLocation.ts
@@ -1,5 +1,6 @@
 import { inBody } from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
+
 import { SugarPosition } from './SugarPosition';
 
 const boxPosition = (dom: Element): SugarPosition => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
@@ -4,6 +4,7 @@ import { PlatformDetection } from '@ephox/sand';
 import { fromRawEvent } from '../../impl/FilteredEvent';
 import { EventHandler, EventUnbinder } from '../events/Types';
 import { SugarElement } from '../node/SugarElement';
+
 import * as Scroll from './Scroll';
 
 export interface Bounds {

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Dimension.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Dimension.ts
@@ -2,6 +2,7 @@ import { Arr, Type } from '@ephox/katamari';
 
 import { SugarElement } from '../api/node/SugarElement';
 import * as Css from '../api/properties/Css';
+
 import * as Style from './Style';
 
 export interface Dimension {

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Style.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Style.ts
@@ -3,7 +3,7 @@ import { Type } from '@ephox/katamari';
 // some elements, such as mathml, don't have style attributes
 // others, such as angular elements, have style attributes that aren't a CSSStyleDeclaration
 const isSupported = <T extends Node>(dom: T): dom is (T & ElementCSSInlineStyle) =>
-  // eslint-disable-next-line @typescript-eslint/unbound-method
+
   (dom as any).style !== undefined && Type.isFunction((dom as any).style.getPropertyValue);
 
 export { isSupported };

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/core/SelectionDirection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/core/SelectionDirection.ts
@@ -2,6 +2,7 @@ import { Adt, Fun, Optional, Thunk } from '@ephox/katamari';
 
 import { SugarElement } from '../../api/node/SugarElement';
 import { SimSelection } from '../../api/selection/SimSelection';
+
 import * as NativeRange from './NativeRange';
 
 type SelectionDirectionHandler<U> = (start: SugarElement<Node>, soffset: number, finish: SugarElement<Node>, foffset: number) => U;

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/ContainerPoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/ContainerPoint.ts
@@ -4,6 +4,7 @@ import { SugarElement } from '../../api/node/SugarElement';
 import * as SugarNode from '../../api/node/SugarNode';
 import * as Traverse from '../../api/search/Traverse';
 import * as Geometry from '../alien/Geometry';
+
 import * as TextPoint from './TextPoint';
 
 /**

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/Within.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/Within.ts
@@ -10,8 +10,8 @@ import * as SelectionDirection from '../core/SelectionDirection';
 
 const withinContainer = <T extends Element>(win: Window, ancestor: SugarElement<Element>, outerRange: Range, selector: string): SugarElement<T>[] => {
   const innerRange = NativeRange.create(win);
-  const self = Selectors.is<T>(ancestor, selector) ? [ ancestor ] : [];
-  const elements = self.concat(SelectorFilter.descendants<T>(ancestor, selector));
+  const ancestorArray = Selectors.is<T>(ancestor, selector) ? [ ancestor ] : [];
+  const elements = ancestorArray.concat(SelectorFilter.descendants<T>(ancestor, selector));
   return Arr.filter(elements, (elem) => {
     // Mutate the selection to save creating new ranges each time
     NativeRange.selectNodeContentsUsing(innerRange, elem);

--- a/modules/tinymce/src/themes/silver/test/ts/module/GuiSetup.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/GuiSetup.ts
@@ -145,10 +145,10 @@ const bddSetup = <T = string>(
   createComponent: (store: TestStore<T>, doc: SugarElement<Document>, body: SugarElement<Node>) => AlloyComponent,
   createGui?: () => Gui.GuiSystem
 ): Hook<SugarElement<Document>, T> =>
-    bddSetupIn(() => ({
-      root: SugarDocument.getDocument(),
-      teardown: Fun.noop
-    }), createComponent, createGui);
+  bddSetupIn(() => ({
+    root: SugarDocument.getDocument(),
+    teardown: Fun.noop
+  }), createComponent, createGui);
 
 /**
  * Setup in a Shadow Root, run list of untyped Steps, then tear down.


### PR DESCRIPTION
# Update ESLint configuration and improve code organization

Related Ticket: TINY-11629

## Description of Changes:
* Updated the ESLint configuration path in `package.json` from `.eslintrc.json` to `eslint.config.ts`
* Added consistent blank lines between imports to improve code organization and readability
* Removed an unnecessary ESLint disable comment in `Style.ts`
* Renamed a variable in `Within.ts` from `self` to `ancestorArray` for better clarity

## Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

## Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)