### PR TITLE
TINY-12083: change the order of the bull list icons

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12083-2025-04-28.yaml
+++ b/.changes/unreleased/tinymce-TINY-12083-2025-04-28.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: Changed the default value of advlist_bullet_styles option to `default,disc,circle,square`.
+time: 2025-04-28T15:32:56.639902+02:00
+custom:
+  Issue: TINY-12083

--- a/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/advlist/main/ts/api/Options.ts
@@ -17,7 +17,7 @@ const register = (editor: Editor): void => {
 
   registerOption('advlist_bullet_styles', {
     processor: 'string[]',
-    default: 'default,circle,square,disc'.split(',')
+    default: 'default,disc,circle,square'.split(',')
   });
 };
 


### PR DESCRIPTION
Related Ticket: TINY-12083

Description of Changes:
* Changed the default order of bullet styles in the advlist plugin from `default,circle,square,disc` to `default,disc,circle,square`

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the default order of bullet styles for lists to improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->