### PR TITLE
TINY-11509: move mentions styles to oxide

### DIFF
--- a/modules/oxide/src/less/theme/components/mentions/mentions.less
+++ b/modules/oxide/src/less/theme/components/mentions/mentions.less
@@ -1,0 +1,49 @@
+@mentions-avatar-width: 42px;
+@mentions-avatar-height: 42px;
+@mentions-line-height: 21px;
+
+.tox-mentions__card-common {
+  z-index: 1200;
+}
+  
+.tox {
+  // Unique to mentions hover card
+  &.tox-mentions__card {
+    background: @background-color;
+    border: 1px solid @border-color;
+    display: flex;
+    padding: @pad-xs @pad-sm;
+
+    .tox-mentions__container {
+      display: flex;
+      flex-direction: column;
+      align-self: center;
+      margin: 0 @pad-xs;
+    }
+  }
+
+  // Shared between mentions hover card and autocompleter items
+  .tox-mentions__avatar {
+    width: @mentions-avatar-width;
+    height: @mentions-avatar-width;
+    border-radius: 50%;
+    margin-right: @pad-xs;
+  }
+
+  .tox-mentions__username {
+    font-size: @font-size-sm;
+    line-height: @mentions-line-height;
+  }
+
+  .tox-mentions__description {
+    font-size: @font-size-xs;
+    line-height: @mentions-line-height;
+    color: @text-color-muted;
+  }
+
+  .tox-collection__item--active {
+    .tox-mentions__description {
+      color: inherit;
+    }
+  }
+}

--- a/modules/oxide/src/less/theme/components/mentions/mentions.less
+++ b/modules/oxide/src/less/theme/components/mentions/mentions.less
@@ -25,7 +25,7 @@
   // Shared between mentions hover card and autocompleter items
   .tox-mentions__avatar {
     width: @mentions-avatar-width;
-    height: @mentions-avatar-width;
+    height: @mentions-avatar-height;
     border-radius: 50%;
     margin-right: @pad-xs;
   }

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -49,6 +49,7 @@
 @import 'components/image-tools/image-tools';
 @import 'components/image-selector/image-selector';
 @import 'components/insert-table-picker/insert-table-picker';
+@import 'components/mentions/mentions';
 @import 'components/menu/menu';
 @import 'components/menubar/menubar';
 @import 'components/menubar/promotion';


### PR DESCRIPTION
Related Ticket: TINY-11509

Description of Changes:
* Moved less file from mentions plugin to Oxide
* Replaced fixed values with variables
* Defined variables for avatar dimensions and line height
* Added import for mentions component in theme.less

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced new styles for mentions components, enhancing the appearance of avatars, usernames, and descriptions in mention-related UI elements.
- **Style**
  - Integrated mentions component styling into the overall theme for a consistent look and feel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->