### PR TITLE
TINY-11884: Prevent tooltip from going outside of browser view.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11884-2025-03-10.yaml
+++ b/.changes/unreleased/tinymce-TINY-11884-2025-03-10.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Long tooltips could overflow narrow browser windows.
+time: 2025-03-10T08:31:21.579191+01:00
+custom:
+    Issue: TINY-11884

--- a/modules/oxide/src/less/theme/components/tooltip/tooltip.less
+++ b/modules/oxide/src/less/theme/components/tooltip/tooltip.less
@@ -13,13 +13,13 @@
 @tooltip-padding-y: @pad-xs;
 @tooltip-text-color: @color-white;
 @tooltip-text-transform: none;
-@tooltip-max-width: 15em;
+@tooltip-max-width: min(80%, 15em);
 
 .tox {
   .tox-tooltip {
     display: inline-block;
     max-width: @tooltip-max-width;
-    padding: @tooltip-arrow-size;
+    padding: @tooltip-arrow-size 0 0 0;
 
     /*
      * The pointer-events: none is designed to make mouse events bleed through the tooltip


### PR DESCRIPTION
Related Ticket: TINY-11884

Description of Changes:
After discussion we will go forward with this ticket. It does not solve the original problem, but it should prevent the reported fiddle from using this error next time which would be beneficial

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where long tooltips could overflow in narrow browser windows by adjusting tooltip width and padding for better display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->