### PR TITLE
TINY-12017: scroll into viewport after receiving focus

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12017-2025-04-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-12017-2025-04-25.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Editor did not scroll into viewport on receiving focus on Chrome and Safari.
+time: 2025-04-25T13:53:34.434967+02:00
+custom:
+  Issue: TINY-12017

--- a/modules/tinymce/src/core/main/ts/focus/FocusController.ts
+++ b/modules/tinymce/src/core/main/ts/focus/FocusController.ts
@@ -1,5 +1,6 @@
 import { Fun } from '@ephox/katamari';
-import { Class, Focus, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { PlatformDetection } from '@ephox/sand';
+import { Class, Focus, SugarElement, SugarShadowDom, WindowVisualViewport } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -8,6 +9,7 @@ import FocusManager from '../api/FocusManager';
 import * as Options from '../api/Options';
 import Delay from '../api/util/Delay';
 import * as NodeType from '../dom/NodeType';
+import * as OuterPosition from '../frames/OuterPosition';
 import * as SelectionRestore from '../selection/SelectionRestore';
 
 let documentFocusInHandler: ((e: FocusEvent) => void) | null;
@@ -67,6 +69,19 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
     }
   };
 
+  const bringEditorIntoView = (editor: Editor) => {
+    const minimumVisibility = 25;
+    if (!editor.iframeElement) {
+      return;
+    }
+    const element = SugarElement.fromDom(editor.iframeElement);
+    const op = OuterPosition.find(element);
+    const viewportBounds = WindowVisualViewport.getBounds(window);
+    if (op.top < viewportBounds.y || op.top > (viewportBounds.bottom - minimumVisibility)) {
+      element.dom.scrollIntoView({ block: 'center' });
+    }
+  };
+
   editor.on('focusin', () => {
     const focusedEditor = editorManager.focusedEditor;
 
@@ -83,6 +98,10 @@ const registerEvents = (editorManager: EditorManager, e: { editor: Editor }) => 
       editorManager.focusedEditor = editor;
       editor.dispatch('focus', { blurredEditor: focusedEditor });
       editor.focus(true);
+      const browser = PlatformDetection.detect().browser;
+      if (editor.inline !== true && (browser.isSafari() || browser.isChromium())) {
+        bringEditorIntoView(editor);
+      }
     }
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/FocusControllerTest.ts
@@ -1,5 +1,6 @@
-import { context, describe, it } from '@ephox/bedrock-client';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
+import { Attribute, Scroll, SugarDocument, SugarElement, SugarLocation, WindowVisualViewport } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -73,11 +74,49 @@ describe('browser.tinymce.core.focus.FocusControllerTest', () => {
 
       it('isUIElement on editor sibling is false', () => {
         const editor = hook.editor();
-        const inputElm = DOMUtils.DOM.create('input', { }, null);
+        const inputElm = DOMUtils.DOM.create('input', {}, null);
         editor.getContainer().parentNode?.appendChild(inputElm);
         assert.isFalse(FocusController.isUIElement(editor, inputElm), 'Should be false as not sitting inside editor');
         DOMUtils.DOM.remove(inputElm);
       });
+    });
+  });
+
+  context('Editor should be inside the viewport once focused', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce'
+    }, [], false);
+
+    const assertEditorBodyInsideViewport = (editor: Editor) => {
+      const iframe = editor.iframeElement!;
+      const iframeBounds = SugarLocation.viewport(SugarElement.fromDom(iframe));
+      const scroll = Scroll.get(SugarDocument.getDocument());
+      const iframeTop = iframeBounds.top + scroll.top;
+      const viewportBounds = WindowVisualViewport.getBounds(window);
+
+      assert.isAbove(iframeTop, viewportBounds.y, 'Editor\'s iframe should be inside the viewport');
+      assert.isBelow(iframeTop, viewportBounds.bottom, 'Editor\'s iframe should be inside the viewport');
+    };
+
+    before(() => {
+      const editor = hook.editor();
+      const container = editor.getContainer();
+      const expanderDiv = SugarElement.fromTag('div');
+      Attribute.set(expanderDiv, 'style', 'height: 3000px; width: 100px');
+      Attribute.set(expanderDiv, 'class', 'remove-on-cleanup');
+
+      container.parentNode?.insertBefore(expanderDiv.dom, container);
+    });
+
+    after(() => {
+      const elements = document.querySelectorAll('.remove-on-cleanup');
+      elements.forEach((element) => element.parentNode?.removeChild(element));
+    });
+
+    it('TINY-12017: Editor is inside the viewport once focused', async () => {
+      const editor = hook.editor();
+      editor.getBody().focus();
+      assertEditorBodyInsideViewport(editor);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-12017

Description of Changes:
* Editor did not scroll into viewport on receiving focus on Chrome and Safari.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the editor did not scroll into view upon receiving focus in Chrome and Safari, ensuring improved usability on these browsers.
- **Tests**
	- Added a new test to verify that the editor is visible within the viewport when focused, enhancing reliability across different browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->