### PR TITLE
TINY-12065: correct typo in utility functions description.

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/util/Tools.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/Tools.ts
@@ -37,7 +37,7 @@ interface Tools {
 }
 
 /**
- * This class contains various utlity functions. These are also exposed
+ * This class contains various utility functions. These are also exposed
  * directly on the tinymce namespace.
  *
  * @class tinymce.util.Tools


### PR DESCRIPTION
Related Ticket: TINY-12065

Description of Changes:
* Fix typo in `modules/tinymce/src/core/main/ts/api/util/Tools.ts` from `utlity` to `utility`.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in a class-level comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->