### PR TITLE
Fix: Font size conversion from px to pt fails for certain values (#10140)

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -59,7 +59,7 @@ const round = (number: number, precision: number) => {
 const toPt = (fontSize: string, precision?: number): string => {
   if (/[0-9.]+px$/.test(fontSize)) {
     // Round to the nearest 0.5
-    return round(parseInt(fontSize, 10) * 72 / 96, precision || 0) + 'pt';
+    return round(parseFloat(fontSize) * 72 / 96, precision || 0) + 'pt';
   } else {
     return Obj.get(keywordFontSizes, fontSize).getOr(fontSize);
   }


### PR DESCRIPTION
…140)

GitHub issues: #8618

Description of Changes:
Font size conversion from px to pt fails for certain values. 10.6667px should be converted to 8pt, but is instead converted to 7.5pt, and causes #8618 problem. I changed parseInt to parseFloat to fix this bug.
