### PR TITLE
TINY-11912: fix `'contextform'` `onSetup` API

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11912-2025-05-02.yaml
+++ b/.changes/unreleased/tinymce-TINY-11912-2025-05-02.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed an issue where the context form API `onSetup` was referencing the incorrect element.
+time: 2025-05-02T11:53:34.496928541+02:00
+custom:
+    Issue: TINY-11912

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -7,7 +7,7 @@ import {
 } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Singleton } from '@ephox/katamari';
-import { Focus, SugarElement } from '@ephox/sugar';
+import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
 import { backSlideEvent } from './ContextUi';
 
@@ -38,4 +38,10 @@ export const getFormApi = <T>(input: AlloyComponent, valueState: Singleton.Value
       }
     }
   });
+};
+
+export const getFormParentApi = <T>(comp: AlloyComponent, valueState: Singleton.Value<T>, focusfallbackElement?: SugarElement<HTMLElement>): InlineContent.ContextFormInstanceApi<T> => {
+  const parent = Traverse.parent(comp.element);
+  const parentCompOpt = parent.bind((parent) => comp.getSystem().getByDom(parent).toOptional());
+  return getFormApi<T>(parentCompOpt.getOr(comp), valueState, focusfallbackElement);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -16,7 +16,7 @@ export const renderContextFormSliderInput = (
   valueState: Singleton.Value<number>
 ): SketchSpec => {
   const editorOffCell = Cell(Fun.noop);
-  const getApi = (comp: AlloyComponent) => ContextFormApi.getFormApi<number>(comp, valueState);
+  const getApi = (comp: AlloyComponent) => ContextFormApi.getFormParentApi(comp, valueState);
 
   const pLabel = ctx.label.map((label) => FormField.parts.label({
     dom: { tag: 'label', classes: [ 'tox-label' ] },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -20,10 +20,8 @@ export const renderContextFormTextInput = (
   const getFormParentApi = (comp: AlloyComponent, focusfallbackElement?: SugarElement<HTMLElement>) => {
     const parent = Traverse.parent(comp.element);
     const parentCompOpt = parent.bind((parent) => comp.getSystem().getByDom(parent).toOptional());
-    return parentCompOpt.map((parentComp) => ContextFormApi.getFormApi<string>(parentComp, valueState, focusfallbackElement)).getOrThunk(() => {
-      // Fallback to the current component if no parent is found
-      return ContextFormApi.getFormApi<string>(comp, valueState, focusfallbackElement);
-    });
+    return parentCompOpt.map((parentComp) => ContextFormApi.getFormApi<string>(parentComp, valueState, focusfallbackElement))
+      .getOr(ContextFormApi.getFormApi<string>(comp, valueState, focusfallbackElement));
   };
 
   const pLabel = ctx.label.map((label) => FormField.parts.label({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -20,8 +20,7 @@ export const renderContextFormTextInput = (
   const getFormParentApi = (comp: AlloyComponent, focusfallbackElement?: SugarElement<HTMLElement>) => {
     const parent = Traverse.parent(comp.element);
     const parentCompOpt = parent.bind((parent) => comp.getSystem().getByDom(parent).toOptional());
-    return parentCompOpt.map((parentComp) => ContextFormApi.getFormApi<string>(parentComp, valueState, focusfallbackElement))
-      .getOrThunk(() => ContextFormApi.getFormApi<string>(comp, valueState, focusfallbackElement));
+    return ContextFormApi.getFormApi<string>(parentCompOpt.getOr(comp), valueState, focusfallbackElement);
   };
 
   const pLabel = ctx.label.map((label) => FormField.parts.label({

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,7 +1,7 @@
 import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
 import { InlineContent } from '@ephox/bridge';
 import { Cell, Fun, Optional, Singleton } from '@ephox/katamari';
-import { SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
+import { SelectorFind } from '@ephox/sugar';
 
 import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
@@ -17,11 +17,7 @@ export const renderContextFormTextInput = (
   valueState: Singleton.Value<string>
 ): SketchSpec => {
   const editorOffCell = Cell(Fun.noop);
-  const getFormParentApi = (comp: AlloyComponent, focusfallbackElement?: SugarElement<HTMLElement>) => {
-    const parent = Traverse.parent(comp.element);
-    const parentCompOpt = parent.bind((parent) => comp.getSystem().getByDom(parent).toOptional());
-    return ContextFormApi.getFormApi<string>(parentCompOpt.getOr(comp), valueState, focusfallbackElement);
-  };
+  const getFormApi = (comp: AlloyComponent) => ContextFormApi.getFormParentApi<string>(comp, valueState);
 
   const pLabel = ctx.label.map((label) => FormField.parts.label({
     dom: { tag: 'label', classes: [ 'tox-label' ] },
@@ -69,15 +65,15 @@ export const renderContextFormTextInput = (
             );
 
             return closestFocussableOpt.fold(
-              () => getFormParentApi(comp),
-              (closestFocussable) => getFormParentApi(comp, closestFocussable)
+              () => ContextFormApi.getFormParentApi(comp, valueState),
+              (closestFocussable) => ContextFormApi.getFormParentApi(comp, valueState, closestFocussable)
             );
           },
           onBeforeSetup: Keying.focusIn
         }, editorOffCell),
-        onContextFormControlDetached({ getApi: getFormParentApi }, editorOffCell, valueState),
+        onContextFormControlDetached({ getApi: getFormApi }, editorOffCell, valueState),
         AlloyEvents.run(NativeEvents.input(), (comp) => {
-          ctx.onInput(getFormParentApi(comp));
+          ctx.onInput(getFormApi(comp));
         })
       ])
     ])

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -21,7 +21,7 @@ export const renderContextFormTextInput = (
     const parent = Traverse.parent(comp.element);
     const parentCompOpt = parent.bind((parent) => comp.getSystem().getByDom(parent).toOptional());
     return parentCompOpt.map((parentComp) => ContextFormApi.getFormApi<string>(parentComp, valueState, focusfallbackElement))
-      .getOr(ContextFormApi.getFormApi<string>(comp, valueState, focusfallbackElement));
+      .getOrThunk(() => ContextFormApi.getFormApi<string>(comp, valueState, focusfallbackElement));
   };
 
   const pLabel = ctx.label.map((label) => FormField.parts.label({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
@@ -1,0 +1,118 @@
+import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => {
+  const store = TestStore();
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addContextToolbar('test-toolbar', {
+        items: 'test-form',
+        position: 'node',
+        scope: 'node',
+        predicate: (node) => node.nodeName.toLowerCase() === 'div',
+      });
+
+      ed.ui.registry.addContextForm('test-form', {
+        type: 'contextform',
+        launch: {
+          type: 'contextformbutton',
+          text: 'Alt',
+          tooltip: 'Alt'
+        },
+        onSetup: (api) => {
+          api.setInputEnabled(false);
+          store.add(`input-enable-${api.isInputEnabled()}`);
+          return Fun.noop;
+        },
+        onInput: (_api) => Fun.noop,
+        label: 'Alt',
+        commands: [
+          {
+            type: 'contextformbutton',
+            align: 'start',
+            icon: 'chevron-left',
+            onAction: (formApi) => {
+              formApi.back();
+            }
+          },
+          {
+            type: 'contextformtogglebutton',
+            align: 'start',
+            text: 'Decorative',
+            tooltip: 'Decorative',
+            onAction: (formApi, buttonApi) => {
+              buttonApi.setActive(!buttonApi.isActive());
+              formApi.setInputEnabled(!formApi.isInputEnabled());
+            }
+          },
+          {
+            type: 'contextformbutton',
+            align: 'end',
+            icon: 'info',
+            tooltip: 'Check',
+            onAction: (formApi) => {
+              store.add(`input-enable-${formApi.isInputEnabled()}`);
+            }
+          },
+        ]
+      });
+    }
+  }, [], true);
+  const buttonDecorativeSelector = '.tox-pop button[aria-label="Decorative"]';
+  const buttonCheckSelector = '.tox-pop button[aria-label="Check"]';
+
+  afterEach(async () => {
+    const editor = hook.editor();
+
+    store.clear();
+    editor.focus();
+
+    // Simulate clicking elsewhere in the editor
+    clickAway(editor);
+    await pAssertNoPopDialog();
+  });
+
+  const openToolbar = (editor: Editor, toolbarKey: string) => {
+    editor.dispatch('contexttoolbar-show', {
+      toolbarKey
+    });
+  };
+
+  const clickAway = (editor: Editor) => {
+    // <a> tags make the context bar appear so click away from an a tag. We have no content so it's probably fine.
+    TinySelections.setCursor(editor, [ ], 0);
+    Mouse.trueClick(TinyDom.body(editor));
+  };
+
+  const pAssertNoPopDialog = () => Waiter.pTryUntil(
+    'Pop dialog should disappear (soon)',
+    () => UiFinder.notExists(SugarBody.body(), '.tox-pop')
+  );
+
+  it('TINY-11912: disabling the input `onSetup` should results in a disabled input also in the commands', () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    store.assertEq('Input should be disabled by setup', [ 'input-enable-false' ]);
+    TinyUiActions.clickOnUi(editor, buttonCheckSelector);
+    store.assertEq('Input should be disabled by setup', [ 'input-enable-false', 'input-enable-false' ]);
+  });
+
+  it('TINY-11912: disabling the input via commans should results in a disabled input also in other the commands', () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form');
+    store.assertEq('Input should be disabled by setup', [ 'input-enable-false' ]);
+    TinyUiActions.clickOnUi(editor, buttonDecorativeSelector);
+    TinyUiActions.clickOnUi(editor, buttonCheckSelector);
+    store.assertEq('Input should be disabled by setup', [ 'input-enable-false', 'input-enable-true' ]);
+    TinyUiActions.clickOnUi(editor, buttonDecorativeSelector);
+    TinyUiActions.clickOnUi(editor, buttonCheckSelector);
+    store.assertEq('Input should be disabled by setup', [ 'input-enable-false', 'input-enable-true', 'input-enable-false' ]);
+  });
+});
+

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
@@ -1,8 +1,8 @@
-import { TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -73,6 +73,8 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => 
     store.clear();
     editor.focus();
 
+    // Simulate clicking elsewhere in the editor
+    clickAway(editor);
     await pAssertNoPopDialog();
   });
 
@@ -80,6 +82,11 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => 
     editor.dispatch('contexttoolbar-show', {
       toolbarKey
     });
+  };
+
+  const clickAway = (editor: Editor) => {
+    TinySelections.setCursor(editor, [ ], 0);
+    Mouse.trueClick(TinyDom.body(editor));
   };
 
   const pAssertNoPopDialog = () => Waiter.pTryUntil(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
@@ -1,8 +1,8 @@
-import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
-import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -73,8 +73,6 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => 
     store.clear();
     editor.focus();
 
-    // Simulate clicking elsewhere in the editor
-    clickAway(editor);
     await pAssertNoPopDialog();
   });
 
@@ -82,12 +80,6 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => 
     editor.dispatch('contexttoolbar-show', {
       toolbarKey
     });
-  };
-
-  const clickAway = (editor: Editor) => {
-    // <a> tags make the context bar appear so click away from an a tag. We have no content so it's probably fine.
-    TinySelections.setCursor(editor, [ ], 0);
-    Mouse.trueClick(TinyDom.body(editor));
   };
 
   const pAssertNoPopDialog = () => Waiter.pTryUntil(

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
@@ -102,7 +102,7 @@ describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => 
     store.assertEq('Input should be disabled by setup', [ 'input-enable-false', 'input-enable-false' ]);
   });
 
-  it('TINY-11912: disabling the input via commans should results in a disabled input also in other the commands', () => {
+  it('TINY-11912: disabling the input via commands should results in a disabled input also in other commands', () => {
     const editor = hook.editor();
     openToolbar(editor, 'test-form');
     store.assertEq('Input should be disabled by setup', [ 'input-enable-false' ]);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -79,6 +79,41 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
           }
         ]
       });
+
+      ed.ui.registry.addContextToolbar('test-toolbar-disabled', {
+        items: 'test-form-disabled undo',
+        position: 'node',
+        scope: 'node',
+        predicate: (node) => node.nodeName.toLowerCase() === 'div',
+      });
+
+      ed.ui.registry.addContextForm('test-form-disabled', {
+        type: 'contextsizeinputform',
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'ABC'
+        },
+        initValue: Fun.constant({ width: '100', height: '200' }),
+        onSetup: (api) => {
+          api.setInputEnabled(false);
+          store.add('setup');
+          return Fun.noop;
+        },
+        commands: [
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'A',
+            align: 'start',
+            onAction: (formApi) => {
+              store.add(`${formApi.isInputEnabled()}`);
+              formApi.setInputEnabled(true);
+              store.add(`${formApi.isInputEnabled()}`);
+            }
+          }
+        ]
+      });
     }
   }, [], true);
   const inputWidthSelector = '.tox-pop .tox-toolbar__group:nth-of-type(2) .tox-focusable-wrapper:nth-of-type(1) input';
@@ -257,6 +292,13 @@ describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => 
     TinyUiActions.keystroke(editor, Keys.tab());
 
     await FocusTools.pTryOnSelector('Focus should be on the B button', SugarDocument.getDocument(), buttonBSelector);
+  });
+
+  it('TINY-11912: disabling the input `onSetup` should results in a disabled input also in the commands', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form-disabled');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="A"]');
+    store.assertEq('Input should trigger onInput with the right value and type', [ 'setup', 'false', 'true' ]);
   });
 });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -48,6 +48,37 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
           }
         ]
       });
+
+      ed.ui.registry.addContextForm('test-form-disabled', {
+        type: 'contextsliderform',
+        launch: {
+          type: 'contextformtogglebutton',
+          icon: 'fake-icon-name',
+          tooltip: 'ABC'
+        },
+        predicate: (node) => node.nodeName.toLowerCase() === 'a',
+        min: Fun.constant(-100),
+        max: Fun.constant(100),
+        initValue: Fun.constant(37),
+        onSetup: (api) => {
+          api.setInputEnabled(false);
+          store.add('setup');
+          return Fun.noop;
+        },
+        commands: [
+          {
+            type: 'contextformbutton',
+            icon: 'fake-icon-name',
+            tooltip: 'A',
+            align: 'start',
+            onAction: (formApi) => {
+              store.add(`${formApi.isInputEnabled()}`);
+              formApi.setInputEnabled(true);
+              store.add(`${formApi.isInputEnabled()}`);
+            }
+          }
+        ]
+      });
     }
   }, [], true);
 
@@ -187,6 +218,13 @@ describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
     TinyUiActions.keystroke(editor, Keys.tab(), { shiftKey: true });
 
     await FocusTools.pTryOnSelector('Focus should be back on A button', SugarDocument.getDocument(), buttonASelector);
+  });
+
+  it('TINY-11912: disabling the input `onSetup` should results in a disabled input also in the commands', async () => {
+    const editor = hook.editor();
+    openToolbar(editor, 'test-form-disabled');
+    TinyUiActions.clickOnUi(editor, '.tox-pop button[aria-label="A"]');
+    store.assertEq('Input should trigger onInput with the right value and type', [ 'setup', 'false', 'true' ]);
   });
 });
 


### PR DESCRIPTION
Related Ticket: TINY-11912

Description of Changes:
while `onAction(api)` refers to the whole `tox-context-form__group` that contains the input `onSetup(api)` just refers to the input itself, this mean that if we use `api.setInputEnabled(false);` and then we have a button that checks `formApi.isInputEnabled()` it will return `true` instead of `false` because the first will disable the entire `tox-context-form__group` but the second will check just the input.

I chose to have the parent in the `onSetup` instead of taking the `input` on `onAction` because the buttons `onAction` is a shared component that is used from many forms (file: `modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts`), and since different forms could have more than 1 input having just it could be limiting.

P.S. I used AI to improve the changelog entry, if it's not correct anyway next time I'll try to generate it directly with AI :sweat_smile: 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the context form setup targeted the wrong element, ensuring more accurate handling during form initialization.  
- **Tests**
	- Added automated tests verifying enable/disable behavior and command synchronization for context form text inputs and sliders in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->