### PR TITLE
TINY-12013: Change the default pagebreak to work with PDF export (breaking change)

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12013-2025-05-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-12013-2025-05-04.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: Default value for `pagebreak_separator` option to work with document converters.
+time: 2025-05-04T23:51:29.511658+01:00
+custom:
+    Issue: TINY-12013

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/api/Options.ts
@@ -12,7 +12,7 @@ const register = (editor: Editor): void => {
 
   registerOption('pagebreak_separator', {
     processor: 'string',
-    default: '<!-- pagebreak -->'
+    default: '<div style="break-after: all"></div>'
   });
 
   registerOption('pagebreak_split_block', {

--- a/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
+++ b/modules/tinymce/src/plugins/pagebreak/test/ts/browser/PageBreakSplitBlockTest.ts
@@ -89,7 +89,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
 
       const content = editor.getContent({ source_view: true });
       // NOTE: p that wraps pagebreak is stripped
-      assert.equal(content, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`);
+      assert.equal(content, `<p>some</p>\n<div style="break-after: all"></div>\n<p>text</p>`);
     });
 
     it('TINY-3388: source_view with `pagebreak_split_block=false`', () => {
@@ -101,7 +101,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
       clickPageBreak(editor);
 
       const content = editor.getContent({ source_view: true });
-      assert.equal(content, `<p>some<!-- pagebreak -->text</p>`);
+      assert.equal(content, `<p>some<div style="break-after: all"></div>text</p>`);
     });
 
     it('TINY-3388: getContent with `pagebreak_split_block=true`', () => {
@@ -112,7 +112,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
       clickPageBreak(editor);
 
-      TinyAssertions.assertContent(editor, `<p>some</p>\n<!-- pagebreak -->\n<p>text</p>`);
+      TinyAssertions.assertContent(editor, `<p>some</p>\n<div style="break-after: all"></div>\n<p>text</p>`);
     });
 
     it('TINY-3388: getContent with `pagebreak_split_block=false`', () => {
@@ -123,7 +123,7 @@ describe('browser.tinymce.plugins.pagebreak.PageBreakSplitBlockTest', () => {
       TinySelections.setCursor(editor, [ 0, 0 ], 4);
       clickPageBreak(editor);
 
-      TinyAssertions.assertContent(editor, '<p>some<!-- pagebreak -->text</p>');
+      TinyAssertions.assertContent(editor, '<p>some<div style="break-after: all"></div>text</p>');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
