### PR TITLE
TINY-12112: fix issues with dark mode in mentions

### DIFF
--- a/modules/oxide/src/less/theme/components/mentions/mentions.less
+++ b/modules/oxide/src/less/theme/components/mentions/mentions.less
@@ -33,6 +33,7 @@
   .tox-mentions__username {
     font-size: @font-size-sm;
     line-height: @mentions-line-height;
+    color: @text-color;
   }
 
   .tox-mentions__description {
@@ -42,6 +43,7 @@
   }
 
   .tox-collection__item--active {
+    .tox-mentions__username,
     .tox-mentions__description {
       color: inherit;
     }


### PR DESCRIPTION
Related Ticket: TINY-12112

Description of Changes:
* Fixed issue with user name not visible on the mention card in dark mode

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated mention username colors to use the standard text color and inherit color when active for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->