### PR TITLE
TINY-12018: Keyboard navigation no longer add new rows if they would not be editable.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12018-2025-04-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-12018-2025-04-22.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Tabbing forward in some tables with a non-editable final row would cause a freeze and error.
+body: Tab to create a new row in tables with a non-editable final row would freeze the editor.
 time: 2025-04-22T18:44:33.789955+02:00
 custom:
     Issue: TINY-12018

--- a/.changes/unreleased/tinymce-TINY-12018-2025-04-22.yaml
+++ b/.changes/unreleased/tinymce-TINY-12018-2025-04-22.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tabbing forward in some tables with a non-editable final row would cause a freeze and error.
+time: 2025-04-22T18:44:33.789955+02:00
+custom:
+    Issue: TINY-12018

--- a/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
+++ b/modules/tinymce/src/core/main/ts/keyboard/TableNavigation.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { CellLocation, CellNavigation, TableLookup } from '@ephox/snooker';
-import { Compare, ContentEditable, CursorPosition, Insert, PredicateExists, PredicateFind, SimSelection, SugarElement, SugarNode, WindowSelection } from '@ephox/sugar';
+import { Compare, ContentEditable, CursorPosition, Insert, PredicateExists, PredicateFind, SimSelection, SugarElement, SugarNode, Traverse, WindowSelection } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import * as CaretFinder from '../caret/CaretFinder';
@@ -127,13 +127,17 @@ const getCellFirstCursorPosition = (cell: SugarElement<Node>): Range => {
   return WindowSelection.toNative(selection);
 };
 
+const rowHasEditableCell = (cell: SugarElement<HTMLTableCellElement | HTMLTableCaptionElement>) => {
+  return isCellEditable(cell) || Traverse.siblings(cell).some((element) => SugarNode.isHTMLElement(element) && isCellEditable(element));
+};
+
 const tabGo = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell: CellLocation): Optional<Range> => {
   return cell.fold<Optional<Range>>(Optional.none, Optional.none, (_current, next) => {
     return CursorPosition.first(next).map((cell) => {
       return getCellFirstCursorPosition(cell);
     });
   }, (current) => {
-    if (editor.mode.isReadOnly() || !isCellInEditableTable(current)) {
+    if (editor.mode.isReadOnly() || !isCellInEditableTable(current) || !rowHasEditableCell(current)) {
       return Optional.none();
     }
 
@@ -152,7 +156,7 @@ const tabForward = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, 
 const tabBackward = (editor: Editor, isRoot: (e: SugarElement<Node>) => boolean, cell: SugarElement<HTMLTableCellElement>) =>
   tabGo(editor, isRoot, CellNavigation.prev(cell, isCellEditable));
 
-const isCellEditable = (cell: SugarElement<HTMLTableCellElement>) =>
+const isCellEditable = (cell: SugarElement<HTMLElement>) =>
   ContentEditable.isEditable(cell) || PredicateExists.descendant(cell, isEditableHTMLElement);
 
 const isEditableHTMLElement = (node: SugarElement<Node>) =>
@@ -188,8 +192,8 @@ const handleTab = (editor: Editor, forward: boolean): boolean => {
 };
 
 export {
+  handleTab,
   isFakeCaretTableBrowser,
   moveH,
-  moveV,
-  handleTab
+  moveV
 };

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardCellNavigationTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/KeyboardCellNavigationTest.ts
@@ -69,6 +69,34 @@ describe('browser.tinymce.core.table.KeyboardCellNavigationTest', () => {
     TinyAssertions.assertCursor(editor, [ 0, 0, 2, 1 ], 0);
   });
 
+  it('TINY-12018: Tabbing forwards should not create a new row if it would not be editable', () => {
+    const editor = hook.editor();
+    const table = '<table>\n<tbody>\n<tr>\n<td>A</td>\n<td>B</td>\n</tr>\n<tr>\n<td contenteditable="false">C</td>\n<td contenteditable="false">D</td>\n</tr>\n</tbody>\n</table>';
+    editor.setContent(table );
+    TinySelections.setCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
+
+    TinyContentActions.keydown(editor, Keys.tab());
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
+    TinyContentActions.keydown(editor, Keys.tab());
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
+    TinyAssertions.assertContent(editor, table);
+  });
+
+  it('TINY-12018: Tabbing forwards should create a row if the last row is editable ( Last Cell )', () => {
+    const editor = hook.editor();
+    const tableStart = '<table>\n<tbody>\n<tr>\n<td>A</td>\n<td>B</td>\n</tr>\n<tr>\n<td contenteditable="false">C</td>\n<td>D</td>\n</tr>\n</tbody>\n</table>';
+    const tableEnd = '<table>\n<tbody>\n<tr>\n<td>A</td>\n<td>B</td>\n</tr>\n<tr>\n<td contenteditable="false">C</td>\n<td>D</td>\n</tr>\n<tr>\n<td>&nbsp;</td>\n<td>&nbsp;</td>\n</tr>\n</tbody>\n</table>';
+    editor.setContent(tableStart );
+    TinySelections.setCursor(editor, [ 0, 0, 0, 1, 0 ], 0);
+
+    TinyContentActions.keydown(editor, Keys.tab());
+    TinyAssertions.assertCursor(editor, [ 0, 0, 1, 1, 0 ], 0);
+    TinyContentActions.keydown(editor, Keys.tab());
+    TinyAssertions.assertCursor(editor, [ 0, 0, 2, 0 ], 0);
+    TinyAssertions.assertContent(editor, tableEnd);
+
+  });
+
   it('TINY-7705: Tabbing backwards should ignore cef cells', () => {
     const editor = hook.editor();
     editor.setContent(


### PR DESCRIPTION
Related Ticket: TINY-12018

Description of Changes:
Check if the last row is editable. If it is not adding another row would also not be editable, repeating the action forever.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where tabbing forward in tables with a non-editable final row could cause the editor to freeze or throw an error. Tab navigation in such tables now works smoothly.

- **Tests**
  - Added new tests to verify correct tabbing behavior in tables with editable and non-editable cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->