### PR TITLE
TINY-11997: fix caret position on Firefox

### DIFF
--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -165,12 +165,14 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
     editor.on('focusin', (e) => {
       if (fakeCaret.isShowing() && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
-        if (isGecko) {
-          editor.selection.select(e.target);
-        }
 
         fakeCaret.hide();
 
+        if (isGecko && editor.selection.getRng().commonAncestorContainer === editor.getBody()) {
+          const rng = editor.dom.createRng();
+          rng.selectNode(e.target);
+          editor.selection.setRng(rng);
+        }
         const rng = setElementSelection(editor.selection.getRng(), true);
         if (rng) {
           editor.selection.setRng(rng);

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -2,7 +2,6 @@ import { Arr, Obj, Type, Unicode } from '@ephox/katamari';
 import { Attribute, Compare, Css, Focus, Insert, InsertAll, Remove, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from './api/Editor';
-import Env from './api/Env';
 import VK from './api/util/VK';
 import * as CaretContainer from './caret/CaretContainer';
 import * as CaretUtils from './caret/CaretUtils';
@@ -31,8 +30,6 @@ const getContentEditableRoot = (editor: Editor, node: Node) => CefUtils.getConte
 
 const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   const selection = editor.selection, dom = editor.dom;
-  const browser = Env.browser;
-  const isGecko = browser.isFirefox();
 
   const rootNode = editor.getBody();
   const fakeCaret = FakeCaret(editor, rootNode, dom.isBlock, () => EditorFocus.hasFocus(editor));
@@ -168,7 +165,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
         fakeCaret.hide();
 
-        if (isGecko && editor.selection.getNode() === editor.getBody()) {
+        if (editor.selection.getNode() === editor.getBody()) {
           const rng = editor.dom.createRng();
           rng.selectNode(e.target);
           editor.selection.setRng(rng);

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -165,11 +165,11 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
         fakeCaret.hide();
 
-        if (editor.selection.getNode() === editor.getBody()) {
-          const rng = editor.dom.createRng();
-          rng.selectNode(e.target);
-          editor.selection.setRng(rng);
+        if (!e.target.contains(editor.selection.getNode())) {
+          editor.selection.select(e.target, true);
+          editor.selection.collapse(true);
         }
+
         const rng = setElementSelection(editor.selection.getRng(), true);
         if (rng) {
           editor.selection.setRng(rng);

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -2,6 +2,7 @@ import { Arr, Obj, Type, Unicode } from '@ephox/katamari';
 import { Attribute, Compare, Css, Focus, Insert, InsertAll, Remove, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
 import Editor from './api/Editor';
+import Env from './api/Env';
 import VK from './api/util/VK';
 import * as CaretContainer from './caret/CaretContainer';
 import * as CaretUtils from './caret/CaretUtils';
@@ -30,6 +31,8 @@ const getContentEditableRoot = (editor: Editor, node: Node) => CefUtils.getConte
 
 const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   const selection = editor.selection, dom = editor.dom;
+  const browser = Env.browser;
+  const isGecko = browser.isFirefox();
 
   const rootNode = editor.getBody();
   const fakeCaret = FakeCaret(editor, rootNode, dom.isBlock, () => EditorFocus.hasFocus(editor));
@@ -162,6 +165,10 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
     editor.on('focusin', (e) => {
       if (fakeCaret.isShowing() && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
+        if (isGecko) {
+          editor.selection.select(e.target);
+        }
+
         fakeCaret.hide();
 
         const rng = setElementSelection(editor.selection.getRng(), true);

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -168,7 +168,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
         fakeCaret.hide();
 
-        if (isGecko && editor.selection.getRng().commonAncestorContainer === editor.getBody()) {
+        if (isGecko && editor.selection.getNode() === editor.getBody()) {
           const rng = editor.dom.createRng();
           rng.selectNode(e.target);
           editor.selection.setRng(rng);

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretImageCaptionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretImageCaptionTest.ts
@@ -6,6 +6,7 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
 
+// this
 describe('browser.tinymce.core.FakeCaretImageCaptionTest', () => {
   const browser = PlatformDetection.detect().browser;
   const isFirefox = browser.isFirefox();
@@ -37,6 +38,7 @@ describe('browser.tinymce.core.FakeCaretImageCaptionTest', () => {
     await Waiter.pTryUntil('Wait for fake caret to be removed', () => {
       TinyAssertions.assertContentPresence(editor, { '.mce-visual-caret': 0 });
     });
+    TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
   });
 
   it('TINY-11997: should hide after tabbing inside CEF', async function () {
@@ -68,5 +70,6 @@ describe('browser.tinymce.core.FakeCaretImageCaptionTest', () => {
     await Waiter.pTryUntil('Wait for fake caret to be removed', () => {
       TinyAssertions.assertContentPresence(editor, { '.mce-visual-caret': 0 });
     });
+    TinyAssertions.assertCursor(editor, [ 0, 0, 0, 0, 0 ], 0);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretImageCaptionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/caret/FakeCaretImageCaptionTest.ts
@@ -6,7 +6,6 @@ import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
 
-// this
 describe('browser.tinymce.core.FakeCaretImageCaptionTest', () => {
   const browser = PlatformDetection.detect().browser;
   const isFirefox = browser.isFirefox();


### PR DESCRIPTION
Related Ticket: TINY-11997

Description of Changes:
I fixed the bug with the selection overrides in Firefox but I couldn't test it since the tests for this override aren't working for Firefox (the `TinySelections.setRawSelection` used to simulate the `tab` doesn't work in Firefox), so I just improved a little bit the one for Chrome

EDIT: I removed the check for Firefox since the check `editor.selection.getNode() === editor.getBody()` doesn't need any additional check

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
