### PR TITLE
TINY-12045: Prevent block from being added to itself.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12045-2025-05-06.yaml
+++ b/.changes/unreleased/tinymce-TINY-12045-2025-05-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Attempting to add a newline directly after a block element such as an image would cause an error.
+time: 2025-05-06T10:00:58.65126+02:00
+custom:
+    Issue: TINY-12045

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -429,7 +429,13 @@ const insert = (editor: Editor, evt?: EditorEvent<KeyboardEvent>): void => {
     trimZwsp(fragment);
     trimLeadingLineBreaks(fragment);
     newBlock = fragment.firstChild as Element;
-    dom.insertAfter(fragment, parentBlock);
+    if (parentBlock === newBlock) { // Can't add yourself to yourself. Additionally the newBlock is removed from the DOM earlier, so even if you could, it'd still not work.
+      if (Type.isNonNullable(parentBlockParent)) {
+        dom.insertAfter(fragment, parentBlockParent);
+      }
+    } else {
+      dom.insertAfter(fragment, parentBlock);
+    }
     trimInlineElementsOnLeftSideOfBlock(dom, nonEmptyElementsMap, newBlock);
     addBrToBlockIfNeeded(dom, parentBlock);
 

--- a/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/api/commands/NewlineCommandsTest.ts
@@ -110,6 +110,15 @@ describe('browser.tinymce.core.api.commands.NewlineCommandTest', () => {
     TinyAssertions.assertCursor(editor, [ 0 ], 2);
   });
 
+  it('TINY-12045: Newline after image should not cause an error.', () => {
+    const editor = hook.editor();
+    editor.setContent('<div><img alt="icon" src="URL" width="100" height="100"><p>Text</p></div>');
+    TinySelections.setCursor(editor, [ 0 ], 1);
+    editor.execCommand('mceInsertNewLine');
+    TinyAssertions.assertContent(editor, '<div><img src="URL" alt="icon" width="100" height="100"></div><p>Text</p>');
+    TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
+  });
+
   context('TINY-8458: InsertLineBreak and newline_behavior', () => {
     before(() => {
       hook.editor().options.set('newline_behavior', 'block');


### PR DESCRIPTION
Related Ticket: TINY-12045

Description of Changes:
If the cursor is placed directly behind an image the selection become somewhat strange and end up trying to attach an element into itself.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where adding a newline immediately after a block element, such as an image, could cause an error. Newline insertion now works as expected in this scenario.

- **Tests**
  - Added a new test to ensure that inserting a newline after an image does not result in errors and that the content is split correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->