### PR TITLE
TINY-12038: focus trigger element after closing dialog or alert

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12038-2025-05-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-12038-2025-05-07.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: Focus is now restored to a dialog after closing alert, confirmation or another
+  dialog.
+time: 2025-05-07T17:44:52.025973+02:00
+custom:
+  Issue: TINY-12038

--- a/.changes/unreleased/tinymce-TINY-12038-2025-05-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-12038-2025-05-07.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Focus is now restored to a dialog after closing alert, confirmation or another
+body: Focus is now restored to a dialog after closing an alert, confirmation or another
   dialog.
 time: 2025-05-07T17:44:52.025973+02:00
 custom:

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -82,11 +82,9 @@ const WindowManager = (editor: Editor): WindowManager => {
     });
   };
 
-  const addDialog = <T extends Dialog.DialogData>(dialog: InstanceApi<T>, triggerElement: Optional<SugarElement<HTMLElement>>, shouldFireEvent: boolean) => {
+  const addDialog = <T extends Dialog.DialogData>(dialog: InstanceApi<T>, triggerElement: Optional<SugarElement<HTMLElement>>) => {
     dialogs.push({ instanceApi: dialog, triggerElement });
-    if (shouldFireEvent) {
-      fireOpenEvent(dialog);
-    }
+    fireOpenEvent(dialog);
   };
 
   const closeDialog = <T extends Dialog.DialogData>(dialog: InstanceApi<T>) => {
@@ -119,7 +117,7 @@ const WindowManager = (editor: Editor): WindowManager => {
 
     editor.ui.show();
     const dialog = openDialog();
-    addDialog(dialog, activeEl, true);
+    addDialog(dialog, activeEl);
     return dialog;
   };
 

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -92,18 +92,19 @@ const WindowManager = (editor: Editor): WindowManager => {
   const closeDialog = <T extends Dialog.DialogData>(dialog: InstanceApi<T>) => {
     fireCloseEvent(dialog);
 
-    const dialogIndex = dialogs.findIndex(({ instanceApi }) => instanceApi === dialog);
-    const dialogTriggerElement = dialogs[dialogIndex].triggerElement;
+    Arr.findIndex(dialogs, ({ instanceApi }) => instanceApi === dialog).each( (dialogIndex) => {
+      const dialogTriggerElement = dialogs[dialogIndex].triggerElement;
 
-    dialogs.splice(dialogIndex, 1);
+      dialogs.splice(dialogIndex, 1);
 
-    // Move focus back to editor when the last window is closed
-    if (dialogs.length === 0) {
-      editor.focus();
-    } else {
-      // Move focus to the element that was active before the dialog was opened
-      dialogTriggerElement.each((el) => Focus.focus(el));
-    }
+      // Move focus back to editor when the last window is closed
+      if (dialogs.length === 0) {
+        editor.focus();
+      } else {
+        // Move focus to the element that was active before the dialog was opened
+        dialogTriggerElement.each((el) => Focus.focus(el));
+      }
+    });
   };
 
   const getTopDialog = () => {

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -147,7 +147,7 @@ const WindowManager = (editor: Editor): WindowManager => {
     const activeEl = Focus.active();
     const windowManagerImpl = getImplementation();
     windowManagerImpl.confirm(message, funcBind(scope ? scope : windowManagerImpl, (state: boolean) => {
-      tryToRestoreFocus(activeEl);
+      restoreFocus(activeEl);
       callback?.(state);
     }));
   };

--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -126,7 +126,7 @@ const WindowManager = (editor: Editor): WindowManager => {
     return storeSelectionAndOpenDialog(() => getImplementation().openUrl(args, closeDialog));
   };
 
-  const tryToRestoreFocus = (activeEl: Optional<SugarElement<HTMLElement>>): void => {
+  const restoreFocus = (activeEl: Optional<SugarElement<HTMLElement>>): void => {
     if (dialogs.length !== 0) {
       // If there are some dialogs, the confirm/alert was probably triggered from the dialog
       // Move focus to the element that was active before the confirm/alert was opened
@@ -138,7 +138,7 @@ const WindowManager = (editor: Editor): WindowManager => {
     const activeEl = Focus.active();
     const windowManagerImpl = getImplementation();
     windowManagerImpl.alert(message, funcBind(scope ? scope : windowManagerImpl, () => {
-      tryToRestoreFocus(activeEl);
+      restoreFocus(activeEl);
       callback?.();
     }));
   };

--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -1,5 +1,8 @@
+import { FocusTools, Mouse } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { Fun } from '@ephox/katamari';
+import { SugarBody, SugarDocument } from '@ephox/sugar';
+import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -42,5 +45,92 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
     assert.equal(closeWindowArgs?.type, 'closewindow');
 
     editor.off('CloseWindow OpenWindow');
+  });
+
+  const openDialog = (editor: Editor) => {
+    editor.windowManager.open({
+      title: 'Dialog 1',
+      body: {
+        type: 'panel',
+        items: [
+          {
+            type: 'button',
+            text: 'confirm',
+            name: 'confirm'
+          },
+          {
+            type: 'button',
+            text: 'alert',
+            name: 'alert'
+          },
+          {
+            type: 'button',
+            text: 'dialog',
+            name: 'dialog'
+          }
+        ]
+      },
+      buttons: [],
+      onAction: (_, button: { name: string }) => {
+        if (button.name === 'confirm') {
+          editor.windowManager.confirm('Ok?', Fun.noop);
+        }
+        if (button.name === 'alert') {
+          editor.windowManager.alert('This is an alert');
+        }
+        if (button.name === 'dialog') {
+          editor.windowManager.open({
+            title: 'Dialog 2',
+            body: {
+              type: 'panel',
+              items: []
+            },
+            buttons: []
+          });
+        }
+      }
+    });
+  };
+
+  it('TINY-12038: Focus is restored to the dialog after closing confirmation dialog', async () => {
+    const editor = hook.editor();
+    openDialog(editor);
+    await TinyUiActions.pWaitForDialogByTitle(editor, 'Dialog 1');
+    const triggerButtonSelector = '[role="dialog"] button[data-mce-name="confirm"]';
+
+    Mouse.trueClickOn(SugarBody.body(), triggerButtonSelector);
+    await TinyUiActions.pWaitForPopup(editor, '.tox-confirm-dialog');
+    TinyUiActions.clickOnUi(editor, '[role="dialog"].tox-confirm-dialog button:contains("Yes")');
+
+    await FocusTools.pTryOnSelector('Focus should be restored to the trigger button', SugarDocument.getDocument(), triggerButtonSelector);
+    TinyUiActions.closeDialogByTitle(editor, 'Dialog 1');
+  });
+
+  it('TINY-12038: Focus is restored to the dialog after closing an alert', async () => {
+    const editor = hook.editor();
+    openDialog(editor);
+    await TinyUiActions.pWaitForDialogByTitle(editor, 'Dialog 1');
+    const triggerButtonSelector = '[role="dialog"] button[data-mce-name="alert"]';
+
+    Mouse.trueClickOn(SugarBody.body(), triggerButtonSelector);
+    await TinyUiActions.pWaitForPopup(editor, '.tox-alert-dialog');
+    TinyUiActions.clickOnUi(editor, '[role="dialog"].tox-alert-dialog button:contains("OK")');
+
+    await FocusTools.pTryOnSelector('Focus should be restored to the trigger button', SugarDocument.getDocument(), triggerButtonSelector);
+    TinyUiActions.closeDialogByTitle(editor, 'Dialog 1');
+  });
+
+  it('TINY-12038: Focus is restored to the dialog after closing second dialog', async () => {
+    const editor = hook.editor();
+    openDialog(editor);
+    await TinyUiActions.pWaitForDialogByTitle(editor, 'Dialog 1');
+    const triggerButtonSelector = '[role="dialog"] button[data-mce-name="dialog"]';
+
+    Mouse.trueClickOn(SugarBody.body(), triggerButtonSelector);
+    await TinyUiActions.pWaitForDialogByTitle(editor, 'Dialog 2');
+    TinyUiActions.closeDialogByTitle(editor, 'Dialog 2');
+
+    await FocusTools.pTryOnSelector('Focus should be restored to the trigger button', SugarDocument.getDocument(), triggerButtonSelector);
+    TinyUiActions.closeDialogByTitle(editor, 'Dialog 1');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-12038

Description of Changes:
* Improved focus management in WindowManager by tracking trigger elements
* Added focus restoration when closing dialogs, alerts, and confirms
* Refactored dialog storage to include both instance API and trigger element

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved focus management: When dialogs, alerts, or confirms are closed, focus is now restored to the element that was active before the dialog opened, ensuring a smoother and more accessible user experience.  
  - Enhanced dialog interactions with multiple layered dialogs, maintaining focus on the appropriate dialog elements after alerts or confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->