### PR TITLE
TINY-11982: fix arrow navigation inside `figcaption`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11982-2025-05-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11982-2025-05-07.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed an issue where it wasn't possible to navigate out of a `figcaption` using the left and right arrow keys in Firefox.
+time: 2025-05-07T11:32:56.183932266+02:00
+custom:
+    Issue: TINY-11982

--- a/.changes/unreleased/tinymce-TINY-11982-2025-05-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11982-2025-05-07.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Fixed an issue where it wasn't possible to navigate out of a `figcaption` using the left and right arrow keys in Firefox.
+body: It wasn't possible to navigate out of a `figcaption` using the left and right arrow keys in Firefox.
 time: 2025-05-07T11:32:56.183932266+02:00
 custom:
     Issue: TINY-11982

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -408,10 +408,11 @@ const Quirks = (editor: Editor): Quirks => {
    * to allow navigation to the previous/next sibling of the figure element.
   */
   const arrowInFigcaption = () => {
+    const isFigcaption = SugarNode.isTag('figcaption');
     editor.on('keydown', (e) => {
       if (e.keyCode === VK.LEFT || e.keyCode === VK.RIGHT) {
         const currentNode = SugarElement.fromDom(editor.selection.getNode());
-        if (SugarNode.isTag('figcaption')(currentNode) && editor.selection.isCollapsed()) {
+        if (isFigcaption(currentNode) && editor.selection.isCollapsed()) {
           Traverse.parent(currentNode).bind((parent) => {
             if (editor.selection.getRng().startOffset === 0 && e.keyCode === VK.LEFT) {
               return Traverse.prevSibling(parent);

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -421,10 +421,7 @@ const Quirks = (editor: Editor): Quirks => {
               return Optional.none();
             }
           }).each((targetSibling) => {
-            const rng = editor.dom.createRng();
-            rng.setStart(targetSibling.dom, 0);
-            rng.setEnd(targetSibling.dom, 0);
-            editor.selection.setRng(rng);
+            editor.selection.setCursorLocation(targetSibling.dom, 0);
           });
         }
 

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,4 +1,5 @@
 import { Fun, Optional, Optionals } from '@ephox/katamari';
+import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
 import Env from '../api/Env';
@@ -401,6 +402,34 @@ const Quirks = (editor: Editor): Quirks => {
     });
   };
 
+  /*
+    this fix the left and right arrows navigation to leave a `<figcaption>`
+  */
+  const arrowInFigcaption = () => {
+    editor.on('keydown', (e) => {
+      if (e.keyCode === VK.LEFT || e.keyCode === VK.RIGHT) {
+        const currentNode = SugarElement.fromDom(editor.selection.getNode());
+        if (SugarNode.isTag('figcaption')(currentNode) && editor.selection.isCollapsed()) {
+          Traverse.parent(currentNode).bind((parent) => {
+            if (editor.selection.getRng().startOffset === 0 && e.keyCode === VK.LEFT) {
+              return Traverse.prevSibling(parent);
+            } else if (editor.selection.getRng().endOffset === currentNode.dom.textContent?.length && e.keyCode === VK.RIGHT) {
+              return Traverse.nextSibling(parent);
+            } else {
+              return Optional.none();
+            }
+          }).each((targetSibling) => {
+            const rng = editor.dom.createRng();
+            rng.setStart(targetSibling.dom, 0);
+            rng.setEnd(targetSibling.dom, 0);
+            editor.selection.setRng(rng);
+          });
+        }
+
+      }
+    });
+  };
+
   /**
    * Sets various Gecko editing options on mouse down and before a execCommand to disable inline table editing that is broken etc.
    */
@@ -743,6 +772,7 @@ const Quirks = (editor: Editor): Quirks => {
 
     // Gecko
     if (isGecko) {
+      arrowInFigcaption();
       fixFirefoxImageSelection();
       removeHrOnBackspace();
       focusBody();

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -403,7 +403,9 @@ const Quirks = (editor: Editor): Quirks => {
   };
 
   /*
-    this fix the left and right arrows navigation to leave a `<figcaption>`
+   * Firefox-specific fix for arrow key navigation. In Firefox, users can't move the caret out of a
+   * `<figcaption>` element using the left and right arrow keys. This function handles those keystrokes
+   * to allow navigation to the previous/next sibling of the figure element.
   */
   const arrowInFigcaption = () => {
     editor.on('keydown', (e) => {

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
@@ -84,7 +84,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
         this.skip();
       }
       const editor = hook.editor();
-      editor.setContent('<p><figure contenteditable="false"><img src="tinymce/ui/img/raster.gif" /><figcaption contenteditable="true">abc</figcaption></figure></p>');
+      editor.setContent('<p>&nbsp;</p><figure contenteditable="false"><img src="tinymce/ui/img/raster.gif" /><figcaption contenteditable="true">abc</figcaption></figure><p>&nbsp;</p>');
 
       TinySelections.setCursor(editor, [ 1, 1, 0 ], 0);
       TinyContentActions.keydown(editor, Keys.left());
@@ -96,7 +96,7 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
         this.skip();
       }
       const editor = hook.editor();
-      editor.setContent('<p><figure contenteditable="false"><img src="tinymce/ui/img/raster.gif" /><figcaption contenteditable="true">abc</figcaption></figure></p>');
+      editor.setContent('<p>&nbsp;</p><figure contenteditable="false"><img src="tinymce/ui/img/raster.gif" /><figcaption contenteditable="true">abc</figcaption></figure><p>&nbsp;</p>');
 
       TinySelections.setCursor(editor, [ 1, 1, 0 ], 'abc'.length);
       TinyContentActions.keydown(editor, Keys.right());

--- a/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/keyboard/ArrowKeysContentEndpointTest.ts
@@ -1,10 +1,12 @@
 import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
+  const platform = PlatformDetection.detect();
   const hook = TinyHooks.bddSetupLight<Editor>({
     add_unload_trigger: false,
     base_url: '/project/tinymce/js/tinymce',
@@ -75,6 +77,30 @@ describe('browser.tinymce.core.keyboard.ArrowKeysContentEndpointTest', () => {
       TinyAssertions.assertContent(editor, '<figure><figcaption>a</figcaption></figure><p class="x">&nbsp;</p>');
       TinyAssertions.assertSelection(editor, [ 1 ], 0, [ 1 ], 0);
       editor.options.unset('forced_root_block_attrs');
+    });
+
+    it('TINY-11982: Arrow left at figcaption start should move the caret before the figure', function () {
+      if (!platform.browser.isFirefox()) {
+        this.skip();
+      }
+      const editor = hook.editor();
+      editor.setContent('<p><figure contenteditable="false"><img src="tinymce/ui/img/raster.gif" /><figcaption contenteditable="true">abc</figcaption></figure></p>');
+
+      TinySelections.setCursor(editor, [ 1, 1, 0 ], 0);
+      TinyContentActions.keydown(editor, Keys.left());
+      TinyAssertions.assertCursor(editor, [ 0 ], 0);
+    });
+
+    it('TINY-11982: Arrow right at figcaption end should move the caret after the figure', function () {
+      if (!platform.browser.isFirefox()) {
+        this.skip();
+      }
+      const editor = hook.editor();
+      editor.setContent('<p><figure contenteditable="false"><img src="tinymce/ui/img/raster.gif" /><figcaption contenteditable="true">abc</figcaption></figure></p>');
+
+      TinySelections.setCursor(editor, [ 1, 1, 0 ], 'abc'.length);
+      TinyContentActions.keydown(editor, Keys.right());
+      TinyAssertions.assertCursor(editor, [ 2 ], 0);
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11982

Description of Changes:
to manage this issue I added a Quirk for Firefox since the issue is only on Firefox.

About the tests, I added a couple of tests but they don't simulate the real navigation and they works only because of that quirk, that's why I had to skip them if they are not on Firefox

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue in Firefox preventing navigation out of figcaption elements using left and right arrow keys.

- **Tests**
  - Added tests to ensure proper caret movement with arrow keys in figcaption elements on Firefox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->