### PR TITLE
TINY-12073: fix nested font sizes were causing too much spacing between lines

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12073-2025-05-08.yaml
+++ b/.changes/unreleased/tinymce-TINY-12073-2025-05-08.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Nested font sizes were causing too much spacing between lines.
+time: 2025-05-08T12:12:48.954715+02:00
+custom:
+  Issue: TINY-12073


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
