### PR TITLE
TINY-12114: Include notices file in tinymce packages

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -349,6 +349,10 @@ module.exports = function (grunt) {
           {
             src: '../../README.md',
             dest: 'js/tinymce/README.md'
+          },
+          {
+            src: '../../NOTICES.txt',
+            dest: 'js/tinymce/notices.txt'
           }
         ]
       },
@@ -444,6 +448,7 @@ module.exports = function (grunt) {
           'js/tinymce/tinymce.d.ts',
           'js/tinymce/tinymce.min.js',
           'js/tinymce/license.md',
+          'js/tinymce/notices.txt',
           'CHANGELOG.md',
           'LICENSE.md',
           'README.md'
@@ -487,6 +492,7 @@ module.exports = function (grunt) {
               'patches',
               '.yarnrc',
               'LICENSE.md',
+              'NOTICES.txt',
               'README.md',
               'lerna.json',
               'package.json',
@@ -570,7 +576,8 @@ module.exports = function (grunt) {
           'js/tinymce/icons',
           'js/tinymce/themes',
           'js/tinymce/models',
-          'js/tinymce/license.md'
+          'js/tinymce/license.md',
+          'js/tinymce/notices.txt'
         ]
       },
 
@@ -707,7 +714,8 @@ module.exports = function (grunt) {
           'js/tinymce/tinymce.min.js',
           'js/tinymce/license.md',
           'CHANGELOG.md',
-          'js/tinymce/README.md'
+          'js/tinymce/README.md',
+          'js/tinymce/notices.txt'
         ]
       }
     },
@@ -757,6 +765,7 @@ module.exports = function (grunt) {
           { src: 'js/tinymce/tinymce.d.ts', dest: '/content/scripts/tinymce/tinymce.d.ts' },
           { src: 'js/tinymce/tinymce.min.js', dest: '/content/scripts/tinymce/tinymce.min.js' },
           { src: 'js/tinymce/license.md', dest: '/content/scripts/tinymce/license.md' },
+          { src: 'js/tinymce/notices.txt', dest: '/content/scripts/tinymce/notices.txt' },
           { src: 'tools/nuget/build/TinyMCE.targets', dest: '/build/TinyMCE.targets' }
         ]
       },


### PR DESCRIPTION
Related Ticket: TIN-12114

Description of Changes:
* Include notices.txt file as part of the tinyMCE distribution

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Ensured the `NOTICES.txt` file is included in all TinyMCE build packages and distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->