### PR TITLE
TINY-12102: Fix new list item formatting

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12102-2025-05-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-12102-2025-05-12.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: New list item was not inserted correctly, if existing list item had <p> tag
-  inside.
+body: New list item was not inserted correctly when existing list item had a block element inside.
 time: 2025-05-12T15:19:38.897889+02:00
 custom:
   Issue: TINY-12102

--- a/.changes/unreleased/tinymce-TINY-12102-2025-05-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-12102-2025-05-12.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: New list item was not inserted correctly, if existing list item had <p> tag
+  inside.
+time: 2025-05-12T15:19:38.897889+02:00
+custom:
+  Issue: TINY-12102

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -125,9 +125,6 @@ const leaf = (element: SugarElement<Node>, offset: number): ElementAndOffset<Nod
   return cs.length > 0 && offset < cs.length ? spot(cs[offset], 0) : spot(element, offset);
 };
 
-const leftmostLeaf = (element: SugarElement<Node>): SugarElement<Node> =>
-  firstChild(element).fold(Fun.constant(element), leftmostLeaf);
-
 export {
   owner,
   documentOrOwner,
@@ -150,6 +147,5 @@ export {
   lastChild,
   childNodesCount,
   hasChildNodes,
-  leaf,
-  leftmostLeaf
+  leaf
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Traverse.ts
@@ -125,6 +125,9 @@ const leaf = (element: SugarElement<Node>, offset: number): ElementAndOffset<Nod
   return cs.length > 0 && offset < cs.length ? spot(cs[offset], 0) : spot(element, offset);
 };
 
+const leftmostLeaf = (element: SugarElement<Node>): SugarElement<Node> =>
+  firstChild(element).fold(Fun.constant(element), leftmostLeaf);
+
 export {
   owner,
   documentOrOwner,
@@ -147,5 +150,6 @@ export {
   lastChild,
   childNodesCount,
   hasChildNodes,
-  leaf
+  leaf,
+  leftmostLeaf
 };

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Optional, Optionals, Unicode } from '@ephox/katamari';
-import { Css, SugarElement } from '@ephox/sugar';
+import { Css, Insert, SugarElement, Traverse } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
@@ -38,6 +38,9 @@ const moveToCaretPosition = (editor: Editor, root: Node): void => {
 
     if (firstChild && /^(UL|OL|DL)$/.test(firstChild.nodeName)) {
       root.insertBefore(dom.doc.createTextNode(Unicode.nbsp), root.firstChild);
+    } else if (firstChild && dom.isEmpty(firstChild)) {
+      const element = Traverse.leftmostLeaf(SugarElement.fromDom(firstChild));
+      Insert.append(element, SugarElement.fromText(Unicode.nbsp));
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Optional, Optionals, Unicode } from '@ephox/katamari';
-import { Css, Insert, SugarElement, Traverse } from '@ephox/sugar';
+import { Css, Insert, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
@@ -35,12 +35,13 @@ const moveToCaretPosition = (editor: Editor, root: Node): void => {
 
   if (/^(LI|DT|DD)$/.test(root.nodeName)) {
     const firstChild = firstNonWhiteSpaceNodeSibling(root.firstChild);
-
     if (firstChild && /^(UL|OL|DL)$/.test(firstChild.nodeName)) {
       root.insertBefore(dom.doc.createTextNode(Unicode.nbsp), root.firstChild);
     } else if (firstChild && dom.isEmpty(firstChild)) {
       const element = Traverse.leftmostLeaf(SugarElement.fromDom(firstChild));
-      Insert.append(element, SugarElement.fromText(Unicode.nbsp));
+      if (SugarNode.name(element) !== 'br') {
+        Insert.append(element, SugarElement.fromText(Unicode.nbsp));
+      }
     }
   }
 

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -1,5 +1,6 @@
 import { Arr, Fun, Obj, Optional, Optionals, Unicode } from '@ephox/katamari';
-import { Css, Insert, SugarElement, Traverse } from '@ephox/sugar';
+import { DomDescent } from '@ephox/phoenix';
+import { Css, Insert, SugarElement } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
@@ -38,7 +39,7 @@ const moveToCaretPosition = (editor: Editor, root: Node): void => {
     if (firstChild && /^(UL|OL|DL)$/.test(firstChild.nodeName)) {
       root.insertBefore(dom.doc.createTextNode(Unicode.nbsp), root.firstChild);
     } else if (firstChild && dom.isEmpty(firstChild)) {
-      const element = Traverse.leftmostLeaf(SugarElement.fromDom(firstChild));
+      const element = DomDescent.toLeaf(SugarElement.fromDom(firstChild), 0).element;
       if (!ElementType.isBr(element)) {
         Insert.append(element, SugarElement.fromText(Unicode.nbsp));
       }

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Optional, Optionals, Unicode } from '@ephox/katamari';
-import { Css, Insert, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { Css, Insert, SugarElement, Traverse } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import DomTreeWalker from '../api/dom/TreeWalker';
@@ -39,7 +39,7 @@ const moveToCaretPosition = (editor: Editor, root: Node): void => {
       root.insertBefore(dom.doc.createTextNode(Unicode.nbsp), root.firstChild);
     } else if (firstChild && dom.isEmpty(firstChild)) {
       const element = Traverse.leftmostLeaf(SugarElement.fromDom(firstChild));
-      if (SugarNode.name(element) !== 'br') {
+      if (!ElementType.isBr(element)) {
         Insert.append(element, SugarElement.fromText(Unicode.nbsp));
       }
     }

--- a/modules/tinymce/src/core/test/ts/browser/newline/NewlineInLiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/NewlineInLiTest.ts
@@ -1,0 +1,89 @@
+import { Keys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyAssertions, TinyHooks, TinySelections, TinyContentActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.newline.NewlineInLiTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, [], true);
+
+  it('TINY-12102: pressing enter in p inside li should insert nbsp in new li', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>'
+        + '<li><p>One</p></li>'
+        + '<li>'
+          + '<p>Two</p>'
+          + '<ul>'
+            + '<li>One sub</li>'
+            + '<li>Two sub</li>'
+          + '</ul>'
+        + '</li>'
+      + '</ul>'
+    );
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0 ], 'Two'.length);
+    TinyContentActions.keydown(editor, Keys.enter());
+
+    const expectedContent = [ '<ul>',
+      '<li>',
+      '<p>One</p>',
+      '</li>',
+      '<li>',
+      '<p>Two</p>',
+      '</li>',
+      '<li>',
+      '<p>&nbsp;</p>',
+      '<ul>',
+      '<li>One sub</li>',
+      '<li>Two sub</li>',
+      '</ul>',
+      '</li>',
+      '</ul>' ].join('\n');
+    TinyAssertions.assertContent(editor, expectedContent);
+    TinyAssertions.assertCursor(editor, [ 0, 2, 0, 0 ], 0);
+  });
+
+  it('TINY-12102: pressing enter in multiple nested spans in p inside li should insert nbsp in new li', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>'
+        + '<li><p>One</p></li>'
+        + '<li>'
+         + '<p>'
+            + '<span style="font-size: 24pt;">'
+              + '<span style="background: red;">'
+                + 'Two'
+              + '</span>'
+            + '</span>'
+          + '</p>'
+          + '<ul>'
+            + '<li>One sub</li>'
+            + '<li>Two sub</li>'
+          + '</ul>'
+        + '</li>'
+      + '</ul>'
+    );
+    TinySelections.setCursor(editor, [ 0, 1, 0, 0, 0, 0 ], 'Two'.length);
+    TinyContentActions.keydown(editor, Keys.enter());
+
+    const expectedContent = [ '<ul>',
+      '<li>',
+      '<p>One</p>',
+      '</li>',
+      '<li>',
+      '<p><span style="font-size: 24pt;"><span style="background: red;">Two</span></span></p>',
+      '</li>',
+      '<li>',
+      '<p><span style="font-size: 24pt;"><span style="background: red;">&nbsp;</span></span></p>',
+      '<ul>',
+      '<li>One sub</li>',
+      '<li>Two sub</li>',
+      '</ul>',
+      '</li>',
+      '</ul>' ].join('\n');
+    TinyAssertions.assertContent(editor, expectedContent);
+    TinyAssertions.assertCursor(editor, [ 0, 2, 0, 0, 0, 0 ], 0);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-12102

Description of Changes:
* New list item was not inserted correctly, if existing list item had <p> tag  inside.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where inserting a new list item failed when the existing item contained a block element, ensuring correct insertion in such cases.

- **Tests**
  - Added new tests to verify correct behavior when pressing Enter inside paragraphs and nested elements within list items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->