### PR TITLE
TINY-12067: refactor Width api to have the exact value

### DIFF
--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -17,7 +17,7 @@ import { applyTransitionCss } from './Transitions';
  */
 
 const elementSize = (p: SugarElement<HTMLElement>): AnchorElement => ({
-  width: Math.round(Width.getOuter(p)),
+  width: Math.ceil(Width.getOuter(p)),
   height: Height.getOuter(p)
 });
 
@@ -69,7 +69,10 @@ const setPlacement = (element: SugarElement<HTMLElement>, decision: RepositionDe
 };
 
 export {
-  layout, position, setClasses,
-  setHeight, setPlacement, setWidth
+  layout,
+  setClasses,
+  setHeight,
+  setWidth,
+  position,
+  setPlacement
 };
-

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -17,7 +17,7 @@ import { applyTransitionCss } from './Transitions';
  */
 
 const elementSize = (p: SugarElement<HTMLElement>): AnchorElement => ({
-  width: Math.ceil(Width.getOuterExact(p)),
+  width: Math.ceil(Width.getOuter(p)),
   height: Height.getOuter(p)
 });
 

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/view/Callouts.ts
@@ -17,7 +17,7 @@ import { applyTransitionCss } from './Transitions';
  */
 
 const elementSize = (p: SugarElement<HTMLElement>): AnchorElement => ({
-  width: Math.ceil(Width.getOuter(p)),
+  width: Math.round(Width.getOuter(p)),
   height: Height.getOuter(p)
 });
 
@@ -69,10 +69,7 @@ const setPlacement = (element: SugarElement<HTMLElement>, decision: RepositionDe
 };
 
 export {
-  layout,
-  setClasses,
-  setHeight,
-  setWidth,
-  position,
-  setPlacement
+  layout, position, setClasses,
+  setHeight, setPlacement, setWidth
 };
+

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
@@ -29,7 +29,7 @@ const colInfo = (col: number, x: number): ColInfo => ({
 
 const rtlEdge = (cell: SugarElement<HTMLElement>): number => {
   const pos = SugarLocation.absolute(cell);
-  return pos.left + Math.round(Width.getOuter(cell));
+  return pos.left + Width.getOuter(cell);
 };
 
 const ltrEdge = (cell: SugarElement<HTMLElement>): number => {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
@@ -29,7 +29,7 @@ const colInfo = (col: number, x: number): ColInfo => ({
 
 const rtlEdge = (cell: SugarElement<HTMLElement>): number => {
   const pos = SugarLocation.absolute(cell);
-  return pos.left + Width.getOuter(cell);
+  return pos.left + Math.round(Width.getOuter(cell));
 };
 
 const ltrEdge = (cell: SugarElement<HTMLElement>): number => {

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -71,7 +71,7 @@ const getWidthFrom = <T>(
       } else {
         // Invalid column so fallback to trying to get the computed width from the cell
         const cell = Optionals.bindFrom(columnCells[c], Fun.identity);
-        return getDimension(cell, c, backups, colFilter, (cell) => fallback(Optional.some(Width.get(cell))), fallback);
+        return getDimension(cell, c, backups, colFilter, (cell) => fallback(Optional.some(Math.round(Width.get(cell)))), fallback);
       }
     }, fallback);
   });

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -79,7 +79,7 @@ export const getRawHeight = (element: SugarElement<HTMLElement>): Optional<strin
 
 // Get a percentage size for a percentage parent table
 export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
-  getPercentSize(cell, (elm) => Math.round(Width.get(elm)), Width.getInner);
+  getPercentSize(cell, Width.get, Width.getInner);
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -79,7 +79,7 @@ export const getRawHeight = (element: SugarElement<HTMLElement>): Optional<strin
 
 // Get a percentage size for a percentage parent table
 export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
-  getPercentSize(cell, Width.get, Width.getInner);
+  getPercentSize(cell, (elm) => Math.round(Width.get(elm)), Width.getInner);
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -83,7 +83,7 @@ export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTM
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
-  isCol(cell) ? Math.round(Width.get(cell)) : Width.getRuntime(cell);
+  isCol(cell) ? Math.round(Width.get(cell)) : Math.round(Width.getRuntime(cell));
 
 export const getHeight = (cell: SugarElement<HTMLTableCellElement | HTMLTableRowElement>): number => {
   return isRow(cell) ? Height.get(cell) : get(cell as SugarElement<HTMLTableCellElement>, 'rowspan', getTotalHeight);

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -83,7 +83,7 @@ export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTM
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
-  isCol(cell) ? Math.round(Width.get(cell)) : Math.round(Width.getRuntime(cell));
+  isCol(cell) ? Math.round(Width.get(cell)) : Width.getRuntime(cell);
 
 export const getHeight = (cell: SugarElement<HTMLTableCellElement | HTMLTableRowElement>): number => {
   return isRow(cell) ? Height.get(cell) : get(cell as SugarElement<HTMLTableCellElement>, 'rowspan', getTotalHeight);

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -83,7 +83,7 @@ export const getPercentageWidth = (cell: SugarElement<HTMLTableCellElement | HTM
 
 export const getPixelWidth = (cell: SugarElement<HTMLTableCellElement | HTMLTableColElement>): number =>
   // For col elements use the computed width as col elements aren't affected by borders, padding, etc...
-  isCol(cell) ? Width.get(cell) : Width.getRuntime(cell);
+  isCol(cell) ? Math.round(Width.get(cell)) : Width.getRuntime(cell);
 
 export const getHeight = (cell: SugarElement<HTMLTableCellElement | HTMLTableRowElement>): number => {
   return isRow(cell) ? Height.get(cell) : get(cell as SugarElement<HTMLTableCellElement>, 'rowspan', getTotalHeight);

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
@@ -4,12 +4,7 @@ import * as SugarBody from '../node/SugarBody';
 import { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
 
-const api = Dimension('width', (element: SugarElement<HTMLElement>) =>
-  // IMO passing this function is better than using dom['offset' + 'width']
-  element.dom.offsetWidth
-);
-
-const apiExact = Dimension('width', (element: SugarElement<HTMLElement>) => {
+const api = Dimension('width', (element: SugarElement<HTMLElement>) => {
   const dom = element.dom;
   return SugarBody.inBody(element) ? dom.getBoundingClientRect().width : dom.offsetWidth;
 });
@@ -19,8 +14,6 @@ const set = (element: SugarElement<HTMLElement>, h: string | number): void => ap
 const get = (element: SugarElement<HTMLElement>): number => api.get(element);
 
 const getOuter = (element: SugarElement<HTMLElement>): number => api.getOuter(element);
-
-const getOuterExact = (element: SugarElement<HTMLElement>): number => apiExact.getOuter(element);
 
 const getInner = RuntimeSize.getInnerWidth;
 
@@ -38,7 +31,6 @@ export {
   get,
   getInner,
   getOuter,
-  getOuterExact,
   getRuntime,
   setMax
 };

--- a/modules/sugar/src/test/ts/browser/ScrollTest.ts
+++ b/modules/sugar/src/test/ts/browser/ScrollTest.ts
@@ -138,7 +138,7 @@ UnitTest.asynctest('ScrollTest', (success, failure) => {
     setToElement(doc, cEl, cPos.left, cPos.top, 1, 1, 'set to centre el');
 
     // scroll text of the centre cell into view (right-aligned in RTL mode)
-    const x = cX + (doc.rtl ? (Width.get(cEl) - Width.get(doc.iframe)) : 0);
+    const x = cX + (doc.rtl ? (Math.round(Width.get(cEl)) - Width.get(doc.iframe)) : 0);
     scrollTo(x, cY, doc); // scroll back to centre
 
     scrollBy(-50, 30, doc, 'scrollBy/1');


### PR DESCRIPTION
Related Ticket: TINY-12067

Description of Changes:
I removed `apiExact` and used that code in `api` in [Width.ts](https://github.com/tinymce/tinymce/blob/main/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts) to be more similar to [Height.ts](https://github.com/tinymce/tinymce/blob/main/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts), after this I got 10 tests failing in 3 different files:

modules/snooker/src/test/ts/browser/TableAdjustmentsTest.ts(7)
modules/tinymce/src/plugins/table/test/ts/browser/TableRemoveTrailingBrTest.ts(2)
modules/sugar/src/test/ts/browser/ScrollTest.ts(1)

to fix the tests in tables I choose to round the value in `getPixelWidth` since tables seem to have mechanism of [redistribution](https://github.com/tinymce/tinymce/blob/main/modules/snooker/src/main/ts/ephox/snooker/resize/Redistribution.ts) that already [round it](https://github.com/tinymce/tinymce/blob/main/modules/snooker/src/main/ts/ephox/snooker/resize/Redistribution.ts#L77), so I choose to preserve the old round to have the same behavior and not risk to create some strange edge case that we already managed in tables.

about the `ScrollTest.ts` I rounded it since it seems that `scrollLeft` is rounded, check it here: https://fiddle.tiny.cloud/hzyRDNHVnr/0

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of width calculations by rounding pixel widths to integer values where appropriate.
  - Adjusted layout computations to use consistent width measurements, enhancing visual alignment in some scenarios.

- **Tests**
  - Updated scroll behavior tests to reflect rounded width values, improving reliability in right-to-left (RTL) layouts.

- **Refactor**
  - Removed obsolete width measurement functions to simplify internal code and reduce redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->