### PR TITLE
TINY-12131: fix select styles overwitten by css reset

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12131-2025-05-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-12131-2025-05-13.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Select styles would break for chrome verison 136.
+body: Select UI elements was not properly styled on Chrome version 136.
 time: 2025-05-13T12:48:52.825263+02:00
 custom:
   Issue: TINY-12131

--- a/.changes/unreleased/tinymce-TINY-12131-2025-05-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-12131-2025-05-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Select styles would break for chrome verison 136.
+time: 2025-05-13T12:48:52.825263+02:00
+custom:
+  Issue: TINY-12131

--- a/modules/oxide/src/less/theme/components/form/select.less
+++ b/modules/oxide/src/less/theme/components/form/select.less
@@ -76,6 +76,11 @@
     top: 50%;
     transform: translateY(-50%);
   }
+
+  .tox-selectfield select option:checked {
+	  background-color: revert;
+	  color: revert;
+  }
 }
 
 .tox:not([dir=rtl]) {


### PR DESCRIPTION
Related Ticket: TINY-12131

Description of Changes:
Fixed select styles overwitten by css reset for chrome version 136

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
