### PR TITLE
TINY-12092: DomParser not removing whitespace around `colgroup` and `col` elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12092-2025-05-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-12092-2025-05-13.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: DomPaser not removing whitespace around `colgroup` and `col` elements.
+body: HTML schema did not treat `colgroup` or `col` elements as block elements.
 time: 2025-05-13T22:28:14.566677+08:00
 custom:
     Issue: TINY-12092

--- a/.changes/unreleased/tinymce-TINY-12092-2025-05-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-12092-2025-05-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: DomPaser not removing whitespace around `colgroup` and `col` elements.
+time: 2025-05-13T22:28:14.566677+08:00
+custom:
+    Issue: TINY-12092

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -157,7 +157,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     'blockquote center dir fieldset header footer article section hgroup aside main nav figure');
   const blockElementsMap = createLookupTable('block_elements', 'hr table tbody thead tfoot ' +
     'th tr td li ol ul caption dl dt dd noscript menu isindex option ' +
-    'datalist select optgroup figcaption details summary html body multicol listing', textBlockElementsMap);
+    'datalist select optgroup figcaption details summary html body multicol listing colgroup col', textBlockElementsMap);
   const textInlineElementsMap = createLookupTable('text_inline_elements', 'span strong b em i font s strike u var cite ' +
     'dfn code mark q sup sub samp');
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1707,6 +1707,20 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     });
   });
 
+  context('Table elements', () => {
+    it('Should strip whitespace elements in table element', () => {
+      const input = '<table>  \t\r\n  <tbody>  \t\r\n <tr> \t\r\n <td> \t\r\n  test  \t\r\n </td> \t\r\n  </tr> \t\r\n </tbody>  \t\r\n  </table>';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser().parse(input));
+      assert.equal(serializedHtml, '<table><tbody><tr><td>test</td></tr></tbody></table>');
+    });
+
+    it('TINY-12092: Should strip whitespace around colgroup and col elements', () => {
+      const input = '<table> \t\r\n <colgroup> \t\r\n <col> \t\r\n </colgroup>  \t\r\n  <tbody>  \t\r\n <tr> \t\r\n <td> \t\r\n  test  \t\r\n </td> \t\r\n  </tr> \t\r\n </tbody>  \t\r\n  </table>';
+      const serializedHtml = HtmlSerializer({}, schema).serialize(DomParser().parse(input));
+      assert.equal(serializedHtml, '<table><colgroup><col></colgroup><tbody><tr><td>test</td></tr></tbody></table>');
+    });
+  });
+
   context('Math elements', () => {
     it('TINY-10809: Should not wrap math elements', () => {
       const schema = Schema();

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -226,13 +226,13 @@ describe('browser.tinymce.core.html.SchemaTest', () => {
       DL: {}, CENTER: {}, BLOCKQUOTE: {}, CAPTION: {}, UL: {}, OL: {}, LI: {},
       TD: {}, TR: {}, TH: {}, TFOOT: {}, THEAD: {}, TBODY: {}, TABLE: {}, FORM: {},
       PRE: {}, ADDRESS: {}, DIV: {}, P: {}, HR: {}, H6: {}, H5: {}, H4: {}, H3: {},
-      H2: {}, H1: {}, NAV: {}, FIGURE: {}, DATALIST: {}, OPTGROUP: {}, OPTION: {}, SELECT: {},
+      H2: {}, H1: {}, NAV: {}, FIGURE: {}, DATALIST: {}, OPTGROUP: {}, OPTION: {}, SELECT: {}, COL: {}, COLGROUP: {},
       details: {}, listing: {}, multicol: {}, body: {}, html: {}, summary: {}, main: {}, aside: {}, hgroup: {}, section: {}, article: {}, footer: {}, header: {},
       isindex: {}, menu: {}, noscript: {}, fieldset: {}, dir: {}, dd: {}, dt: {}, dl: {}, center: {},
       blockquote: {}, caption: {}, ul: {}, ol: {}, li: {}, td: {}, tr: {}, th: {}, tfoot: {}, thead: {},
       tbody: {}, table: {}, form: {}, pre: {}, address: {}, div: {}, p: {}, hr: {}, h6: {},
       h5: {}, h4: {}, h3: {}, h2: {}, h1: {}, nav: {}, figure: {}, figcaption: {}, datalist: {}, optgroup: {},
-      option: {}, select: {}
+      option: {}, select: {}, col: {}, colgroup: {}
     });
   });
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/PasteTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/PasteTableTest.ts
@@ -10,7 +10,7 @@ describe('browser.tinymce.models.dom.table.PasteTableTest', () => {
     table_merge_content_on_paste: false,
     base_url: '/project/tinymce/js/tinymce',
   }, []);
-  const nestedTable = `<table style="border-collapse: collapse; width: 100.242%;" border="1"><colgroup> <col style="width: 49.9179%;"> <col style="width: 49.9179%;"> </colgroup>
+  const nestedTable = `<table style="border-collapse: collapse; width: 100.242%;" border="1"><colgroup><col style="width: 49.9179%;"><col style="width: 49.9179%;"></colgroup>
 <tbody>
 <tr>
 <td>1</td>
@@ -24,7 +24,7 @@ describe('browser.tinymce.models.dom.table.PasteTableTest', () => {
 </table>`;
 
   const getContent = (secondCellContent = '&nbsp;') =>
-    `<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup> <col style="width: 33.2976%;"> <col style="width: 33.2976%;"> <col style="width: 33.2976%;"> </colgroup>
+    `<table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 33.2976%;"><col style="width: 33.2976%;"><col style="width: 33.2976%;"></colgroup>
 <tbody>
 <tr>
 <td>


### PR DESCRIPTION
Related Ticket: TINY-12092

Description of Changes:
* Adding to `blockElementsMap` so the whitespaces around `colgroup` and `col` elements

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
