### PR TITLE
TINY-12087: add migration guide URL

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Deprecations.ts
@@ -1,6 +1,7 @@
-// TODO: add migration URL in ToggleToolbarDrawer message #TINY-12087
+const migrationFrom7x = 'https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/';
+
 const deprecatedFeatures = {
-  skipFocus: 'ToggleToolbarDrawer skipFocus is deprecated see migration guide: ....',
+  skipFocus: `ToggleToolbarDrawer skipFocus is deprecated see migration guide: ${migrationFrom7x}`,
 };
 
 const logFeatureDeprecationWarning = (feature: keyof typeof deprecatedFeatures): void => {


### PR DESCRIPTION
Related Ticket: TINY-12087

Description of Changes:
* Added migration URL for ToggleToolbarDrawer deprecation message
* Created a constant for the migration guide URL
* Updated the skipFocus deprecation message to use the new URL constant

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):