### PR TITLE
TINY-12150: Update `lib` in `tsconfig.shared.json` to `es2022` for access to newer JavaScript features

### DIFF
--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -3,7 +3,7 @@
     "moduleResolution": "node",
     "target": "es2018",
     "module": "es2015",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "importHelpers": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Related Ticket: [TINY-12150](https://ephocks.atlassian.net/browse/TINY-12150)

Description of Changes:
* This PR updates the `lib` in `tsconfig.shared.json` from `es2020` to `es2022` to enable TypeScript support for newer JavaScript features like top-level await and private class fields.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12150]: https://ephocks.atlassian.net/browse/TINY-12150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated TypeScript settings to use the ES2022 standard library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->