### PR TITLE
TINY-12118: fix context form back behavior for inline editors

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12118-2025-05-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-12118-2025-05-16.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The `contextform` subtoolbar was being dismissed when navigating back in inline editors.
+time: 2025-05-16T14:25:44.523886887+02:00
+custom:
+    Issue: TINY-12118

--- a/.changes/unreleased/tinymce-TINY-12118-2025-05-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-12118-2025-05-16.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: The `contextform` subtoolbar was being dismissed when navigating back in inline editors.
+body: The `contextform` subtoolbar is no longer dismissed when using the back button in inline editors.
 time: 2025-05-16T14:25:44.523886887+02:00
 custom:
     Issue: TINY-12118

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -68,6 +68,13 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     },
     onBack: () => {
       Events.fireContextFormSlideBack(editor);
+    },
+    focusElement: (el) => {
+      if (editor.getBody().contains(el.dom)) {
+        editor.focus();
+      } else {
+        Focus.focus(el);
+      }
     }
   });
 
@@ -152,8 +159,7 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     // ASSUMPTION: This should only ever show one context toolbar since it's used for context forms hence [toolbarApi]
     const alloySpec = buildToolbar([ toolbarApi ]);
     AlloyTriggers.emitWith(contextbar, forwardSlideEvent, {
-      forwardContents: wrapInPopDialog(alloySpec),
-      currentSelection: editor.selection.getNode()
+      forwardContents: wrapInPopDialog(alloySpec)
     });
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -152,7 +152,8 @@ const register = (editor: Editor, registryContextToolbars: Record<string, Contex
     // ASSUMPTION: This should only ever show one context toolbar since it's used for context forms hence [toolbarApi]
     const alloySpec = buildToolbar([ toolbarApi ]);
     AlloyTriggers.emitWith(contextbar, forwardSlideEvent, {
-      forwardContents: wrapInPopDialog(alloySpec)
+      forwardContents: wrapInPopDialog(alloySpec),
+      currentSelection: editor.selection.getNode()
     });
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -28,7 +28,7 @@ interface ContextToolbarSpec {
   readonly sink: AlloyComponent;
   readonly onHide: () => void;
   readonly onBack: () => void;
-  readonly focusElement: (el: SugarElement<any>) => void;
+  readonly focusElement: (el: SugarElement<HTMLElement>) => void;
 }
 
 export interface ContextToolbarRenderResult {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -3,7 +3,7 @@ import {
   SketchSpec
 } from '@ephox/alloy';
 import { Arr, Cell, Id, Optional, Result } from '@ephox/katamari';
-import { Class, Compare, Css, EventArgs, Focus, SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
+import { Class, Compare, Css, EventArgs, Focus, SugarElement, SugarNode, SugarShadowDom, Width } from '@ephox/sugar';
 
 import * as ContextToolbarFocus from './ContextToolbarFocus';
 
@@ -121,10 +121,13 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
 
         AlloyEvents.run<ForwardSlideEvent>(forwardSlideEvent, (comp, se) => {
           InlineView.getContent(comp).each((oldContents) => {
+            const isIframe = SugarNode.isTag('iframe');
+            const activeElement = Focus.active(SugarShadowDom.getRootNode(comp.element));
+            const hasSelectionInside = activeElement.exists((e) => !isIframe(e) && e.dom.contains(se.event.currentSelection));
             stack.set(stack.get().concat([
               {
                 bar: oldContents,
-                focus: Focus.active(SugarShadowDom.getRootNode(comp.element))
+                focus: hasSelectionInside ? Focus.active(SugarElement.fromDom(se.event.currentSelection)) : activeElement
               }
             ]));
           });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -3,7 +3,7 @@ import {
   SketchSpec
 } from '@ephox/alloy';
 import { Arr, Cell, Id, Optional, Result } from '@ephox/katamari';
-import { Class, Compare, Css, EventArgs, Focus, SugarElement, SugarNode, SugarShadowDom, Width } from '@ephox/sugar';
+import { Class, Compare, Css, EventArgs, Focus, SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
 
 import * as ContextToolbarFocus from './ContextToolbarFocus';
 
@@ -28,6 +28,7 @@ interface ContextToolbarSpec {
   readonly sink: AlloyComponent;
   readonly onHide: () => void;
   readonly onBack: () => void;
+  readonly focusElement: (el: SugarElement<any>) => void;
 }
 
 export interface ContextToolbarRenderResult {
@@ -107,7 +108,7 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
                 (active) => {
                   // We need this extra check since if the focus is aleady on the iframe we don't want to call focus on it again since that closes the context toolbar
                   if (!Compare.eq(active, f)) {
-                    Focus.focus(f);
+                    spec.focusElement(f);
                   }
                 }
               );
@@ -121,13 +122,10 @@ const renderContextToolbar = (spec: ContextToolbarSpec): ContextToolbarRenderRes
 
         AlloyEvents.run<ForwardSlideEvent>(forwardSlideEvent, (comp, se) => {
           InlineView.getContent(comp).each((oldContents) => {
-            const isIframe = SugarNode.isTag('iframe');
-            const activeElement = Focus.active(SugarShadowDom.getRootNode(comp.element));
-            const hasSelectionInside = activeElement.exists((e) => !isIframe(e) && e.dom.contains(se.event.currentSelection));
             stack.set(stack.get().concat([
               {
                 bar: oldContents,
-                focus: hasSelectionInside ? Focus.active(SugarElement.fromDom(se.event.currentSelection)) : activeElement
+                focus: Focus.active(SugarShadowDom.getRootNode(comp.element))
               }
             ]));
           });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormAsSubtoolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormAsSubtoolbarTest.ts
@@ -1,0 +1,170 @@
+import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.ContextFormAsSubtoolbarTest', () => {
+  Arr.each([ true, false ], (inline) => {
+    context(inline ? 'inline' : 'non-inline', () => {
+      const store = TestStore();
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        inline,
+        setup: (ed: Editor) => {
+          ed.ui.registry.addContextForm('alt-button', {
+            type: 'contextform',
+            launch: {
+              type: 'contextformbutton',
+              text: 'Alt',
+              tooltip: 'Alt'
+            },
+            label: 'Alt',
+            commands: [
+              {
+                type: 'contextformbutton',
+                align: 'start',
+                icon: 'chevron-left',
+                tooltip: 'back',
+                onAction: (formApi) => {
+                  formApi.back();
+                }
+              },
+              {
+                type: 'contextformtogglebutton',
+                align: 'start',
+                text: 'Decorative',
+                onAction: (formApi, buttonApi) => {
+                  buttonApi.setActive(!buttonApi.isActive());
+                  formApi.setInputEnabled(!formApi.isInputEnabled());
+                }
+              },
+              {
+                type: 'contextformbutton',
+                align: 'end',
+                icon: 'check',
+                onAction: (formApi, _buttonApi) => {
+                  formApi.back();
+                  ed.focus();
+                  store.add(ed.selection.getNode().nodeName);
+                }
+              }
+            ]
+          });
+
+          ed.ui.registry.addContextForm('slider', {
+            type: 'contextsliderform',
+            launch: {
+              type: 'contextformbutton',
+              text: 'Brightness',
+              tooltip: 'Brightness'
+            },
+            min: Fun.constant(-100),
+            max: Fun.constant(100),
+            initValue: Fun.constant(0),
+            label: 'Brightness',
+            commands: [
+              {
+                type: 'contextformbutton',
+                align: 'start',
+                icon: 'chevron-left',
+                tooltip: 'back',
+                onAction: (formApi) => {
+                  formApi.back();
+                }
+              },
+              {
+                type: 'contextformbutton',
+                primary: true,
+                text: 'Apply',
+                onAction: (formApi) => {
+                  formApi.back();
+                  ed.focus();
+                }
+              },
+              {
+                type: 'contextformbutton',
+                text: 'Reset',
+                onAction: (formApi) => {
+                  formApi.setValue(50);
+                }
+              }
+            ]
+          });
+
+          ed.ui.registry.addContextForm('size', {
+            type: 'contextsizeinputform',
+            launch: {
+              type: 'contextformbutton',
+              text: 'Size',
+              tooltip: 'Size'
+            },
+            initValue: () => ({ width: '400', height: '300' }),
+            label: 'Size',
+            commands: [
+              {
+                type: 'contextformbutton',
+                align: 'start',
+                icon: 'chevron-left',
+                tooltip: 'back',
+                onAction: (formApi) => {
+                  formApi.back();
+                }
+              },
+              {
+                type: 'contextformbutton',
+                text: 'Reset',
+                onAction: (formApi) => {
+                  formApi.setValue({ width: '400', height: '300' });
+                }
+              }
+            ]
+          });
+
+          ed.ui.registry.addContextToolbar('contexttoolbar1', {
+            predicate: (node) => node.nodeName === 'IMG' || node.nodeName === 'SPAN',
+            items: 'alt-button slider size',
+            position: 'node',
+            scope: 'node'
+          });
+        }
+      }, []);
+
+      const pGetToolbarButtonnByMceName = async (editor: Editor, dataMceName: string): Promise<SugarElement<HTMLButtonElement>> =>
+        await TinyUiActions.pWaitForUi(editor, `.tox-toolbar button[data-mce-name="${dataMceName}"]`) as SugarElement<HTMLButtonElement>;
+
+      const pClickToolbarButtonByMceName = async (editor: Editor, dataMceName: string): Promise<void> => (await (pGetToolbarButtonnByMceName(editor, dataMceName))).dom.click();
+
+      const pGetToolbarButtonnByAriaName = async (editor: Editor, dataAriaName: string): Promise<SugarElement<HTMLButtonElement>> =>
+        await TinyUiActions.pWaitForUi(editor, `.tox-toolbar button[aria-label="${dataAriaName}"]`) as SugarElement<HTMLButtonElement>;
+
+      const pClickToolbarButtonByAriaName = async (editor: Editor, dataAriaName: string): Promise<void> => (await (pGetToolbarButtonnByAriaName(editor, dataAriaName))).dom.click();
+
+      const testButtonBack = async (dataMceName: string) => {
+        const editor = hook.editor();
+        editor.setContent('<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" width="50" height="25"><span>some span</span></p>');
+        editor.focus();
+
+        TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+        Mouse.trueClickOn(TinyDom.body(editor), 'img');
+
+        await TinyUiActions.pWaitForUi(editor, `.tox-toolbar button[data-mce-name="${dataMceName}"]`);
+
+        await pClickToolbarButtonByMceName(editor, dataMceName);
+        await pClickToolbarButtonByAriaName(editor, 'back');
+        // this is needed because in case of fail the toolbar needs time to disapear
+        await Waiter.pWait(50);
+
+        await UiFinder.pWaitFor('toolbar should still be present', SugarBody.body(), `.tox-toolbar button[data-mce-name="${dataMceName}"]`);
+      };
+
+      it(`TINY-12118: pressing back from a context toolbar should show the previous toolbar (alt-button: ${inline ? 'inline' : 'not-inline'})`, async () => await testButtonBack('alt-button'));
+
+      it(`TINY-12118: pressing back from a context toolbar should show the previous toolbar (slider: ${inline ? 'inline' : 'not-inline'})`, async () => await testButtonBack('slider'));
+
+      it(`TINY-12118: pressing back from a context toolbar should show the previous toolbar (size: ${inline ? 'inline' : 'not-inline'})`, async () => await testButtonBack('size'));
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-12118

Description of Changes:
Here the problem was that in non-inline editors the active element returned by `Focus.active(SugarShadowDom.getRootNode(comp.element))` was always the `iframe` and focussing it again the focus remains on the real focussed element (an image for example) but in the inline editors it returned the `div` container and focussing it back the focus goes on the `div` so if the selection was on an image the focus get lost and the toolbar get dismissed.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the context form subtoolbar was dismissed unexpectedly when navigating back in inline editors, ensuring the subtoolbar remains visible as expected.

- **Tests**
  - Introduced new automated tests to verify context form subtoolbar behavior in both inline and non-inline editors, ensuring correct toolbar visibility when using navigation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->