### PR TITLE
TINY-12038: fix restoring focus to the triggger button 

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/WindowManager.ts
+++ b/modules/tinymce/src/core/main/ts/api/WindowManager.ts
@@ -91,8 +91,8 @@ const WindowManager = (editor: Editor): WindowManager => {
   const closeDialog = <T extends Dialog.DialogData>(dialog: InstanceApi<T>) => {
     fireCloseEvent(dialog);
 
-    dialogs = Arr.filter(dialogs, ({ instanceApi }) => instanceApi !== dialog);
     const dialogTriggerElement = Arr.findMap(dialogs, ({ instanceApi, triggerElement }) => instanceApi === dialog ? triggerElement : Optional.none());
+    dialogs = Arr.filter(dialogs, ({ instanceApi }) => instanceApi !== dialog);
 
     // Move focus back to editor when the last window is closed
     if (dialogs.length === 0) {

--- a/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/WindowManagerTest.ts
@@ -83,7 +83,12 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
             title: 'Dialog 2',
             body: {
               type: 'panel',
-              items: []
+              items: [
+                {
+                  type: 'input',
+                  name: 'input',
+                }
+              ]
             },
             buttons: []
           });
@@ -100,6 +105,7 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
 
     Mouse.trueClickOn(SugarBody.body(), triggerButtonSelector);
     await TinyUiActions.pWaitForPopup(editor, '.tox-confirm-dialog');
+    await FocusTools.pTryOnSelector('Focus should be inside confirmation dialog', SugarDocument.getDocument(), '[role="dialog"].tox-confirm-dialog button:contains("Yes")');
     TinyUiActions.clickOnUi(editor, '[role="dialog"].tox-confirm-dialog button:contains("Yes")');
 
     await FocusTools.pTryOnSelector('Focus should be restored to the trigger button', SugarDocument.getDocument(), triggerButtonSelector);
@@ -114,6 +120,7 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
 
     Mouse.trueClickOn(SugarBody.body(), triggerButtonSelector);
     await TinyUiActions.pWaitForPopup(editor, '.tox-alert-dialog');
+    await FocusTools.pTryOnSelector('Focus should be inside alert dialog', SugarDocument.getDocument(), '[role="dialog"].tox-alert-dialog button:contains("OK")');
     TinyUiActions.clickOnUi(editor, '[role="dialog"].tox-alert-dialog button:contains("OK")');
 
     await FocusTools.pTryOnSelector('Focus should be restored to the trigger button', SugarDocument.getDocument(), triggerButtonSelector);
@@ -128,6 +135,7 @@ describe('browser.tinymce.core.WindowManagerTest', () => {
 
     Mouse.trueClickOn(SugarBody.body(), triggerButtonSelector);
     await TinyUiActions.pWaitForDialogByTitle(editor, 'Dialog 2');
+    await FocusTools.pTryOnSelector('Focus should be inside Dialog 2', SugarDocument.getDocument(), 'input');
     TinyUiActions.closeDialogByTitle(editor, 'Dialog 2');
 
     await FocusTools.pTryOnSelector('Focus should be restored to the trigger button', SugarDocument.getDocument(), triggerButtonSelector);


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Fixed a bug in the WindowManager where the dialog trigger element was being lost while filtering the dialogs array.
* Added focus tests to ensure focus is properly set inside dialogs before closing them. This should remove false positives from before.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dialog closing behavior to ensure correct focus management when dialogs are closed.

- **Tests**
  - Enhanced tests to verify that focus is properly set on dialog elements during interactions and returns to the trigger button after dialogs close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->