### PR TITLE
TINY-12125: Toolbar drawer closes when the editor loses focus 

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12125-2025-05-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-12125-2025-05-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Toolbar drawer now closes when the editor loses focus.
+time: 2025-05-19T19:50:54.021145+02:00
+custom:
+    Issue: TINY-12125

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -489,6 +489,12 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     });
 
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));
+
+    editor.on('blur', (_e) => {
+      if (Options.getToolbarMode(editor) === Options.ToolbarMode.floating && OuterContainer.isToolbarDrawerToggled(outerContainer)) {
+        OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);
+      }
+    });
   };
 
   const renderUIWithRefs = (uiRefs: ReadyUiReferences): ModeRenderInfo => {

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -490,7 +490,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
 
     editor.addQueryStateHandler('ToggleToolbarDrawer', () => OuterContainer.isToolbarDrawerToggled(outerContainer));
 
-    editor.on('blur', (_e) => {
+    editor.on('blur', () => {
       if (Options.getToolbarMode(editor) === Options.ToolbarMode.floating && OuterContainer.isToolbarDrawerToggled(outerContainer)) {
         OuterContainer.toggleToolbarDrawerWithoutFocusing(outerContainer);
       }

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -185,4 +185,46 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarDrawerToggleTest',
       });
     });
   });
+
+  it('TINY-12125: Toolbar drawer should close when the editor loses focus', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      menubar: false,
+      statusbar: false,
+      width: 200,
+      toolbar_mode: 'floating',
+      base_url: '/project/tinymce/js/tinymce'
+    });
+    await UiUtils.pWaitForEditorToRender();
+
+    assertToolbarToggleState(editor, false);
+
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="overflow-button"]');
+    await pWaitForOverflowToolbar(editor, 'floating');
+
+    editor.dispatch('blur');
+
+    assertToolbarToggleState(editor, false);
+    McEditor.remove(editor);
+  });
+
+  it('TINY-12125: Toolbar drawer should stay open when the editor loses focus if the toolbar is in sliding mode', async () => {
+    const editor = await McEditor.pFromSettings<Editor>({
+      menubar: false,
+      statusbar: false,
+      width: 200,
+      toolbar_mode: 'sliding',
+      base_url: '/project/tinymce/js/tinymce'
+    });
+    await UiUtils.pWaitForEditorToRender();
+
+    assertToolbarToggleState(editor, false);
+
+    TinyUiActions.clickOnUi(editor, 'button[data-mce-name="overflow-button"]');
+    await pWaitForOverflowToolbar(editor, 'sliding');
+
+    editor.dispatch('blur');
+
+    await pWaitForOverflowToolbar(editor, 'sliding');
+    McEditor.remove(editor);
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -85,8 +85,20 @@ const testStickyHeader = (toolbarMode: ToolbarMode, toolbarLocation: ToolbarLoca
         }
       });
 
+      beforeEach(async () => {
+        const editor = hook.editor();
+
+        // Open the more drawer if it was closed during the previous test
+        if (toolbarMode !== ToolbarMode.default && !editor.queryCommandState('ToggleToolbarDrawer')) {
+          await MenuUtils.pOpenMore(toolbarMode);
+          MenuUtils.assertMoreDrawerInViewport(toolbarMode);
+        }
+      });
+
       after(async () => {
-        if (toolbarMode !== ToolbarMode.default) {
+        const editor = hook.editor();
+
+        if (toolbarMode !== ToolbarMode.default && editor.queryCommandState('ToggleToolbarDrawer')) {
           await MenuUtils.pCloseMore(toolbarMode);
         }
       });


### PR DESCRIPTION
Related Ticket: TINY-12125

Description of Changes:
* Added functionality to close the toolbar drawer when the editor loses focus
* Added a test case to verify the toolbar drawer closes on editor blur

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Improved**
  - The toolbar drawer now automatically closes when the editor loses focus in floating mode.  
- **Tests**
  - Added tests confirming the toolbar drawer closes on editor blur in floating mode and stays open in sliding mode.  
- **Documentation**
  - Updated the changelog to document the toolbar drawer behavior enhancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->