### PR TITLE
TINY-11974: Update return type of `fetchUsers` and add avatar generation logic

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -1,5 +1,6 @@
 
 import { UploadHandler } from '../file/Uploader';
+import { ExpectedUser } from '../lookup/UserLookup';
 import { DynamicPatternsLookup, Pattern, RawDynamicPatternsLookup, RawPattern } from '../textpatterns/core/PatternTypes';
 
 import Editor from './Editor';
@@ -110,6 +111,7 @@ interface BaseEditorOptions {
   extended_mathml_elements?: string[];
   extended_valid_elements?: string;
   event_root?: string;
+  fetch_users?: (userIds: string[]) => Promise<ExpectedUser[]>;
   file_picker_callback?: FilePickerCallback;
   file_picker_types?: string;
   file_picker_validator_handler?: FilePickerValidationCallback;
@@ -215,6 +217,7 @@ interface BaseEditorOptions {
   style_formats_merge?: boolean;
   submit_patch?: boolean;
   suffix?: string;
+  user_id?: string;
   table_tab_navigation?: boolean;
   target?: HTMLElement;
   text_patterns?: RawPattern[] | false;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -919,7 +919,7 @@ const register = (editor: Editor): void => {
       }
       return {
         valid: false,
-        message: 'fetch_users must be a function that returns a Promise<User[]>'
+        message: 'fetch_users must be a function that returns a Promise<ExpectedUser[]>'
       };
     }
   });

--- a/modules/tinymce/src/core/main/ts/api/PublicApi.ts
+++ b/modules/tinymce/src/core/main/ts/api/PublicApi.ts
@@ -1,5 +1,5 @@
 import { Bookmark } from '../bookmark/BookmarkTypes';
-import type { User } from '../lookup/UserLookup';
+import type { User, ExpectedUser } from '../lookup/UserLookup';
 import { UndoManager } from '../undo/UndoManagerTypes';
 
 import AddOnManager from './AddOnManager';
@@ -136,5 +136,6 @@ export {
   Theme,
   Model,
   WriterSettings,
-  User
+  User,
+  ExpectedUser
 };

--- a/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
+++ b/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
@@ -202,7 +202,7 @@ const UserLookup = (editor: Editor): UserLookup => {
           ...user,
           id: user.id,
           name: Optional.from(user.name).getOr(user.id),
-          avatar: Optional.from(user.avatar).getOr(deriveAvatar(user.name)),
+          avatar: Optional.from(user.avatar).getOr(deriveAvatar(user.id)),
         });
         pendingResolvers.delete(userId);
       });

--- a/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
+++ b/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
@@ -46,7 +46,6 @@ export interface ValidatedUser {
   id: UserId;
   name: Optional<string>;
   avatar: Optional<string>;
-  description: Optional<string>;
   custom: Optional<Record<string, any>>;
 }
 
@@ -122,7 +121,6 @@ const userSchema = StructureSchema.objOf([
   FieldSchema.required('id'),
   FieldSchema.optionString('name'),
   FieldSchema.optionString('avatar'),
-  FieldSchema.optionString('description'),
   FieldSchema.option('custom')
 ]);
 

--- a/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
+++ b/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
@@ -150,7 +150,7 @@ const UserLookup = (editor: Editor): UserLookup => {
       return [];
     }
 
-    const uncachedIds = Arr.filter(userIds, (userId) => !lookup(userId).isSome());
+    const uncachedIds = Arr.unique(Arr.filter((userIds), (userId) => !lookup(userId).isSome()));
 
     Arr.each(uncachedIds, (userId) => {
       const newPromise = new Promise<User>((resolve, reject) => {

--- a/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
+++ b/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
@@ -251,16 +251,16 @@ const UserLookup = (editor: Editor): UserLookup => {
         });
     };
 
-    return userIds.reduce((acc, userId) => ({
-      ...acc,
-      [userId]: lookup(userId).getOr(
+    return Arr.foldl<UserId, Record<UserId, Promise<User>>>(userIds, (acc, userId) => {
+      acc[userId] = lookup(userId).getOr(
         Promise.resolve({
           id: userId,
           name: userId,
           avatar: deriveAvatar(userId)
         })
-      ),
-    }), {} as Record<UserId, Promise<User>>);
+      );
+      return acc;
+    }, {});
   };
 
   const userId = Options.getUserId(editor);

--- a/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
+++ b/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
@@ -223,7 +223,7 @@ const UserLookup = (editor: Editor): UserLookup => {
       store(newPromise, userId);
     });
 
-    if (uncachedIds.length > 0 && fetchUsersFn) {
+    if (uncachedIds.length > 0) {
       fetchUsersFn(uncachedIds)
         .then(validateResponse)
         .then((users: User[]) => {

--- a/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
+++ b/modules/tinymce/src/core/main/ts/lookup/UserLookup.ts
@@ -199,8 +199,8 @@ const UserLookup = (editor: Editor): UserLookup => {
         resolve({
           ...user,
           id: user.id,
-          name: Optional.from(user.name).getOr(user.id),
-          avatar: Optional.from(user.avatar).getOr(deriveAvatar(user.id)),
+          name: user.name,
+          avatar: user.avatar,
         });
         pendingResolvers.delete(userId);
       });

--- a/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
@@ -250,15 +250,17 @@ describe('browser.tinymce.core.UserLookupTest', () => {
             id: 'user-3',
             name: undefined,
             avatar: null,
-            description: '',
-            custom: {}
+            custom: {
+              description: ''
+            }
           },
           expected: {
             id: 'user-3',
             name: 'user-3',
             avatar: (value: string) => value.startsWith('data:image/svg+xml,'),
-            description: '',
-            custom: {}
+            custom: {
+              description: ''
+            }
           }
         },
         {
@@ -266,14 +268,16 @@ describe('browser.tinymce.core.UserLookupTest', () => {
             id: 'user-4',
             name: 'Jane',
             avatar: 'avatar.jpg',
-            description: null,
-            custom: { role: 'admin' }
+            custom: {
+              role: 'admin',
+              description: null
+            }
           },
           expected: {
             id: 'user-4',
             name: 'Jane',
             avatar: 'avatar.jpg',
-            custom: { role: 'admin' }
+            custom: { role: 'admin', description: null }
           }
         }
       ];
@@ -307,10 +311,10 @@ describe('browser.tinymce.core.UserLookupTest', () => {
         id: userId,
         name: 'Test User',
         avatar: 'test-avatar.png',
-        description: 'Test Description',
         custom: {
           role: 'admin',
-          department: 'IT'
+          department: 'IT',
+          description: 'Test Description',
         }
       }]));
 
@@ -321,10 +325,10 @@ describe('browser.tinymce.core.UserLookupTest', () => {
         id: userId,
         name: 'Test User',
         avatar: 'test-avatar.png',
-        description: 'Test Description',
         custom: {
           role: 'admin',
-          department: 'IT'
+          department: 'IT',
+          description: 'Test Description'
         }
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
@@ -11,18 +11,25 @@ import { createUserLookup, type User } from 'tinymce/core/lookup/UserLookup';
 
 Chai.use(chaiAsPromised);
 
+interface ExpectedUser {
+  id: string;
+  [key: string]: any;
+};
+
 const createMockUser = (id: string): User => ({
   id,
   name: 'Test User',
   avatar: 'test-avatar.png',
-  description: 'Test Description'
+  custom: {
+    description: 'Test Description'
+  }
 });
 
 describe('browser.tinymce.core.UserLookupTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     user_id: 'test-user-1',
-    fetch_users: (userIds: string[]): Promise<User[]> => {
+    fetch_users: (userIds: string[]): Promise<ExpectedUser[]> => {
       return new Promise((resolve) => {
         setTimeout(() => {
           const validIds = Arr.filter(userIds, (id): id is string =>
@@ -123,7 +130,9 @@ describe('browser.tinymce.core.UserLookupTest', () => {
         id: userId,
         name: 'Test User',
         avatar: 'test-avatar.png',
-        description: 'Test Description'
+        custom: {
+          description: 'Test Description'
+        }
       };
 
       await expect(userPromise).to.eventually.deep.equal(
@@ -159,7 +168,9 @@ describe('browser.tinymce.core.UserLookupTest', () => {
         id: existingId,
         name: 'Test User',
         avatar: 'test-avatar.png',
-        description: 'Test Description'
+        custom: {
+          description: 'Test Description'
+        }
       });
 
       await expect(nonExistentPromise).to.be.rejectedWith(`User ${nonExistentId} not found`);

--- a/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
@@ -7,14 +7,9 @@ import { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import type Editor from 'tinymce/core/api/Editor';
-import { createUserLookup, type User } from 'tinymce/core/lookup/UserLookup';
+import { createUserLookup, type User, type ExpectedUser } from 'tinymce/core/lookup/UserLookup';
 
 Chai.use(chaiAsPromised);
-
-interface ExpectedUser {
-  id: string;
-  [key: string]: any;
-};
 
 const createMockUser = (id: string): User => ({
   id,

--- a/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/lookup/UserLookupTest.ts
@@ -47,7 +47,7 @@ describe('browser.tinymce.core.UserLookupTest', () => {
     },
   });
 
-  let originalFetchUsers: (userIds: string[]) => Promise<User[]>;
+  let originalFetchUsers: ((userIds: string[]) => Promise<ExpectedUser[]>) | undefined;
 
   before(() => {
     const editor = hook.editor();
@@ -212,7 +212,7 @@ describe('browser.tinymce.core.UserLookupTest', () => {
       const userIds = Arr.range(100, (i) => `test-user-${i}`);
 
       const promises = editor.userLookup.fetchUsers(userIds);
-      const users = await Promise.all(Arr.map(userIds, (id) => promises[id]));
+      const users = await Promise.all(Object.values(promises));
 
       await Promise.all(Arr.map(users, async (user, index) =>
         expect(Promise.resolve(user)).to.eventually.have.property('id').that.equals(`test-user-${index}`)
@@ -287,7 +287,7 @@ describe('browser.tinymce.core.UserLookupTest', () => {
 
       const userIds = Arr.map(testCases, (c) => c.input.id);
       const promises = editor.userLookup.fetchUsers(userIds);
-      const results = await Promise.all(Arr.map(userIds, (id) => promises[id]));
+      const results = await Promise.all(Object.values(promises));
 
       Arr.each(results, (result, index) => {
         const expected = testCases[index].expected;
@@ -434,20 +434,6 @@ describe('browser.tinymce.core.UserLookupTest', () => {
 
       // Verify fetch count
       store.assertEq('Should fetch exactly twice - once for each unique ID', [ userId1, userId2 ]);
-    });
-
-    it('TINY-11974: Should throw an exception when fetch_users has not been configured', () => {
-      const editor = hook.editor();
-
-      editor.options.unset('fetch_users');
-
-      editor.userLookup = createUserLookup(editor);
-
-      const userIds = [ 'test-user-1' ];
-
-      expect(() => {
-        editor.userLookup.fetchUsers(userIds);
-      }).to.throw('fetch_users option must be configured');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: [TINY-11974](https://ephocks.atlassian.net/browse/TINY-11974)

Description of Changes:
* Upon using the `UserLookup` API we discovered that knowing which promise in the `Promise<User>[]` belonged to which user was difficult as we would need to wait for a promise to resolve before knowing its `id`. We've revised the return type to be a `Record<UserId, Promise<User>>` such that even if the promise hasn't been resolved, we will always know which promise is associated with a specific user. The tests were also updated accordingly to work with this new expected return type.
* We also added centralized avatar generation logic, removing the need for a custom implementation across various plugins.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-11974]: https://ephocks.atlassian.net/browse/TINY-11974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ