### PR TITLE
TINY-11753: fix tab selection inside caption

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11753-2025-05-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11753-2025-05-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tabbing when a `figure` was selected didn't move the selection on the `figcaption` correctly.
+time: 2025-05-20T11:04:03.717927963+02:00
+custom:
+    Issue: TINY-11753

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -161,7 +161,8 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     });
 
     editor.on('focusin', (e) => {
-      if (e.target.textContent && editor.getBody().contains(e.target) && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
+      // for medias the selection is already managed in `MediaFocus.ts`
+      if (!NodeType.isMedia(e.target) && editor.getBody().contains(e.target) && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
         if (fakeCaret.isShowing()) {
           fakeCaret.hide();
         }

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -161,9 +161,10 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
     });
 
     editor.on('focusin', (e) => {
-      if (fakeCaret.isShowing() && editor.getBody().contains(e.target) && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
-        fakeCaret.hide();
-
+      if (e.target.textContent && editor.getBody().contains(e.target) && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
+        if (fakeCaret.isShowing()) {
+          fakeCaret.hide();
+        }
         if (!e.target.contains(editor.selection.getNode())) {
           editor.selection.select(e.target, true);
           editor.selection.collapse(true);


### PR DESCRIPTION
Related Ticket: TINY-11753

Description of Changes:
the problem was similar to this: https://github.com/tinymce/tinymce/pull/10282 but starting from the `figure` selection instead of before the `figure`, to solve it I changed the check removing the `fakeCaret.isShowing()` and replaced it with `e.target.textContent` this because removing only the fakeCaret check it would change the selection also for cases like [this one](https://github.com/tinymce/tinymce/blob/main/modules/tinymce/src/core/test/ts/browser/focus/MediaFocusTest.ts#L20) trying to move the selection "inside" an element that doesn't have an "inside"

about the tests, since I couldn't find a way to simulate the exac behavior of the `tab` without using the webdriver tests

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard navigation by ensuring that pressing Tab moves the selection from a selected figure to its figcaption, enhancing accessibility and user experience within the editor.
  - Fixed caret visibility behavior to better support media elements, improving selection handling and interaction within the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->