### PR TITLE
TINY-11927: Parse invalid content with full structure

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11927-2025-05-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-11927-2025-05-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Inserting HTML fragments with invalid contents now retains more of the structure.
+time: 2025-05-15T13:38:04.735513+02:00
+custom:
+    Issue: TINY-11927

--- a/.changes/unreleased/tinymce-TINY-11927-2025-05-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-11927-2025-05-16.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: DomParser no longer tries to fix some nodes when parsed with a context.
+time: 2025-05-16T13:38:04.735513+02:00
+custom:
+    Issue: TINY-11927

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -491,9 +491,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     // Fix invalid children or report invalid children in a contextual parsing
     if (validate && invalidChildren.length > 0) {
       if (args.context) {
-        const { pass: topLevelChildren, fail: otherChildren } = Arr.partition(invalidChildren, (child) => child.parent === rootNode);
-        InvalidNodes.cleanInvalidNodes(otherChildren, schema, rootNode, matchFinder);
-        args.invalid = topLevelChildren.length > 0;
+        args.invalid = true;
       } else {
         InvalidNodes.cleanInvalidNodes(invalidChildren, schema, rootNode, matchFinder);
       }

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -379,10 +379,9 @@ export const insertHtmlAtCaret = (editor: Editor, value: string, details: Insert
     const editingHost = markerNode.bind(ParserUtils.findClosestEditingHost).getOr(root);
     markerNode.each((marker) => marker.replace(fragment));
 
-    const toExtract = fragment.children();
-    const parent = fragment.parent ?? root;
+    const fragmentNodes = ParserUtils.getAllDescendants(fragment);
     fragment.unwrap();
-    const invalidChildren = Arr.filter(toExtract, (node) => InvalidNodes.isInvalid(editor.schema, node, parent));
+    const invalidChildren = Arr.filter(fragmentNodes, (node) => InvalidNodes.isInvalid(editor.schema, node));
     InvalidNodes.cleanInvalidNodes(invalidChildren, editor.schema, editingHost);
     FilterNode.filter(parser.getNodeFilters(), parser.getAttributeFilters(), root);
     value = serializer.serialize(root);

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -52,11 +52,22 @@ const findClosestEditingHost = (scope: AstNode): Optional<AstNode> => {
   return Optional.from(editableNode);
 };
 
+const getAllDescendants = (scope: AstNode): AstNode[] => {
+  const collection: AstNode[] = [];
+
+  for (let node = scope.firstChild; node; node = node.walk()) {
+    collection.push(node);
+  }
+
+  return collection;
+};
+
 export {
   paddEmptyNode,
   isPaddedWithNbsp,
   hasOnlyChild,
   isEmpty,
   isLineBreakNode,
-  findClosestEditingHost
+  findClosestEditingHost,
+  getAllDescendants
 };

--- a/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
+++ b/modules/tinymce/src/core/main/ts/html/ParserUtils.ts
@@ -55,7 +55,7 @@ const findClosestEditingHost = (scope: AstNode): Optional<AstNode> => {
 const getAllDescendants = (scope: AstNode): AstNode[] => {
   const collection: AstNode[] = [];
 
-  for (let node = scope.firstChild; node; node = node.walk()) {
+  for (let node = scope.firstChild; Type.isNonNullable(node); node = node.walk()) {
     collection.push(node);
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/InsertContentTest.ts
@@ -557,14 +557,13 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
       editor,
       '<table>' +
         '<button>' +
-          '<a>' +
-            '<meta>' +
-            '</meta>' +
+          '<a href="#">' +
+            '<meta>foo</meta>' +
           '</a>' +
         '</button>' +
       '</table>'
     );
-    TinyAssertions.assertContent(editor, '');
+    TinyAssertions.assertContent(editor, '<p><button><a href="#">foo</a></button></p>');
 
     editor.setContent('');
     TinySelections.setCursor(editor, [ 0 ], 0);
@@ -578,8 +577,8 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
                 '<button>' +
                   '<img/>' +
                   '<button>' +
-                    '<a>' +
-                      '<meta></meta>' +
+                    '<a href="#">' +
+                      '<meta>foo</meta>' +
                     '</a>' +
                   '</button>' +
                   '<img/>' +
@@ -600,7 +599,7 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
               '<button>' +
                 '<img>' +
               '</button>' +
-              '<button></button>' +
+              '<button><a href="#">foo</a></button>' +
               '<img>' +
             '</td>' +
           '</tr>' +
@@ -684,6 +683,15 @@ describe('browser.tinymce.core.content.insert.InsertContentTest', () => {
     editor.insertContent('X');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 1);
     TinyAssertions.assertContent(editor, '<p>X</p>');
+  });
+
+  it('TINY-11927: Inserting invalid content should clean away invalid children', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>ad</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    editor.insertContent('<b><summary>bc</summary></b>');
+    TinyAssertions.assertContentPresence(editor, { summary: 0 });
+    TinyAssertions.assertContent(editor, '<p>a<strong>bc</strong>d</p>');
   });
 
   context('Transparent blocks', () => {


### PR DESCRIPTION
Related Ticket: TINY-11927

Description of Changes:
* Changes so context parsing is just validating as it was before 6
* Inserts the fragment and re-evalulates the the validness of the nodes when it's in place of the whole structure.
* Changed some tests to match the new or basically the old behaviour of 5.
* Added two changelog items since this is both fixing a bug and altering the behaviour of the parser slighlty.
* Added new tests for the customer cases.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of HTML fragments with invalid content, ensuring the editor preserves more of the original structure during insertion.
  - When parsing with a specific context, invalid nodes are now retained and the content is marked as invalid, rather than being automatically fixed.

- **New Features**
  - Enhanced detection and cleaning of invalid nodes during content insertion for more accurate content preservation.

- **Tests**
  - Expanded and reorganized test coverage for scenarios involving invalid HTML content insertion and parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->