### PR TITLE
TINY-12004: Normalize tag order of strikethrough/font size

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12004-2025-05-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-12004-2025-05-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Strikethrough elements was not always placed inside font size altering elements when applying formatting or pasting contents.
+time: 2025-05-23T13:10:50.881205+02:00
+custom:
+    Issue: TINY-12004

--- a/.changes/unreleased/tinymce-TINY-12004-2025-05-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-12004-2025-05-23.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Strikethrough elements was not always placed inside font size altering elements when applying formatting or pasting contents.
+body: Strikethrough format could be added outside font size format, which renders incorrectly in some browsers.
 time: 2025-05-23T13:10:50.881205+02:00
 custom:
     Issue: TINY-12004

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -196,6 +196,16 @@ export const findIndex = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optiona
   return Optional.none();
 };
 
+export const findLastIndex = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<number> => {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (pred(arr[i], i)) {
+      return Optional.some(i);
+    }
+  }
+
+  return Optional.none();
+};
+
 export const flatten = <T>(xs: ArrayLike<T[]>): T[] => {
   // Note, this is possible because push supports multiple arguments:
   // http://jsperf.com/concat-push/6

--- a/modules/katamari/src/test/ts/atomic/api/arr/FindLastIndexTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/FindLastIndexTest.ts
@@ -1,0 +1,74 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+import fc from 'fast-check';
+
+import * as Arr from 'ephox/katamari/api/Arr';
+import * as Fun from 'ephox/katamari/api/Fun';
+import { arbNegativeInteger } from 'ephox/katamari/test/arb/ArbDataTypes';
+import { assertNone, assertOptional, assertSome } from 'ephox/katamari/test/AssertOptional';
+
+describe('atomic.katamari.api.arr.FindLastIndexTest', () => {
+  it('unit tests', () => {
+    const checkNoneHelper = (input: ArrayLike<number>, pred: (x: number) => boolean): void => {
+      assertNone(Arr.findLastIndex(input, pred));
+    };
+
+    const checkNone = (input: number[], pred: (x: number) => boolean): void => {
+      checkNoneHelper(input, pred);
+      checkNoneHelper(Object.freeze(input.slice()), pred);
+    };
+
+    const checkHelper = (expected: number, input: ArrayLike<number>, pred: (x: number) => boolean): void => {
+      assertSome(Arr.findLastIndex(input, pred), expected);
+    };
+
+    const check = (expected: number, input: number[], pred: (x: number) => boolean): void => {
+      checkHelper(expected, input, pred);
+      checkHelper(expected, Object.freeze(input), pred);
+    };
+
+    checkNone([], (x) => x > 0);
+    checkNone([ -1 ], (x) => x > 0);
+    check(0, [ 1 ], (x) => x > 0);
+    check(3, [ 4, 2, 10, 41, 3 ], (x) => x === 41);
+    check(5, [ 4, 2, 10, 41, 3, 100 ], (x) => x > 80);
+    checkNone([ 4, 2, 10, 412, 3 ], (x) => x === 41);
+  });
+
+  describe('finds element in middle of array', () => {
+    fc.assert(fc.property(fc.array(fc.nat()), arbNegativeInteger(), fc.array(fc.nat()), (prefix, element, suffix) => {
+      const arr = [ ...prefix, element, ...suffix ];
+      assertSome(
+        Arr.findLastIndex(arr, (x) => x === element),
+        prefix.length
+      );
+    }));
+  });
+
+  it('finds elements that pass the predicate', () => {
+    fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
+      const pred = (x: number) => x % 3 === 0;
+      assert.isTrue(Arr.findLastIndex(arr, pred).forall((x) => pred(arr[x])));
+    }));
+  });
+
+  it('returns none if predicate always returns false', () => {
+    fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
+      assertNone(Arr.findLastIndex(arr, Fun.never));
+    }));
+  });
+
+  it('is consistent with find in reverse', () => {
+    fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
+      const pred = (x: number) => x % 5 === 0;
+      assertOptional(Arr.findLastIndex(arr, pred).map((x) => arr[x]), Arr.find(Arr.reverse(arr), pred));
+    }));
+  });
+
+  it('is consistent with exists', () => {
+    fc.assert(fc.property(fc.array(fc.integer()), (arr) => {
+      const pred = (x: number) => x % 6 === 0;
+      assert.equal(Arr.findLastIndex(arr, pred).isSome(), Arr.exists(arr, pred));
+    }));
+  });
+});

--- a/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
@@ -1,5 +1,3 @@
-import { Global } from '@ephox/katamari';
-
 import DOMUtils from '../api/dom/DOMUtils';
 import * as NodeType from '../dom/NodeType';
 
@@ -118,9 +116,6 @@ const resolveBookmark = (bookmark: Bookmark): Range => {
 
   return NormalizeBookmarkPoint.normalizeRange(rng);
 };
-
-Global.createBookmark = createBookmark;
-Global.resolveBookmark = resolveBookmark;
 
 export {
   createBookmark,

--- a/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
@@ -1,0 +1,125 @@
+import DOMUtils from '../api/dom/DOMUtils';
+import * as NodeType from '../dom/NodeType';
+
+import * as NormalizeBookmarkPoint from './NormalizeBookmarkPoint';
+
+// TODO: This is a clone of the list bookmark code if we move lists to core then de-duplicate this
+
+const DOM = DOMUtils.DOM;
+
+interface Bookmark {
+  startContainer: Node;
+  startOffset: number;
+  endContainer?: Node;
+  endOffset?: number;
+}
+
+/**
+ * Returns a range bookmark. This will convert indexed bookmarks into temporary span elements with
+ * index 0 so that they can be restored properly after the DOM has been modified. Text bookmarks will not have spans
+ * added to them since they can be restored after a dom operation.
+ *
+ * So this: <p><b>|</b><b>|</b></p>
+ * becomes: <p><b><span data-mce-type="bookmark">|</span></b><b data-mce-type="bookmark">|</span></b></p>
+ */
+const createBookmark = (rng: Range): Bookmark => {
+  const bookmark: Partial<Bookmark> = {};
+
+  const setupEndPoint = (start?: boolean) => {
+    let container = rng[start ? 'startContainer' : 'endContainer'];
+    let offset = rng[start ? 'startOffset' : 'endOffset'];
+
+    if (NodeType.isElement(container)) {
+      const offsetNode = DOM.create('span', { 'data-mce-type': 'bookmark' });
+
+      if (container.hasChildNodes()) {
+        offset = Math.min(offset, container.childNodes.length - 1);
+
+        if (start) {
+          container.insertBefore(offsetNode, container.childNodes[offset]);
+        } else {
+          DOM.insertAfter(offsetNode, container.childNodes[offset]);
+        }
+      } else {
+        container.appendChild(offsetNode);
+      }
+
+      container = offsetNode;
+      offset = 0;
+    }
+
+    bookmark[start ? 'startContainer' : 'endContainer'] = container;
+    bookmark[start ? 'startOffset' : 'endOffset'] = offset;
+  };
+
+  setupEndPoint(true);
+
+  if (!rng.collapsed) {
+    setupEndPoint();
+  }
+
+  return bookmark as Bookmark;
+};
+
+const resolveBookmark = (bookmark: Bookmark): Range => {
+  const restoreEndPoint = (start?: boolean) => {
+    const nodeIndex = (container: Node): number => {
+      let node = container.parentNode?.firstChild;
+      let idx = 0;
+
+      while (node) {
+        if (node === container) {
+          return idx;
+        }
+
+        // Skip data-mce-type=bookmark nodes
+        if (!NodeType.isElement(node) || node.getAttribute('data-mce-type') !== 'bookmark') {
+          idx++;
+        }
+
+        node = node.nextSibling;
+      }
+
+      return -1;
+    };
+
+    let container: Node | null | undefined = bookmark[start ? 'startContainer' : 'endContainer'];
+    let offset = bookmark[start ? 'startOffset' : 'endOffset'];
+
+    if (!container) {
+      return;
+    }
+
+    if (NodeType.isElement(container) && container.parentNode) {
+      const node = container;
+      offset = nodeIndex(container);
+      container = container.parentNode;
+      DOM.remove(node);
+
+      if (!container.hasChildNodes() && DOM.isBlock(container)) {
+        container.appendChild(DOM.create('br'));
+      }
+    }
+
+    bookmark[start ? 'startContainer' : 'endContainer'] = container;
+    bookmark[start ? 'startOffset' : 'endOffset'] = offset as number;
+  };
+
+  restoreEndPoint(true);
+  restoreEndPoint();
+
+  const rng = DOM.createRng();
+
+  rng.setStart(bookmark.startContainer, bookmark.startOffset);
+
+  if (bookmark.endContainer) {
+    rng.setEnd(bookmark.endContainer, bookmark.endOffset as number);
+  }
+
+  return NormalizeBookmarkPoint.normalizeRange(rng);
+};
+
+export {
+  createBookmark,
+  resolveBookmark
+};

--- a/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
@@ -5,7 +5,7 @@ import * as NodeType from '../dom/NodeType';
 
 import * as NormalizeBookmarkPoint from './NormalizeBookmarkPoint';
 
-// TODO: This is a clone of the list bookmark code if we move lists to core then de-duplicate this
+// TODO: This is a clone of the list bookmark code if we move lists to core then de-duplicate this #TINY-12172
 
 const DOM = DOMUtils.DOM;
 

--- a/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/NodeStructureBookmark.ts
@@ -1,3 +1,5 @@
+import { Global } from '@ephox/katamari';
+
 import DOMUtils from '../api/dom/DOMUtils';
 import * as NodeType from '../dom/NodeType';
 
@@ -33,12 +35,10 @@ const createBookmark = (rng: Range): Bookmark => {
       const offsetNode = DOM.create('span', { 'data-mce-type': 'bookmark' });
 
       if (container.hasChildNodes()) {
-        offset = Math.min(offset, container.childNodes.length - 1);
-
-        if (start) {
-          container.insertBefore(offsetNode, container.childNodes[offset]);
+        if (offset === container.childNodes.length) {
+          container.appendChild(offsetNode);
         } else {
-          DOM.insertAfter(offsetNode, container.childNodes[offset]);
+          container.insertBefore(offsetNode, container.childNodes[offset]);
         }
       } else {
         container.appendChild(offsetNode);
@@ -118,6 +118,9 @@ const resolveBookmark = (bookmark: Bookmark): Range => {
 
   return NormalizeBookmarkPoint.normalizeRange(rng);
 };
+
+Global.createBookmark = createBookmark;
+Global.resolveBookmark = resolveBookmark;
 
 export {
   createBookmark,

--- a/modules/tinymce/src/core/main/ts/bookmark/NormalizeBookmarkPoint.ts
+++ b/modules/tinymce/src/core/main/ts/bookmark/NormalizeBookmarkPoint.ts
@@ -1,0 +1,52 @@
+import RangeUtils from '../api/dom/RangeUtils';
+import * as NodeType from '../dom/NodeType';
+
+// TODO: This is a clone of the list bookmark code if we move lists to core then de-duplicate this
+
+interface Point {
+  readonly container: Node;
+  readonly offset: number;
+}
+
+const getNormalizedPoint = (container: Node, offset: number): Point => {
+  if (NodeType.isText(container)) {
+    return { container, offset };
+  }
+
+  const node = RangeUtils.getNode(container, offset);
+  if (NodeType.isText(node)) {
+    return {
+      container: node,
+      offset: offset >= container.childNodes.length ? node.data.length : 0
+    };
+  } else if (node.previousSibling && NodeType.isText(node.previousSibling)) {
+    return {
+      container: node.previousSibling,
+      offset: node.previousSibling.data.length
+    };
+  } else if (node.nextSibling && NodeType.isText(node.nextSibling)) {
+    return {
+      container: node.nextSibling,
+      offset: 0
+    };
+  }
+
+  return { container, offset };
+};
+
+const normalizeRange = (rng: Range): Range => {
+  const outRng = rng.cloneRange();
+
+  const rangeStart = getNormalizedPoint(rng.startContainer, rng.startOffset);
+  outRng.setStart(rangeStart.container, rangeStart.offset);
+
+  const rangeEnd = getNormalizedPoint(rng.endContainer, rng.endOffset);
+  outRng.setEnd(rangeEnd.container, rangeEnd.offset);
+
+  return outRng;
+};
+
+export {
+  getNormalizedPoint,
+  normalizeRange
+};

--- a/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
+++ b/modules/tinymce/src/core/main/ts/content/InsertContentImpl.ts
@@ -1,5 +1,5 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
-import { Remove, SugarElement } from '@ephox/sugar';
+import { Remove, SugarElement, SugarElements } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -17,6 +17,7 @@ import * as CefUtils from '../dom/CefUtils';
 import ElementUtils from '../dom/ElementUtils';
 import * as NodeType from '../dom/NodeType';
 import * as PaddingBr from '../dom/PaddingBr';
+import * as NormalizeTagOrder from '../fmt/NormalizeTagOrder';
 import * as AstNodeType from '../html/AstNodeType';
 import * as FilterNode from '../html/FilterNode';
 import * as InvalidNodes from '../html/InvalidNodes';
@@ -120,6 +121,8 @@ const reduceInlineTextElements = (editor: Editor, merge: boolean | undefined): v
         }
       }
     });
+
+    NormalizeTagOrder.normalizeElements(editor, SugarElements.fromDom(fragments));
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyElementFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyElementFormat.ts
@@ -1,0 +1,48 @@
+import { Type } from '@ephox/katamari';
+
+import DOMUtils from '../api/dom/DOMUtils';
+import Editor from '../api/Editor';
+import Tools from '../api/util/Tools';
+import { RangeLikeObject } from '../selection/RangeTypes';
+
+import { ApplyFormat, FormatVars } from './FormatTypes';
+import * as FormatUtils from './FormatUtils';
+
+export const applyStyles = (dom: DOMUtils, elm: Element, format: ApplyFormat, vars: FormatVars | undefined): void => {
+  Tools.each(format.styles, (value, name) => {
+    dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
+  });
+
+  // Needed for the WebKit span spam bug
+  // TODO: Remove this once WebKit/Blink fixes this
+  if (format.styles) {
+    const styleVal = dom.getAttrib(elm, 'style');
+
+    if (styleVal) {
+      dom.setAttrib(elm, 'data-mce-style', styleVal);
+    }
+  }
+};
+
+export const setElementFormat = (ed: Editor, elm: Element, fmt: ApplyFormat, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
+  const dom = ed.dom;
+
+  if (Type.isFunction(fmt.onformat)) {
+    fmt.onformat(elm, fmt as any, vars, node);
+  }
+
+  applyStyles(dom, elm, fmt, vars);
+
+  Tools.each(fmt.attributes, (value, name) => {
+    dom.setAttrib(elm, name, FormatUtils.replaceVars(value, vars));
+  });
+
+  Tools.each(fmt.classes, (value) => {
+    const newValue = FormatUtils.replaceVars(value, vars);
+
+    if (!dom.hasClass(elm, newValue)) {
+      dom.addClass(elm, newValue);
+    }
+  });
+};
+

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Type } from '@ephox/katamari';
-import { PredicateExists, SugarElement } from '@ephox/sugar';
+import { PredicateExists, SugarElement, SugarElements } from '@ephox/sugar';
 
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
@@ -17,6 +17,7 @@ import * as SelectionUtils from '../selection/SelectionUtils';
 import * as TableCellSelection from '../selection/TableCellSelection';
 import * as Zwsp from '../text/Zwsp';
 
+import * as ApplyElementFormat from './ApplyElementFormat';
 import * as CaretFormat from './CaretFormat';
 import * as ExpandRange from './ExpandRange';
 import { isCaretNode } from './FormatContainer';
@@ -26,6 +27,7 @@ import * as Hooks from './Hooks';
 import * as ListItemFormat from './ListItemFormat';
 import * as MatchFormat from './MatchFormat';
 import * as MergeFormats from './MergeFormats';
+import * as NormalizeTagOrder from './NormalizeTagOrder';
 
 const each = Tools.each;
 
@@ -41,48 +43,12 @@ const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, p
   }
 };
 
-const applyStyles = (dom: DOMUtils, elm: Element, format: ApplyFormat, vars: FormatVars | undefined) => {
-  each(format.styles, (value, name) => {
-    dom.setStyle(elm, name, FormatUtils.replaceVars(value, vars));
-  });
-
-  // Needed for the WebKit span spam bug
-  // TODO: Remove this once WebKit/Blink fixes this
-  if (format.styles) {
-    const styleVal = dom.getAttrib(elm, 'style');
-
-    if (styleVal) {
-      dom.setAttrib(elm, 'data-mce-style', styleVal);
-    }
-  }
-};
-
 const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
   const formatList = ed.formatter.get(name) as ApplyFormat[];
   const format = formatList[0];
   const isCollapsed = !node && ed.selection.isCollapsed();
   const dom = ed.dom;
   const selection = ed.selection;
-
-  const setElementFormat = (elm: Element, fmt: ApplyFormat = format) => {
-    if (Type.isFunction(fmt.onformat)) {
-      fmt.onformat(elm, fmt as any, vars, node);
-    }
-
-    applyStyles(dom, elm, fmt, vars);
-
-    each(fmt.attributes, (value, name) => {
-      dom.setAttrib(elm, name, FormatUtils.replaceVars(value, vars));
-    });
-
-    each(fmt.classes, (value) => {
-      const newValue = FormatUtils.replaceVars(value, vars);
-
-      if (!dom.hasClass(elm, newValue)) {
-        dom.addClass(elm, newValue);
-      }
-    });
-  };
 
   const applyNodeStyle = (formatList: ApplyFormat[], node: Node) => {
     let found = false;
@@ -104,7 +70,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
       }
 
       if (dom.is(node, format.selector) && !isCaretNode(node)) {
-        setElementFormat(node as Element, format);
+        ApplyElementFormat.setElementFormat(ed, node as Element, format, vars, node);
         found = true;
         return false;
       }
@@ -118,7 +84,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
   const createWrapElement = (wrapName: string | undefined): HTMLElement | null => {
     if (Type.isString(wrapName)) {
       const wrapElm = dom.create(wrapName);
-      setElementFormat(wrapElm);
+      ApplyElementFormat.setElementFormat(ed, wrapElm, format, vars, node);
       return wrapElm;
     } else {
       return null;
@@ -196,7 +162,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
 
         if (canRenameBlock(node, parentName, isEditableDescendant)) {
           const elm = dom.rename(node as Element, wrapName);
-          setElementFormat(elm);
+          ApplyElementFormat.setElementFormat(ed, elm, format, vars, node);
           newWrappers.push(elm);
           currentWrapElm = null;
           return;
@@ -252,16 +218,16 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
 
     // Apply formats to links as well to get the color of the underline to change as well
     if (format.links === true) {
-      Arr.each(newWrappers, (node) => {
-        const process = (node: Node) => {
-          if (node.nodeName === 'A') {
-            setElementFormat(node as HTMLAnchorElement, format);
+      Arr.each(newWrappers, (wrapper) => {
+        const process = (target: Node) => {
+          if (target.nodeName === 'A') {
+            ApplyElementFormat.setElementFormat(ed, target as HTMLAnchorElement, format, vars, node);
           }
 
-          Arr.each(Arr.from(node.childNodes), process);
+          Arr.each(Arr.from(target.childNodes), process);
         };
 
-        process(node);
+        process(wrapper);
       });
     }
 
@@ -285,7 +251,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
           .filter((child) => dom.getContentEditable(child) !== 'false' && MatchFormat.matchName(dom, child, format));
         return childElement.map((child) => {
           const clone = dom.clone(child, false) as Element;
-          setElementFormat(clone);
+          ApplyElementFormat.setElementFormat(ed, clone, format, vars, node);
 
           dom.replace(clone, node, true);
           dom.remove(child, true);
@@ -317,6 +283,8 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
         MergeFormats.mergeSiblings(ed, format, vars, node);
       }
     });
+
+    NormalizeTagOrder.normalizeFontSizeElementsAfterApply(ed, name, SugarElements.fromDom(newWrappers));
   };
 
   // TODO: TINY-9142: Remove this to make nested noneditable formatting work
@@ -363,7 +331,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
       }
 
       ListItemFormat.getExpandedListItemFormat(ed.formatter, name).each((liFmt) => {
-        Arr.each(ListItemFormat.getFullySelectedListItems(ed.selection), (li) => applyStyles(dom, li, liFmt as ApplyFormat, vars));
+        Arr.each(ListItemFormat.getFullySelectedListItems(ed.selection), (li) => ApplyElementFormat.applyStyles(dom, li, liFmt as ApplyFormat, vars));
       });
     }
 
@@ -373,12 +341,9 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
   Events.fireFormatApply(ed, name, node, vars);
 };
 
-const applyFormat = (editor: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
+export const applyFormat = (editor: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
   if (node || editor.selection.isEditable()) {
     applyFormatAction(editor, name, vars, node);
   }
 };
 
-export {
-  applyFormat
-};

--- a/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatTypes.ts
@@ -1,3 +1,5 @@
+import { Type } from '@ephox/katamari';
+
 import { RangeLikeObject } from '../selection/RangeTypes';
 
 export type ApplyFormat = BlockFormat | InlineFormat | SelectorFormat;
@@ -80,3 +82,7 @@ export interface RemoveBlockFormat extends Block, CommonRemoveFormat<RemoveBlock
 export interface RemoveInlineFormat extends Inline, CommonRemoveFormat<RemoveInlineFormat> {}
 
 export interface RemoveSelectorFormat extends Selector, CommonRemoveFormat<RemoveSelectorFormat> {}
+
+export const isApplyFormat = (format: Format): format is ApplyFormat =>
+  !Type.isArray(format.attributes) && !Type.isArray(format.styles);
+

--- a/modules/tinymce/src/core/main/ts/fmt/NormalizeTagOrder.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/NormalizeTagOrder.ts
@@ -1,0 +1,164 @@
+import { Arr, Optional, Type } from '@ephox/katamari';
+import { Compare, Insert, PredicateFilter, Remove, Replication, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+
+import type DOMUtils from '../api/dom/DOMUtils';
+import type Editor from '../api/Editor';
+import type Formatter from '../api/Formatter';
+import * as NodeStructureBookmark from '../bookmark/NodeStructureBookmark';
+
+import * as ApplyElementFormat from './ApplyElementFormat';
+import * as FormatTypes from './FormatTypes';
+import * as MatchFormat from './MatchFormat';
+import * as RemoveFormat from './RemoveFormat';
+
+interface WrapperData {
+  readonly container: SugarElement<Element>;
+  readonly innerWrapper: SugarElement<Element>;
+  readonly outerWrappers: SugarElement<Element>[];
+}
+
+const fontSizeAlteringFormats = [ 'fontsize', 'subscript', 'superscript' ] as const;
+const formatsToActOn = [ 'strikethrough', ...fontSizeAlteringFormats ] as const;
+
+const hasFormat = (formatter: Formatter, el: SugarElement<Node>, format: string): el is SugarElement<Element> =>
+  Type.isNonNullable(formatter.matchNode(el.dom, format, {}, format === 'fontsize'));
+
+const isFontSizeAlteringElement = (formatter: Formatter) => (el: SugarElement<Node>): el is SugarElement<Element> =>
+  Arr.exists(fontSizeAlteringFormats, (format) => hasFormat(formatter, el, format));
+
+const isFontSizeAlteringFormat = (format: string) => Arr.contains(fontSizeAlteringFormats, format);
+
+const isNormalizingFormat = (format: string) => Arr.contains(formatsToActOn, format);
+
+const gatherWrapperData = (
+  isRoot: (node: SugarElement<Node>) => boolean,
+  scope: SugarElement<Element>,
+  hasFormat: (el: SugarElement<Element>) => boolean,
+  createFormatElement: (el: SugarElement<Element>) => SugarElement<Element>,
+  removeFormatFromElement: (el: SugarElement<Element>) => Optional<SugarElement<Element>>
+): Optional<WrapperData> => {
+  const parents = Traverse.parents(scope, isRoot).filter(SugarNode.isElement);
+
+  return Arr.findLastIndex(parents, hasFormat).map((index) => {
+    const container = parents[index];
+    const innerWrapper = createFormatElement(container);
+    const outerWrappers = [
+      ...removeFormatFromElement(Replication.shallow(container)).toArray(),
+      ...Arr.bind(parents.slice(0, index), (wrapper) => {
+        if (hasFormat(wrapper)) {
+          return removeFormatFromElement(wrapper).toArray();
+        } else {
+          return [ Replication.shallow(wrapper) ];
+        }
+      })
+    ];
+
+    return { container, innerWrapper, outerWrappers };
+  });
+};
+
+const wrapChildrenInInnerWrapper = (
+  target: SugarElement<Element>,
+  wrapper: SugarElement<Element>,
+  hasFormat: (el: SugarElement<Node>) => boolean,
+  removeFormatFromElement: (el: SugarElement<Element>) => Optional<SugarElement<Element>>
+) => {
+  Arr.each(Traverse.children(target), (child) => {
+    if (SugarNode.isElement(child) && hasFormat(child)) {
+      if (removeFormatFromElement(child).isNone()) {
+        Remove.unwrap(child);
+      }
+    }
+  });
+
+  Arr.each(Traverse.children(target), (child) => Insert.append(wrapper, child));
+
+  Insert.prepend(target, wrapper);
+};
+
+const wrapInOuterWrappers = (target: SugarElement<Element>, wrappers: SugarElement<Element>[]) => {
+  if (wrappers.length > 0) {
+    const outermost = wrappers[wrappers.length - 1];
+    Insert.before(target, outermost);
+
+    const innerMost = Arr.foldl(wrappers.slice(0, wrappers.length - 1), (acc, wrapper) => {
+      Insert.append(acc, wrapper);
+      return wrapper;
+    }, outermost);
+
+    Insert.append(innerMost, target);
+  }
+};
+
+const normalizeFontSizeElementsInternal = (
+  domUtils: DOMUtils,
+  fontSizeElements: SugarElement<Element>[],
+  hasFormat: (el: SugarElement<Node>) => boolean,
+  createFormatElement: (el: SugarElement<Element>) => SugarElement<Element>,
+  removeFormatFromElement: (el: SugarElement<Element>) => Optional<SugarElement<Element>>
+): void => {
+  const isRoot = (el: SugarElement<Node>) => Compare.eq(SugarElement.fromDom(domUtils.getRoot()), el) || domUtils.isBlock(el.dom);
+
+  Arr.each(fontSizeElements, (fontSizeElement) => {
+    gatherWrapperData(
+      isRoot,
+      fontSizeElement,
+      hasFormat,
+      createFormatElement,
+      removeFormatFromElement
+    ).each(({ container, innerWrapper, outerWrappers }) => {
+      domUtils.split(container.dom, fontSizeElement.dom);
+      wrapChildrenInInnerWrapper(fontSizeElement, innerWrapper, hasFormat, removeFormatFromElement);
+      wrapInOuterWrappers(fontSizeElement, outerWrappers);
+    });
+  });
+};
+
+const normalizeFontSizeElementsWithFormat = (
+  editor: Editor,
+  formatName: string,
+  fontSizeElements: SugarElement<Element>[]
+): void => {
+  const hasFormat = (el: SugarElement<Node>) => Type.isNonNullable(MatchFormat.matchNode(editor, el.dom, formatName));
+
+  const createFormatElement = (el: SugarElement<Element>) => {
+    const newEl = SugarElement.fromTag(SugarNode.name(el));
+    const format = MatchFormat.matchNode(editor, el.dom, formatName, {});
+
+    if (Type.isNonNullable(format) && FormatTypes.isApplyFormat(format)) {
+      ApplyElementFormat.setElementFormat(editor, newEl.dom, format);
+    }
+
+    return newEl;
+  };
+
+  const removeFormatFromElement = (el: SugarElement<Element>) => {
+    const format = MatchFormat.matchNode(editor, el.dom, formatName, {});
+
+    if (Type.isNonNullable(format)) {
+      return RemoveFormat.removeFormatOnElement(editor, format, {}, el.dom).map(SugarElement.fromDom);
+    } else {
+      return Optional.some(el);
+    }
+  };
+
+  const bookmark = NodeStructureBookmark.createBookmark(editor.selection.getRng());
+  normalizeFontSizeElementsInternal(editor.dom, fontSizeElements, hasFormat, createFormatElement, removeFormatFromElement);
+  editor.selection.setRng(NodeStructureBookmark.resolveBookmark(bookmark));
+};
+
+const collectFontSizeElements = (formatter: Formatter, wrappers: SugarElement<Element>[]) =>
+  Arr.bind(wrappers, (wrapper) => PredicateFilter.descendants(wrapper, isFontSizeAlteringElement(formatter)));
+
+export const normalizeFontSizeElementsAfterApply = (editor: Editor, appliedFormat: string, wrappers: SugarElement<Element>[]): void => {
+  if (isNormalizingFormat(appliedFormat)) {
+    const fontSizeElements = isFontSizeAlteringFormat(appliedFormat) ? wrappers : collectFontSizeElements(editor.formatter, wrappers);
+    normalizeFontSizeElementsWithFormat(editor, 'strikethrough', fontSizeElements);
+  }
+};
+
+export const normalizeElements = (editor: Editor, elements: SugarElement<Element>[]): void => {
+  const fontSizeElements = Arr.filter(elements, isFontSizeAlteringElement(editor.formatter));
+  normalizeFontSizeElementsWithFormat(editor, 'strikethrough', fontSizeElements);
+};
+

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -651,6 +651,14 @@ const removeFormat = (ed: Editor, name: string, vars?: FormatVars, node?: Node |
   }
 };
 
+const removeFormatOnElement = (editor: Editor, format: Format, vars: FormatVars | undefined, node: Element): Optional<Element> => {
+  return removeNodeFormatInternal(editor, format, vars, node).fold(
+    () => Optional.some(node),
+    (newName) => Optional.some(editor.dom.rename(node, newName)),
+    Optional.none
+  );
+};
+
 /**
  * Removes the specified format for the specified node. It will also remove the node if it doesn't have
  * any attributes if the format specifies it to do so.
@@ -676,5 +684,6 @@ const removeNodeFormat = (editor: Editor, format: Format, vars: FormatVars | und
 
 export {
   removeFormat,
+  removeFormatOnElement,
   removeNodeFormat
 };

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2534,6 +2534,50 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
     TinyAssertions.assertContent(editor, '<details><summary><h1>hello<em>world</em></h1></summary>body</details>');
   });
 
+  context('Tag order normalization', () => {
+    it('TINY-12004: Re-order elements when applying font-size on existing strikethrough', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p><s>abc</s></p>');
+      TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 2);
+      editor.formatter.apply('fontsize', { value: '36pt' });
+
+      TinyAssertions.assertContent(editor, '<p><s>a</s><span style="font-size: 36pt;"><s>b</s></span><s>c</s></p>');
+    });
+
+    it('TINY-12004: Re-order elements when applying strikethrough on existing font size', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>a<span style="font-size: 36pt;">b</span>c</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 2 ], 1);
+      editor.formatter.apply('strikethrough');
+
+      TinyAssertions.assertContent(editor, '<p><s>a</s><span style="font-size: 36pt;"><s>b</s></span><s>c</s></p>');
+    });
+
+    it('TINY-12004: Re-order elements on when applying strikethrough after font size', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>abc</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+      editor.formatter.apply('fontsize', { value: '36pt' });
+      editor.formatter.apply('strikethrough');
+
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 36pt;"><s>abc</s></span></p>');
+    });
+
+    it('TINY-12004: Retain order of elements when applying font size after strikethrough', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p>abc</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+      editor.formatter.apply('strikethrough');
+      editor.formatter.apply('fontsize', { value: '36pt' });
+
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 36pt;"><s>abc</s></span></p>');
+    });
+  });
+
   context('TINY-10312: should not partially apply block format when caret is positioned between words', () => {
     it('TINY-10312: should apply heading formatting to whole `summary` content', () => {
       const editor = hook.editor();
@@ -2559,5 +2603,4 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       TinyAssertions.assertContent(editor, '<ul><li><blockquote>a bc d</blockquote></li></ul>');
     });
   });
-
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/insert/MergeInsertedInlineElementsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/insert/MergeInsertedInlineElementsTest.ts
@@ -385,4 +385,12 @@ describe('browser.tinymce.core.content.insert.MergeInsertedInlineElementsTest', 
     Arr.each(nonInheritableColorStyles, (colorStyle) => testMergingNonInheritableStyles(colorStyle, colorStyleValues));
     Arr.each(nonInheritablePixelStyles, (pixelStyle) => testMergingNonInheritableStyles(pixelStyle, pixelStyleValues));
   });
+
+  it('TINY-12004: Re-order strikethrough and font size if font size is inserted into strikethrough', () => {
+    const initial = '<s>test</s>';
+    const inserted = '<span style="font-size: 36pt;">test</span>';
+    const expected = '<s>te</s><span style="font-size: 36pt;"><s>test</s></span><s>st</s>';
+
+    testMergeNestedElements(initial, inserted, expected, [ 0, 0, 0 ], 2);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/CaretFormatTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Mouse, StructAssert } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
@@ -890,5 +890,29 @@ describe('browser.tinymce.core.fmt.CaretFormatTest', () => {
         ]
       });
     }));
+  });
+
+  context('Tag order normalization', () => {
+    it('TINY-12004: Re-order formats for strikethrough after font size', () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      editor.formatter.apply('fontsize', { value: '36pt' });
+      editor.formatter.apply('strikethrough');
+      TinyContentActions.type(editor, 'x');
+
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 36pt;"><s>x</s></span></p>');
+    });
+
+    it('TINY-12004: Retain order formats for font size after strikethrough', () => {
+      const editor = hook.editor();
+
+      editor.setContent('');
+      editor.formatter.apply('strikethrough');
+      editor.formatter.apply('fontsize', { value: '36pt' });
+      TinyContentActions.type(editor, 'x');
+
+      TinyAssertions.assertContent(editor, '<p><span style="font-size: 36pt;"><s>x</s></span></p>');
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
@@ -1,0 +1,196 @@
+import { Cursors } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Css, PredicateFilter, SugarElement, SugarNode } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+import * as NormalizeTagOrder from 'tinymce/core/fmt/NormalizeTagOrder';
+
+interface TestCase {
+  format: string;
+  html: string;
+  selection: Cursors.CursorPath;
+  expectedHtml: string;
+  expectedSelection: Cursors.CursorPath;
+}
+
+describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce',
+    extended_valid_elements: 'b,i',
+    indent: false
+  }, [], true);
+
+  const isFontSizeElement = (element: SugarElement<Node>): element is SugarElement<HTMLElement> => {
+    return SugarNode.isHTMLElement(element) && SugarNode.name(element) === 'span' && Css.getRaw(element, 'font-size').isSome();
+  };
+  const isStrikethroughElement = SugarNode.isTag('s');
+  const isSub = SugarNode.isTag('sub');
+  const isSup = SugarNode.isTag('sup');
+
+  context('normalizeFontSizeElementsAfterApply', () => {
+    const testNormalizeFontSizeElementsAfterApply = ({ format, html, selection, expectedHtml, expectedSelection }: TestCase) => {
+      const editor = hook.editor();
+      editor.setContent(html);
+
+      const isMatch = (el: SugarElement<Node>): el is SugarElement<Element> => {
+        if (format === 'fontsize') {
+          return isFontSizeElement(el);
+        } else if (format === 'strikethrough') {
+          return isStrikethroughElement(el);
+        } else if (format === 'subscript') {
+          return isSub(el);
+        } else if (format === 'superscript') {
+          return isSup(el);
+        } else {
+          return false;
+        }
+      };
+
+      const wrappers = PredicateFilter.descendants<Element>(TinyDom.body(editor), isMatch);
+
+      if (selection) {
+        TinySelections.setSelection(editor, selection.startPath, selection.soffset, selection.finishPath, selection.foffset);
+      }
+
+      NormalizeTagOrder.normalizeFontSizeElementsAfterApply(editor, format, wrappers);
+
+      TinyAssertions.assertContent(editor, expectedHtml);
+      TinyAssertions.assertSelection(editor, expectedSelection.startPath, expectedSelection.soffset, expectedSelection.finishPath, expectedSelection.foffset);
+    };
+
+    context('Applying fontsize', () => {
+      it('TINY-12004: Switch order of strikethrough and font size with text node content', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="font-size: 40px;">Hello</span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><s>Hello</s></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size when strikethrough is mixed with other styles', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><span style="text-decoration: line-through; color: red"><span style="font-size: 40px;">Hello</span></span></p>',
+        selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="color: red;"><span style="font-size: 40px;"><span style="text-decoration: line-through;">Hello</span></span></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size with mixed content', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="font-size: 40px;">Hello <b>world</b></span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><s>Hello <b>world</b></s></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size when font size is wrapped in b', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><b><span style="font-size: 40px;">Hello</span></b></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><b><span style="font-size: 40px;"><s>Hello</s></span></b></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size when font size is wrapped in b and i', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><b><i><span style="font-size: 40px;">Hello</span></></b></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><b><i><span style="font-size: 40px;"><s>Hello</s></span></i></b></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size with text node content when content is before and after font size', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><b><i>foo</i></b><span style="font-size: 40px;">bar</span><i><b>baz</b></i></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2, 0, 0 ], foffset: 'baz'.length },
+        expectedHtml: '<p><s><b><i>foo</i></b></s><span style="font-size: 40px;"><s>bar</s></span><s><i><b>baz</b></i></s></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0, 0, 0 ], foffset: 'baz'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size on text that is also bold and italic', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><b><i>foo<span style="font-size: 40px;">bar</span>baz</b></i></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 2 ], foffset: 'baz'.length },
+        expectedHtml: '<p><s><b><i>foo</i></b></s><b><i><span style="font-size: 40px;"><s>bar</s></span></i></b><s><b><i>baz</i></b></s></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0, 0, 0 ], foffset: 'baz'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size when there is multiple nested font sizes', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="font-size: 40px;"><span style="font-size: 32px;">bar</span></span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'bar'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><span style="font-size: 32px;"><s>bar</s></span></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'bar'.length }
+      }));
+
+      it('TINY-12004: Should reduce nested strikethroughs', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><s><span style="font-size: 40px;">Hello</span></s></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><s>Hello</s></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Should not wrap existing strikethroughs with strikethrough by unwrapping inner ones', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="font-size: 40px;"><s>Hello</s></span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><s>Hello</s></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Should not wrap existing strikethroughs with strikethrough by removing styles from inner ones', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><span style="text-decoration: line-through"><span style="font-size: 40px;"><s>Hello</s> <span style="text-decoration: line-through; color: red;">world</span></span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 2, 0 ], foffset: 'world'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><span style="text-decoration: line-through;">Hello <span style="color: red;">world</span></span></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 2, 0 ], foffset: 'world'.length }
+      }));
+
+      it('TINY-12004: Should remove line-through from nested element but retain the color', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="text-decoration: line-through; color: red;"><span style="font-size: 40px;">Hello</span></span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="color: red;"><span style="font-size: 40px;"><s>Hello</s></span></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Should remove line-through from parent element but retain the color', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><span style="text-decoration: line-through; color: red;"><s><span style="font-size: 40px;">Hello</span></s></span></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><span style="color: red;"><span style="font-size: 40px;"><span style="text-decoration: line-through;">Hello</span></span></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of multiple font size elements', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="font-size: 40px;">Hello</span> <span style="font-size: 32px;">world</span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2, 0 ], foffset: 'world'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><s>Hello</s></span><s> </s><span style="font-size: 32px;"><s>world</s></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0, 0 ], foffset: 'world'.length }
+      }));
+    });
+
+    context('Applying strikethrough', () => {
+      it('TINY-12004: Switch order of strikethrough and font size when applying strike though on text that has font size elements', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'strikethrough',
+        html: '<p><s>one<span style="font-size: 40px;">two</span>three</s></p>',
+        selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2 ], foffset: 'three'.length },
+        expectedHtml: '<p><s>one</s><span style="font-size: 40px;"><s>two</s></span><s>three</s></p>',
+        expectedSelection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0 ], foffset: 'three'.length }
+      }));
+    });
+
+    context('Applying subscript', () => {
+      it('TINY-12004: Switch order of subscript and font size when applying strike though on text that has font size elements', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'subscript',
+        html: '<p><s>one<sub>two</sub>three</s></p>',
+        selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2 ], foffset: 'three'.length },
+        expectedHtml: '<p><s>one</s><sub><s>two</s></sub><s>three</s></p>',
+        expectedSelection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0 ], foffset: 'three'.length }
+      }));
+    });
+  });
+});

--- a/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
@@ -94,7 +94,7 @@ describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
 
       it('TINY-12004: Switch order of strikethrough and font size when font size is wrapped in b and i', () => testNormalizeFontSizeElementsAfterApply({
         format: 'fontsize',
-        html: '<p><s><b><i><span style="font-size: 40px;">Hello</span></></b></s></p>',
+        html: '<p><s><b><i><span style="font-size: 40px;">Hello</span></i></b></s></p>',
         selection: { startPath: [ 0, 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
         expectedHtml: '<p><b><i><span style="font-size: 40px;"><s>Hello</s></span></i></b></p>',
         expectedSelection: { startPath: [ 0, 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }

--- a/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
@@ -142,7 +142,7 @@ describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
 
       it('TINY-12004: Should not wrap existing strikethroughs with strikethrough by removing styles from inner ones', () => testNormalizeFontSizeElementsAfterApply({
         format: 'fontsize',
-        html: '<p><span style="text-decoration: line-through"><span style="font-size: 40px;"><s>Hello</s> <span style="text-decoration: line-through; color: red;">world</span></span></s></p>',
+        html: '<p><span style="text-decoration: line-through"><span style="font-size: 40px;"><s>Hello</s> <span style="text-decoration: line-through; color: red;">world</span></span></p>',
         selection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 2, 0 ], foffset: 'world'.length },
         expectedHtml: '<p><span style="font-size: 40px;"><span style="text-decoration: line-through;">Hello <span style="color: red;">world</span></span></span></p>',
         expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 2, 0 ], foffset: 'world'.length }
@@ -174,7 +174,7 @@ describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
     });
 
     context('Applying strikethrough', () => {
-      it('TINY-12004: Switch order of strikethrough and font size when applying strike though on text that has font size elements', () => testNormalizeFontSizeElementsAfterApply({
+      it('TINY-12004: Switch order of strikethrough and font size when applying strikethrough on text that has font size elements', () => testNormalizeFontSizeElementsAfterApply({
         format: 'strikethrough',
         html: '<p><s>one<span style="font-size: 40px;">two</span>three</s></p>',
         selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2 ], foffset: 'three'.length },
@@ -184,7 +184,7 @@ describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
     });
 
     context('Applying subscript', () => {
-      it('TINY-12004: Switch order of subscript and font size when applying strike though on text that has font size elements', () => testNormalizeFontSizeElementsAfterApply({
+      it('TINY-12004: Switch order of subscript and font size when applying subscript on text that has font size elements', () => testNormalizeFontSizeElementsAfterApply({
         format: 'subscript',
         html: '<p><s>one<sub>two</sub>three</s></p>',
         selection: { startPath: [ 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2 ], foffset: 'three'.length },


### PR DESCRIPTION
Related Ticket: TINY-12004

Description of Changes:
* Added normalization of tag order when inserting new contents when `merge` flag is enabled.
* Added normalization of tag order when applying font size or strikethrough or subscript or superscript
* Added a `findLastIndex` to katamari not sure how often we will need that but seems like a useful thing to have

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functions to create and resolve bookmarks within DOM ranges for reliable range handling.
  - Introduced normalization of DOM range boundary points to ensure consistent text node boundaries.
  - Enhanced formatting application with normalization of tag order, especially for font size, strikethrough, subscript, and superscript.
  - Implemented a new array utility to find the last index matching a predicate.
  - Added functionality to apply styles, attributes, and classes to elements with variable substitution support.
  - Introduced a function to remove formats from individual elements with optional node renaming.

- **Bug Fixes**
  - Fixed issues with inconsistent nesting of strikethrough elements within font size wrappers during formatting and pasting.

- **Tests**
  - Added extensive tests for tag order normalization, bookmark creation/restoration, and format application/removal, covering various scenarios.
  - Included specific tests for verifying correct nesting and order of font size and strikethrough tags.
  - Added tests validating merging behavior of inserted inline elements with font size and strikethrough styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->