### PR TITLE
TINY-12163: fix conflict between `mouseover` and arrow navigation in menubar

### DIFF
--- a/modules/katamari/src/test/ts/atomic/api/fun/ThrottlerTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/fun/ThrottlerTest.ts
@@ -89,7 +89,7 @@ describe('atomic.katamari.api.fun.ThrottlerTest', () => {
     }, 200);
   }));
 
-  it('Throttler.withPriority', () => async () => {
+  it('Throttler.withPriority', async () => {
     const delay = 1;
     const data: string[] = [];
     const throttler = Throttler.withPriority((value: string) => {

--- a/modules/katamari/src/test/ts/atomic/api/fun/ThrottlerTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/fun/ThrottlerTest.ts
@@ -1,3 +1,4 @@
+import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
@@ -87,4 +88,32 @@ describe('atomic.katamari.api.fun.ThrottlerTest', () => {
       }, 200);
     }, 200);
   }));
+
+  it('Throttler.withPriority', () => async () => {
+    const delay = 1;
+    const data: string[] = [];
+    const throttler = Throttler.withPriority((value: string) => {
+      data.push(value);
+    }, delay);
+
+    throttler.throttle(false, 'cat');
+    throttler.throttle(true, 'dog');
+    await Waiter.pWait(delay + 1);
+    assert.deepEqual(data, [ 'dog' ]);
+
+    throttler.throttle(true, 'cat');
+    throttler.throttle(false, 'dog');
+    await Waiter.pWait(delay + 1);
+    assert.deepEqual(data, [ 'dog', 'cat' ]);
+
+    throttler.throttle(false, 'cat');
+    throttler.throttle(false, 'dog');
+    await Waiter.pWait(delay + 1);
+    assert.deepEqual(data, [ 'dog', 'cat', 'cat' ]);
+
+    throttler.throttle(true, 'cat');
+    throttler.throttle(true, 'dog');
+    await Waiter.pWait(delay + 1);
+    assert.deepEqual(data, [ 'dog', 'cat', 'cat', 'dog' ]);
+  });
 });

--- a/modules/katamari/src/test/ts/atomic/api/fun/ThrottlerTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/fun/ThrottlerTest.ts
@@ -1,10 +1,10 @@
-import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import * as Throttler from 'ephox/katamari/api/Throttler';
 
 describe('atomic.katamari.api.fun.ThrottlerTest', () => {
+  const pWait = (time: number): Promise<void> => new Promise((r) => setTimeout(r, time));
 
   it('Throttler.adaptable', () => new Promise<void>((success) => {
     const data: string[] = [];
@@ -98,22 +98,22 @@ describe('atomic.katamari.api.fun.ThrottlerTest', () => {
 
     throttler.throttle(false, 'cat');
     throttler.throttle(true, 'dog');
-    await Waiter.pWait(delay + 1);
+    await pWait(delay + 1);
     assert.deepEqual(data, [ 'dog' ]);
 
     throttler.throttle(true, 'cat');
     throttler.throttle(false, 'dog');
-    await Waiter.pWait(delay + 1);
+    await pWait(delay + 1);
     assert.deepEqual(data, [ 'dog', 'cat' ]);
 
     throttler.throttle(false, 'cat');
     throttler.throttle(false, 'dog');
-    await Waiter.pWait(delay + 1);
+    await pWait(delay + 1);
     assert.deepEqual(data, [ 'dog', 'cat', 'cat' ]);
 
     throttler.throttle(true, 'cat');
     throttler.throttle(true, 'dog');
-    await Waiter.pWait(delay + 1);
+    await pWait(delay + 1);
     assert.deepEqual(data, [ 'dog', 'cat', 'cat', 'dog' ]);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-12163

Description of Changes:
**THE BUG:**
the navigation stopped because both on `mouseover` and on `focusShifted` the focus is moved on the target (the already focussed one in case of `focusShifted` on the element with the mouse over on `mouseover`), for some reason moving the focus to another button sometime trigger the `mouseover` again, it seems releated to [this mixin](https://github.com/tinymce/tinymce/blob/558aa03340563c8e85c7c8f1d67bd9969fc847d4/modules/oxide/src/less/theme/components/menubar/menubar-button.less#L79).

**REASON OF THIS SOLUTION:**
I didn't go in deep to understand it since I preferred to avoid that triggering both could cause the bug, this because if a style can cause it and I don't think we have a good way to test it just fixing what is triggering the issue would have a high risk of regression.

**SOLUTION:**
to avoid it I implemented a new Throttler (`Throttler.withPriority`), this function works like `Throttler.first` but it is possible to indicate that a call has a priority on the others

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
