### PR TITLE
TINY-12163: fix conflict between mouseover and arrow navigation in menubar

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12163-2025-05-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-12163-2025-05-29.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Using arrow navigation between buttons when a button had the mouse over could stop the navigation.
+time: 2025-05-29T08:27:40.214839736+02:00
+custom:
+    Issue: TINY-12163

--- a/modules/oxide/src/less/theme/components/menubar/menubar-button.less
+++ b/modules/oxide/src/less/theme/components/menubar/menubar-button.less
@@ -76,6 +76,7 @@
     z-index: 1; // Ensure focus outline is on top of other buttons
 
     &::after {
+      pointer-events: none;
       .keyboard-focus-outline-mixin();
     }
   }

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -58,7 +58,6 @@
   box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color @_inset;
   content: '';
   left: 0;
-  pointer-events: none;
   position: absolute;
   right: 0;
   top: 0;

--- a/modules/oxide/src/less/theme/globals/global.less
+++ b/modules/oxide/src/less/theme/globals/global.less
@@ -58,6 +58,7 @@
   box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color @_inset;
   content: '';
   left: 0;
+  pointer-events: none;
   position: absolute;
   right: 0;
   top: 0;


### PR DESCRIPTION
Related Ticket: TINY-12163

Description of Changes:
as wrote in the [previous PR](https://github.com/tinymce/tinymce/pull/10386) the bug is that the navigation stopped because both on `mouseover` and on `focusShifted` the focus is moved on the target (the already focussed one in case of `focusShifted` on the element with the mouse over on `mouseover`), for some reason moving the focus to another button sometime trigger the `mouseover` again, it seems releated to [this mixin](https://github.com/tinymce/tinymce/blob/558aa03340563c8e85c7c8f1d67bd9969fc847d4/modules/oxide/src/less/theme/components/menubar/menubar-button.less#L79).

I did implement a solution in the previous PR that prevent that the 2 events were executed in a small amount of time, but @spocke suggested a better solution based on CSS (the one implemented in this PR).

Initially I added `pointer-events: none;` to the `mixin` instead of the specific case but I decided to move to the specific case, because maybe that `mixin` could be use for something with resize handlers and I think the 2 things could conflict.

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved keyboard navigation between buttons so arrow keys work correctly even when the mouse pointer is hovering over a button.
	- Fixed an issue where the focus outline on menu bar buttons could interfere with mouse interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->