### PR TITLE
TINY-12120: Disable spellcheck in text areas.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12120-2025-05-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-12120-2025-05-29.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Codesample dialog would not disable spellcheck as expected.
+time: 2025-05-29T12:07:11.402791+02:00
+custom:
+    Issue: TINY-12120

--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Textarea.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Textarea.ts
@@ -11,6 +11,7 @@ export interface TextAreaSpec extends FormComponentWithLabelSpec {
   maximized?: boolean;
   enabled?: boolean;
   context?: string;
+  spellcheck?: boolean;
 }
 
 export interface TextArea extends FormComponentWithLabel {
@@ -19,6 +20,7 @@ export interface TextArea extends FormComponentWithLabel {
   placeholder: Optional<string>;
   enabled: boolean;
   context: string;
+  spellcheck: Optional<boolean>;
 }
 
 const textAreaFields = formComponentWithLabelFields.concat([
@@ -26,6 +28,7 @@ const textAreaFields = formComponentWithLabelFields.concat([
   FieldSchema.defaultedBoolean('maximized', false),
   ComponentSchema.enabled,
   FieldSchema.defaultedString('context', 'mode:design'),
+  FieldSchema.optionBoolean('spellcheck'),
 ]);
 
 export const textAreaSchema = StructureSchema.objOf(textAreaFields);

--- a/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/code/main/ts/ui/Dialog.ts
@@ -13,7 +13,8 @@ const open = (editor: Editor): void => {
       items: [
         {
           type: 'textarea',
-          name: 'code'
+          name: 'code',
+          spellcheck: false,
         }
       ]
     },

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
@@ -24,11 +24,9 @@ const register = (editor: Editor): void => {
 
 const getLanguages = option<LanguageSpec[] | undefined>('codesample_languages');
 const useGlobalPrismJS = option<boolean>('codesample_global_prismjs');
-const shouldBrowserSpellcheck = option('browser_spellcheck');
 
 export {
   register,
   getLanguages,
-  shouldBrowserSpellcheck,
   useGlobalPrismJS
 };

--- a/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/api/Options.ts
@@ -24,9 +24,11 @@ const register = (editor: Editor): void => {
 
 const getLanguages = option<LanguageSpec[] | undefined>('codesample_languages');
 const useGlobalPrismJS = option<boolean>('codesample_global_prismjs');
+const shouldBrowserSpellcheck = option('browser_spellcheck');
 
 export {
   register,
   getLanguages,
+  shouldBrowserSpellcheck,
   useGlobalPrismJS
 };

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
@@ -2,6 +2,7 @@ import { Arr, Fun } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
+import * as Options from '../api/Options';
 import * as CodeSample from '../core/CodeSample';
 import * as Languages from '../core/Languages';
 
@@ -28,7 +29,8 @@ const open = (editor: Editor): void => {
         {
           type: 'textarea',
           name: 'code',
-          label: 'Code view'
+          label: 'Code view',
+          spellcheck: Options.shouldBrowserSpellcheck(editor),
         }
       ]
     },

--- a/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/codesample/main/ts/ui/Dialog.ts
@@ -2,7 +2,6 @@ import { Arr, Fun } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
 
-import * as Options from '../api/Options';
 import * as CodeSample from '../core/CodeSample';
 import * as Languages from '../core/Languages';
 
@@ -30,7 +29,7 @@ const open = (editor: Editor): void => {
           type: 'textarea',
           name: 'code',
           label: 'Code view',
-          spellcheck: Options.shouldBrowserSpellcheck(editor),
+          spellcheck: false,
         }
       ]
     },

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -1,4 +1,6 @@
+import { UiFinder } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -48,5 +50,16 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
     editor.setContent('<pre class="language-markup"><code>test content</code></pre>');
     TinyAssertions.assertCursor(editor, [ 0 ], 0);
     TinyAssertions.assertContent(editor, '<pre class="language-markup"><code>test content</code></pre>');
+  });
+
+  it('TINY-12120: Spellcheck is enforced.', async () => {
+    const editor = hook.editor();
+    await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
+    await UiFinder.pWaitFor('Should not have spellchecking', SugarBody.body(), 'textarea:not([spellcheck="true"])');
+    await TestUtils.pCancelDialog(editor);
+    editor.options.set('browser_spellcheck', true);
+    await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
+    await UiFinder.pWaitFor('Should not have spellchecking', SugarBody.body(), 'textarea[spellcheck="true"]');
+    await TestUtils.pCancelDialog(editor);
   });
 });

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -55,11 +55,7 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
   it('TINY-12120: Spellcheck is enforced.', async () => {
     const editor = hook.editor();
     await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
-    await UiFinder.pWaitFor('Should not have spellchecking', SugarBody.body(), 'textarea:not([spellcheck="true"])');
-    await TestUtils.pCancelDialog(editor);
-    editor.options.set('browser_spellcheck', true);
-    await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
-    await UiFinder.pWaitFor('Should have spellchecking', SugarBody.body(), 'textarea[spellcheck="true"]');
+    await UiFinder.pWaitFor('Should not have spellchecking', SugarBody.body(), 'textarea:not([spellcheck="false"])');
     await TestUtils.pCancelDialog(editor);
   });
 });

--- a/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/browser/CodeSampleSanityTest.ts
@@ -59,7 +59,7 @@ describe('browser.tinymce.plugins.codesample.CodeSampleSanityTest', () => {
     await TestUtils.pCancelDialog(editor);
     editor.options.set('browser_spellcheck', true);
     await TestUtils.pOpenDialogAndAssertInitial(editor, 'markup', '');
-    await UiFinder.pWaitFor('Should not have spellchecking', SugarBody.body(), 'textarea[spellcheck="true"]');
+    await UiFinder.pWaitFor('Should have spellchecking', SugarBody.body(), 'textarea[spellcheck="true"]');
     await TestUtils.pCancelDialog(editor);
   });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -1,6 +1,5 @@
 import {
-  AddEventsBehaviour, AlloyEvents, AlloyTriggers, Behaviour, Disabling, FormField as AlloyFormField, Input as AlloyInput, Invalidating, Keying,
-  NativeEvents, Representing, SketchSpec, SystemEvents, Tabstopping
+  AddEventsBehaviour, AlloyEvents, FormField as AlloyFormField, Input as AlloyInput, AlloyTriggers, Behaviour, Disabling, Invalidating, Keying, NativeEvents, Representing, SketchSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
 import { Dialog } from '@ephox/bridge';
 import { Arr, Fun, Future, Optional, Result } from '@ephox/katamari';
@@ -29,6 +28,7 @@ export interface TextField {
   readonly maximized: boolean;
   readonly data: Optional<string>;
   readonly context: string;
+  readonly spellcheck: Optional<boolean>;
 }
 
 type InputSpec = Omit<Dialog.Input, 'type'>;
@@ -79,8 +79,10 @@ const renderTextField = (spec: TextField, providersBackstage: UiFactoryBackstage
 
   const placeholder = spec.placeholder.fold( Fun.constant({}), (p) => ({ placeholder: providersBackstage.translate(p) }));
   const inputMode = spec.inputMode.fold(Fun.constant({}), (mode) => ({ inputmode: mode }));
+  const spellcheck = spec.spellcheck.fold(Fun.constant({}), (spellchecker) => ({ spellcheck: spellchecker }));
 
   const inputAttributes = {
+    ...spellcheck,
     ...placeholder,
     ...inputMode,
     'data-mce-name': spec.name
@@ -141,7 +143,8 @@ const renderInput = (spec: InputSpec, providersBackstage: UiFactoryBackstageProv
   validation: Optional.none(),
   maximized: spec.maximized,
   data: initialData,
-  context: spec.context
+  context: spec.context,
+  spellcheck: Optional.none(),
 }, providersBackstage);
 
 const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBackstageProviders, initialData: Optional<string>): SketchSpec => renderTextField({
@@ -156,7 +159,8 @@ const renderTextarea = (spec: TextAreaSpec, providersBackstage: UiFactoryBacksta
   validation: Optional.none(),
   maximized: spec.maximized,
   data: initialData,
-  context: spec.context
+  context: spec.context,
+  spellcheck: spec.spellcheck,
 }, providersBackstage);
 
 export {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/textarea/TextareaTest.ts
@@ -18,7 +18,8 @@ describe('headless.tinymce.themes.silver.components.textarea.TextareaTest', () =
       label: Optional.some('LabelA'),
       placeholder: Optional.none(),
       maximized: false,
-      enabled: true
+      enabled: true,
+      spellcheck: Optional.from(true),
     }, TestProviders, Optional.none())
   ));
 
@@ -39,7 +40,8 @@ describe('headless.tinymce.themes.silver.components.textarea.TextareaTest', () =
               s.element('textarea', {
                 classes: [ arr.has('tox-textarea') ],
                 attrs: {
-                  'data-alloy-tabstop': str.is('true')
+                  'data-alloy-tabstop': str.is('true'),
+                  'spellcheck': str.is('true'),
                 }
               })
             ]


### PR DESCRIPTION
Related Ticket: TINY-12120

Description of Changes:
Mirror the spellcheck-attribute on the code sample text area.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where spellcheck was not properly disabled in the Codesample dialog. Spellcheck is now correctly disabled in code input areas.

- **New Features**
  - Added support for enabling or disabling spellcheck on textarea inputs across dialogs.

- **Tests**
  - Added tests to verify the correct behavior of the spellcheck attribute in code dialogs and textarea components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->