### PR TITLE
TINY-12187: add iframe_aria_required option

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12187-2025-06-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-12187-2025-06-03.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: New `iframe_aria_required` option that sets `aria-required` attribute on iframe element. It's
+  also possible to set the attribute directly on the Ediotr's element.
+time: 2025-06-03T16:54:26.100388+02:00
+custom:
+  Issue: TINY-12187

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -135,6 +135,7 @@ interface BaseEditorOptions {
   icons_url?: string;
   id?: string;
   iframe_aria_text?: string;
+  iframe_aria_required?: boolean;
   iframe_attrs?: Record<string, string>;
   images_file_types?: string;
   images_replace_blob_uris?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -532,6 +532,11 @@ const register = (editor: Editor): void => {
     default: 'Rich Text Area'.concat(editor.hasPlugin('help') ? '. Press ALT-0 for help.' : '')
   });
 
+  registerOption('iframe_aria_required', {
+    processor: 'boolean',
+    default: false
+  });
+
   registerOption('setup', {
     processor: 'function'
   });
@@ -991,6 +996,7 @@ const isVisualAidsEnabled = option('visual');
 const getVisualAidsTableClass = option('visual_table_class');
 const getVisualAidsAnchorClass = option('visual_anchor_class');
 const getIframeAriaText = option('iframe_aria_text');
+const isIframeAriaRequired = option('iframe_aria_required');
 const getSetupCallback = option('setup');
 const getInitInstanceCallback = option('init_instance_callback');
 const getUrlConverterCallback = option('urlconverter_callback');
@@ -1113,6 +1119,7 @@ export {
   getInitInstanceCallback,
   getUrlConverterCallback,
   getIframeAriaText,
+  isIframeAriaRequired,
   getAutoFocus,
   shouldBrowserSpellcheck,
   getProtect,

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -63,11 +63,23 @@ const getIframeHtml = (editor: Editor) => {
   return iframeHTML;
 };
 
+const getIframeAriaRequired = (editor: Editor): {} => {
+  const editorElAriaRequiredOverride = editor.getElement().getAttribute('aria-required');
+  if (editorElAriaRequiredOverride !== null) {
+    return { 'aria-required': editorElAriaRequiredOverride };
+  }
+  return Options.isIframeAriaRequired(editor) ? { 'aria-required': 'true' } : {};
+};
+
 const createIframe = (editor: Editor, boxInfo: BoxInfo) => {
   const iframeTitle = Env.browser.isFirefox() ? Options.getIframeAriaText(editor) : 'Rich Text Area';
   const translatedTitle = editor.translate(iframeTitle);
   const tabindex = Attribute.getOpt(SugarElement.fromDom(editor.getElement()), 'tabindex').bind(Strings.toInt);
-  const ifr = createIframeElement(editor.id, translatedTitle, Options.getIframeAttrs(editor), tabindex).dom;
+  const iframeAttrs = {
+    ...Options.getIframeAttrs(editor),
+    ...getIframeAriaRequired(editor)
+  };
+  const ifr = createIframeElement(editor.id, translatedTitle, iframeAttrs, tabindex).dom;
 
   ifr.onload = () => {
     ifr.onload = null;


### PR DESCRIPTION
Related Ticket: TINY-12187

Description of Changes:
* Added new `iframe_aria_required` option that sets `aria-required` attribute on iframe element
* Implemented functionality to set the attribute directly on the Editor's element

Pre-checks:
* [x] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to set the aria-required attribute on the editor's iframe, enhancing accessibility.
  - Developers can now specify whether the iframe or the editor element is required for ARIA compliance via configuration or direct attribute setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->