### PR TITLE
TINY-12004: Fixed issue with siblings and nested formats

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -231,6 +231,8 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
       });
     }
 
+    NormalizeTagOrder.normalizeFontSizeElementsAfterApply(ed, name, SugarElements.fromDom(newWrappers));
+
     // Cleanup
     Arr.each(newWrappers, (node) => {
       const getChildCount = (node: Node) => {
@@ -283,8 +285,6 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
         MergeFormats.mergeSiblings(ed, format, vars, node);
       }
     });
-
-    NormalizeTagOrder.normalizeFontSizeElementsAfterApply(ed, name, SugarElements.fromDom(newWrappers));
   };
 
   // TODO: TINY-9142: Remove this to make nested noneditable formatting work

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -2576,6 +2576,16 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
 
       TinyAssertions.assertContent(editor, '<p><span style="font-size: 36pt;"><s>abc</s></span></p>');
     });
+
+    it('TINY-12004: Tag order should be altered when applying strikethrough even if selection has strikethrough siblings', () => {
+      const editor = hook.editor();
+
+      editor.setContent('<p><s>one</s><span style="font-size: 36pt;">two</span><s>three</s></p>');
+      TinySelections.setSelection(editor, [ 0, 1, 0 ], 0, [ 0, 1, 0 ], 3);
+      editor.formatter.apply('strikethrough');
+
+      TinyAssertions.assertContent(editor, '<p><s>one</s><span style="font-size: 36pt;"><s>two</s></span><s>three</s></p>');
+    });
   });
 
   context('TINY-10312: should not partially apply block format when caret is positioned between words', () => {

--- a/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/NormalizeTagOrderTest.ts
@@ -7,11 +7,11 @@ import Editor from 'tinymce/core/api/Editor';
 import * as NormalizeTagOrder from 'tinymce/core/fmt/NormalizeTagOrder';
 
 interface TestCase {
-  format: string;
-  html: string;
-  selection: Cursors.CursorPath;
-  expectedHtml: string;
-  expectedSelection: Cursors.CursorPath;
+  readonly format: string;
+  readonly html: string;
+  readonly selection: Cursors.CursorPath;
+  readonly expectedHtml: string;
+  readonly expectedSelection: Cursors.CursorPath;
 }
 
 describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
@@ -74,6 +74,14 @@ describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
         selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0 ], foffset: 'Hello'.length },
         expectedHtml: '<p><span style="color: red;"><span style="font-size: 40px;"><span style="text-decoration: line-through;">Hello</span></span></span></p>',
         expectedSelection: { startPath: [ 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order of strikethrough and font size when strikethrough is mixed with other styles on a s element', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s style="color: red">one<span style="font-size: 40px;">two</span>three</s></p>',
+        selection: { startPath: [ 0, 0, 1, 0 ], soffset: 0, finishPath: [ 0, 0, 1, 0 ], foffset: 'two'.length },
+        expectedHtml: '<p><s style="color: red;">one</s><span style="color: red;"><span style="font-size: 40px;"><s>two</s></span></span><s style="color: red;">three</s></p>',
+        expectedSelection: { startPath: [ 0, 1, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 1, 0, 0, 0 ], foffset: 'two'.length }
       }));
 
       it('TINY-12004: Switch order of strikethrough and font size with mixed content', () => testNormalizeFontSizeElementsAfterApply({
@@ -170,6 +178,22 @@ describe('browser.tinymce.core.fmt.NormalizeTagOrderTest', () => {
         selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 2, 0 ], foffset: 'world'.length },
         expectedHtml: '<p><span style="font-size: 40px;"><s>Hello</s></span><s> </s><span style="font-size: 32px;"><s>world</s></span></p>',
         expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 2, 0, 0 ], foffset: 'world'.length }
+      }));
+
+      it('TINY-12004: Switch order with multiple nested font size alterting elements', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><sub><sup><span style="font-size: 40px;">Hello</span></sup></sub></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0, 0 ], foffset: 'Hello'.length },
+        expectedHtml: '<p><sub><sup><span style="font-size: 40px;"><s>Hello</s></span></sup></sub></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 0, 0, 0 ], foffset: 'Hello'.length }
+      }));
+
+      it('TINY-12004: Switch order with mixed font size and superscript with additional text content', () => testNormalizeFontSizeElementsAfterApply({
+        format: 'fontsize',
+        html: '<p><s><span style="font-size: 40px;">E=mc<sup>2</sup></span></s></p>',
+        selection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 0, 1, 0 ], foffset: '2'.length },
+        expectedHtml: '<p><span style="font-size: 40px;"><s>E=mc</s><sup><s>2</s></sup></span></p>',
+        expectedSelection: { startPath: [ 0, 0, 0, 0 ], soffset: 0, finishPath: [ 0, 0, 1, 0, 0 ], foffset: '2'.length }
       }));
     });
 


### PR DESCRIPTION
Related Ticket: TINY-12004

Description of Changes:
* Fixes an issue found by QA where sibling strikethroughs wouldn't be handled correctly
* Fixed an issue found by me when we have complex nesting of font size altering elements
* Minor cleanup by adding `readonly` to the test case type

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of font size and strikethrough formatting to ensure correct tag order when applying styles, especially in complex nested scenarios.

- **Tests**
  - Added new test cases to verify correct tag order and formatting behavior with combinations of strikethrough, font size, subscript, and superscript.
  - Enhanced immutability in test case definitions for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->