### PR TITLE
TINY-12210: Move Suggested Edits content CSS to oxide

### DIFF
--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -286,7 +286,7 @@
                 }
               }
 
-              .tox-suggestededits__card--suggestion-user {
+              .tox-suggestededits__card--feedback-user {
                 display: flex;
                 align-items: center;
                 flex: 1 0 0;
@@ -393,7 +393,7 @@
                 }
               }
 
-              .tox-suggestededits__card--suggestion {
+              .tox-suggestededits__card--feedback {
                 color: @suggestededits-text-color;
                 width: 100%;
               }
@@ -436,7 +436,7 @@
                 justify-content: space-between;
               }
 
-              &.tox-suggestededits__card--suggestion-buttons {
+              &.tox-suggestededits__card--feedback-buttons {
                 justify-content: right;
               }
 

--- a/modules/oxide/src/less/theme/content-ui.less
+++ b/modules/oxide/src/less/theme/content-ui.less
@@ -22,6 +22,7 @@
 @import 'content/searchreplace/searchreplace';
 @import 'content/selection/selection';
 @import 'content/spellchecker/spellchecker';
+@import 'content/suggestededits/suggestededits';
 @import 'content/table-of-contents/table-of-contents';
 @import 'content/transparent/transparent';
 @import 'content/table/table';
@@ -29,4 +30,3 @@
 @import 'content/visualblocks/visualblocks';
 @import 'content/visualchars/visualchars';
 @import 'content/accessibility-checker/accessibility-checker';
-

--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -1,0 +1,92 @@
+//
+// Suggested Edits
+//
+
+@added-background-color: saturate(lighten(@color-success, 34%), 25%);
+@modified-background-color: desaturate(lighten(@color-tint, 44%), 12%);
+@removed-background-color: desaturate(lighten(@color-error, 40%), 25%);
+
+@selected-outline-color: @color-tint;
+@selected-box-shadow: 0 -2px 0 0 @selected-outline-color inset, 0 -2px 0 0 @selected-outline-color;
+
+.tox-suggestededits__annotation--added,
+.tox-suggestededits__annotation--modified,
+.tox-suggestededits__annotation--removed {
+  text-decoration: none;
+}
+
+.tox-suggestededits__annotation--added__highlight {
+	background-color: @added-background-color;
+  text-decoration: underline;
+}
+
+.tox-suggestededits__annotation--added__selected {
+	background-color: @added-background-color;
+	box-shadow: @selected-box-shadow;
+  text-decoration: none;
+}
+
+.tox-suggestededits__annotation--modified__highlight {
+	background-color: @modified-background-color;
+	text-decoration: underline;
+}
+
+.tox-suggestededits__annotation--modified__selected {
+	background-color: @modified-background-color;
+  box-shadow: @selected-box-shadow;
+  text-decoration: none;
+}
+
+.tox-suggestededits__annotation--removed__highlight {
+	background-color: @removed-background-color;
+	text-decoration: 'strike-through';
+}
+
+.tox-suggestededits__annotation--removed__selected {
+	background-color: @removed-background-color;
+	box-shadow: @selected-box-shadow;
+	text-decoration: 'strike-through';
+}
+
+.tox-suggestededits__annotation--added.tox-suggestededits__annotation--added__hidden,
+.tox-suggestededits__annotation--modified.tox-suggestededits__annotation--modified__hidden,
+.tox-suggestededits__annotation--removed.tox-suggestededits__annotation--removed__hidden {
+  display: none;
+  text-decoration: none;
+}
+
+*:has(> div > iframe) {
+  &.tox-suggestededits__annotation--added,
+  &.tox-suggestededits__annotation--modified,
+  &.tox-suggestededits__annotation--removed {
+    padding: 7px;
+    margin: 5px;
+  }
+}
+
+img,
+video {
+  &.tox-suggestededits__annotation--added__highlight {
+    outline: 0.25em solid @added-background-color;
+  }
+
+  &.tox-suggestededits__annotation--added__selected {
+    outline: 0.25em solid @color-success;
+  }
+
+  &.tox-suggestededits__annotation--modified__highlight {
+    outline: 0.25em solid @modified-background-color;
+  }
+
+  &.tox-suggestededits__annotation--modified__selected {
+    outline: 0.25em solid @color-tint;
+  }
+
+  &.tox-suggestededits__annotation--removed__highlight {
+    outline: 0.25em solid @removed-background-color;
+  }
+
+  &.tox-suggestededits__annotation--removed__selected {
+    outline: 0.25em solid @color-error;
+  }
+}


### PR DESCRIPTION
Related Ticket: TINY-12210, TINY-12063

Description of Changes:
* Moving content css of suggested edits to oxide content css
* Should only be visible in suggested edits view, but would be visible with the right classes
* No support for dark mode due to limitations in global variable usage and contrast calculation
  * Using a darker color for dark mode will result in that color being used in light mode as it is higher contrast
  * There is no workaround for this and the design is impossible to fully implement
  * For now we will only support light mode, but integrators can customize this with their own CSS
* Fixed issue with videos missing highlighting

Pre-checks:
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
