### PR TITLE
TINY-12189: add aria-label for colorswatch, imageselect and inserttable widgets

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12189-2025-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-12189-2025-06-11.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Instructions on how to navigate the color swatch, image select and an insert
+body: Instructions on how to navigate the color swatch, image select and insert
   table widget are now announced by the screen readers.
 time: 2025-06-11T14:36:11.191606+02:00
 custom:

--- a/.changes/unreleased/tinymce-TINY-12189-2025-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-12189-2025-06-11.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Improved
+body: Instructions on how to navigate the color swatch, image select and an insert
+  table widget are now announced by the screen readers.
+time: 2025-06-11T14:36:11.191606+02:00
+custom:
+  Issue: TINY-12189

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
@@ -25,7 +25,7 @@ const forSwatch = (columns: number | 'auto'): StructureSpec => ({
     tag: 'div',
     classes: [ 'tox-menu', 'tox-swatches-menu' ],
     attributes: {
-      'aria-label': 'Use arrow keys to navigate left/right up/down.'
+      'aria-label': 'Use arrow keys to navigate.'
     }
   },
   components: [
@@ -159,7 +159,7 @@ const forCollection = (columns: number | 'auto', initItems: ItemTypes.ItemSpec[]
     ),
     attributes: {
       // widget item can be inserttable, colorswatch or imageselect - all of them are navigated with arrow keys
-      ...hasWidget(initItems) ? { 'aria-label': 'Use arrow keys to navigate left/right up/down.' } : {}
+      ...hasWidget(initItems) ? { 'aria-label': 'Use arrow keys to navigate.' } : {}
     },
   },
   components: [

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
@@ -23,7 +23,10 @@ const chunk = <I>(rowDom: RawDomSchema, numColumns: number) => (items: I[]): Arr
 const forSwatch = (columns: number | 'auto'): StructureSpec => ({
   dom: {
     tag: 'div',
-    classes: [ 'tox-menu', 'tox-swatches-menu' ]
+    classes: [ 'tox-menu', 'tox-swatches-menu' ],
+    attributes: {
+      'aria-label': 'Use arrow keys to navigate left/right up/down.'
+    }
   },
   components: [
     {
@@ -145,12 +148,19 @@ const insertItemsPlaceholder = (
   });
 };
 
+export const hasWidget = (items: ItemTypes.ItemSpec[]): boolean =>
+  Arr.exists(items, (item) => item.type === 'widget');
+
 const forCollection = (columns: number | 'auto', initItems: ItemTypes.ItemSpec[], _hasIcons: boolean = true): StructureSpec => ({
   dom: {
     tag: 'div',
     classes: [ 'tox-menu', 'tox-collection' ].concat(
       columns === 1 ? [ 'tox-collection--list' ] : [ 'tox-collection--grid' ]
-    )
+    ),
+    attributes: {
+      // widget item can be inserttable, colorswatch or imageselect - all of them are navigated with arrow keys
+      ...hasWidget(initItems) ? { 'aria-label': 'Use arrow keys to navigate left/right up/down.' } : {}
+    },
   },
   components: [
     // We don't need to add IDs for each item because there are no

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
@@ -12,6 +12,8 @@ export interface StructureSpec extends SimpleSpec {
   readonly components: AlloySpec[];
 }
 
+const widgetAriaLabel = 'Use arrow keys to navigate.';
+
 const chunk = <I>(rowDom: RawDomSchema, numColumns: number) => (items: I[]): Array<{ dom: RawDomSchema; components: I[] }> => {
   const chunks = Arr.chunk(items, numColumns);
   return Arr.map(chunks, (c) => ({
@@ -25,7 +27,7 @@ const forSwatch = (columns: number | 'auto'): StructureSpec => ({
     tag: 'div',
     classes: [ 'tox-menu', 'tox-swatches-menu' ],
     attributes: {
-      'aria-label': 'Use arrow keys to navigate.'
+      'aria-label': I18n.translate(widgetAriaLabel)
     }
   },
   components: [
@@ -159,7 +161,7 @@ const forCollection = (columns: number | 'auto', initItems: ItemTypes.ItemSpec[]
     ),
     attributes: {
       // widget item can be inserttable, colorswatch or imageselect - all of them are navigated with arrow keys
-      ...hasWidget(initItems) ? { 'aria-label': 'Use arrow keys to navigate.' } : {}
+      ...hasWidget(initItems) ? { 'aria-label': I18n.translate(widgetAriaLabel) } : {}
     },
   },
   components: [


### PR DESCRIPTION
Related Ticket: TINY-12189

Description of Changes:
* Added `aria-label` attribute to the color swatch 
* Added conditional `aria-label` attribute to collection menus when they contain widgets

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved accessibility in the TinyMCE editor with screen reader announcements providing navigation instructions for the color swatch, image select, and insert table widgets.
  - Enhanced keyboard navigation cues in menus with additional ARIA labels for better support with assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->