### PR TITLE
TINY-12213: Introduce minor CSS tweaks

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -31,8 +31,8 @@
 }
 
 .tox {
-  .tox-revisionhistory__pane {
-    padding: 0 !important;      /* Override the default padding of tox-view__pane */
+  .tox-view .tox-revisionhistory__pane {
+    padding: 0;      /* Override the default padding of tox-view__pane */
   }
 
   .tox-revisionhistory__container {

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -8,7 +8,7 @@
 @suggestededits-color-tint: @color-tint;
 @suggestededits-text-color: @text-color;
 
-@suggestededits-dark-transparent-color: transparentize(@color-black, 0.1);
+@suggestededits-dark-transparent-color: mix(@color-black, @background-color, 20%);
 
 @suggestededits-background-color: @background-color;
 @suggestededits-border-color: @border-color;

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -29,6 +29,10 @@
 @suggestededits-card-selected-border-color: @suggestededits-color-tint;
 
 .tox {
+  .tox-suggestededits__pane {
+    padding: 0 !important;      /* Override the default padding of tox-view__pane */
+  }
+
   .tox-suggestededits__sink {
     position: relative;
     z-index: 1000;

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -29,8 +29,8 @@
 @suggestededits-card-selected-border-color: @suggestededits-color-tint;
 
 .tox {
-  .tox-suggestededits__pane {
-    padding: 0 !important;      /* Override the default padding of tox-view__pane */
+  .tox-view .tox-suggestededits__pane {
+    padding: 0;      /* Override the default padding of tox-view__pane */
   }
 
   .tox-suggestededits__sink {

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -161,7 +161,7 @@
             display: flex;
             flex-direction: column;
             gap: 6px;
-            padding: 8px;
+            padding: 6px;
 
             .tox-suggestededits__card--header {
               display: flex;


### PR DESCRIPTION
Related Ticket: [TINY-12213](https://ephocks.atlassian.net/browse/TINY-12213)

Description of Changes:
* Modified `@suggestededits-dark-transparent-color` so that it results in a value of `#d3d5d8`
* The `.tox-view__pane` class has a padding of `8px` but should be `0px` so I added a new selector `.tox-suggestededits__pane` to get around it, just like we did [here](https://github.com/tinymce/tinymce/blob/main/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less#L34). Follow-up ticket also created to address the root issue.
* The `.tox-suggestededits__card--single` has a padding of `8px`, it has now been changed to `6px`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12213]: https://ephocks.atlassian.net/browse/TINY-12213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the dark transparent color for Suggested Edits to improve visual blending.
  - Removed padding from the Suggested Edits pane for better alignment.
  - Reduced padding within single Suggested Edits cards for a more compact appearance.
  - Adjusted padding behavior in the Revision History pane for improved layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->