### PR TITLE
TINY-12228: Add new crossorigin option

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12228-2025-06-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-12228-2025-06-12.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: New `crossorigin` option that sets the `crossorigin` attribute on scripts loaded
+  by the editor.
+time: 2025-06-12T10:10:30.224276+02:00
+custom:
+  Issue: TINY-12228

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -313,10 +313,7 @@ class Editor implements EditorObservable {
       DOMUtils.DOM.styleSheetLoader._setReferrerPolicy(referrerPolicy);
     }
 
-    const crossOrigin = Options.getCrossOrigin(self);
-    if (Type.isNonNullable(crossOrigin)) {
-      ScriptLoader.ScriptLoader._setCrossOrigin(crossOrigin);
-    }
+    ScriptLoader.ScriptLoader._setCrossOrigin(Options.getCrossOrigin(self));
 
     const contentCssCors = Options.hasContentCssCors(self);
     if (Type.isNonNullable(contentCssCors)) {

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -313,6 +313,11 @@ class Editor implements EditorObservable {
       DOMUtils.DOM.styleSheetLoader._setReferrerPolicy(referrerPolicy);
     }
 
+    const crossOrigin = Options.getCrossOrigin(self);
+    if (Type.isNonNullable(crossOrigin)) {
+      ScriptLoader.ScriptLoader._setCrossOrigin(crossOrigin);
+    }
+
     const contentCssCors = Options.hasContentCssCors(self);
     if (Type.isNonNullable(contentCssCors)) {
       DOMUtils.DOM.styleSheetLoader._setContentCssCors(contentCssCors);

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -47,6 +47,8 @@ export interface ToolbarGroup {
 export type ToolbarMode = 'floating' | 'sliding' | 'scrolling' | 'wrap';
 export type ToolbarLocation = 'top' | 'bottom' | 'auto';
 
+export type CrossOrigin = '' | 'anonymous' | 'use-credentials';
+
 interface BaseEditorOptions {
   a11y_advanced_options?: boolean;
   add_form_submit_trigger?: boolean;
@@ -196,7 +198,7 @@ interface BaseEditorOptions {
   protect?: RegExp[];
   readonly?: boolean;
   referrer_policy?: ReferrerPolicy;
-  crossorigin?: '' | 'anonymous' | 'use-credentials';
+  crossorigin?: CrossOrigin;
   relative_urls?: boolean;
   remove_script_host?: boolean;
   remove_trailing_brs?: boolean;
@@ -302,6 +304,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   content_css: string[];
   contextmenu: string[];
   convert_unsafe_embeds: boolean;
+  crossorigin: CrossOrigin;
   custom_colors: boolean;
   default_font_stack: string[];
   document_base_url: string;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -196,7 +196,7 @@ interface BaseEditorOptions {
   protect?: RegExp[];
   readonly?: boolean;
   referrer_policy?: ReferrerPolicy;
-  crossorigin?: 'anonymous' | 'use-credentials';
+  crossorigin?: '' | 'anonymous' | 'use-credentials';
   relative_urls?: boolean;
   remove_script_host?: boolean;
   remove_trailing_brs?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -196,6 +196,7 @@ interface BaseEditorOptions {
   protect?: RegExp[];
   readonly?: boolean;
   referrer_policy?: ReferrerPolicy;
+  crossorigin?: 'anonymous' | 'use-credentials';
   relative_urls?: boolean;
   remove_script_host?: boolean;
   remove_trailing_brs?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -81,6 +81,11 @@ const register = (editor: Editor): void => {
     default: ''
   });
 
+  registerOption('crossorigin', {
+    processor: 'string',
+    default: ''
+  });
+
   registerOption('language_load', {
     processor: 'boolean',
     default: true
@@ -984,6 +989,7 @@ const getImagesUploadCredentials = option('images_upload_credentials');
 const getImagesUploadHandler = option('images_upload_handler');
 const shouldUseContentCssCors = option('content_css_cors');
 const getReferrerPolicy = option('referrer_policy');
+const getCrossOrigin = option('crossorigin');
 const getLanguageCode = option('language');
 const getLanguageUrl = option('language_url');
 const shouldIndentUseMargin = option('indent_use_margin');
@@ -1106,6 +1112,7 @@ export {
   getImagesUploadHandler,
   shouldUseContentCssCors,
   getReferrerPolicy,
+  getCrossOrigin,
   getLanguageCode,
   getLanguageUrl,
   shouldIndentUseMargin,

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -117,7 +117,7 @@ class ScriptLoader {
       }
 
       const crossOrigin = this.settings.crossOrigin;
-      if (Type.isString(crossOrigin) && crossOrigin.length > 0) {
+      if (Type.isString(crossOrigin)) {
         dom.setAttrib(elm, 'crossorigin', crossOrigin);
       }
 

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -32,6 +32,7 @@ const DOM = DOMUtils.DOM;
 
 export interface ScriptLoaderSettings {
   referrerPolicy?: ReferrerPolicy;
+  crossOrigin?: string;
 }
 
 export interface ScriptLoaderConstructor {
@@ -63,6 +64,10 @@ class ScriptLoader {
 
   public _setReferrerPolicy(referrerPolicy: ReferrerPolicy): void {
     this.settings.referrerPolicy = referrerPolicy;
+  }
+
+  public _setCrossOrigin(crossOrigin: string): void {
+    this.settings.crossOrigin = crossOrigin;
   }
 
   /**
@@ -109,6 +114,11 @@ class ScriptLoader {
       if (this.settings.referrerPolicy) {
         // Note: Don't use elm.referrerPolicy = ... here as it doesn't work on Safari
         dom.setAttrib(elm, 'referrerpolicy', this.settings.referrerPolicy);
+      }
+
+      const crossOrigin = this.settings.crossOrigin;
+      if (Type.isString(crossOrigin) && crossOrigin.length > 0) {
+        dom.setAttrib(elm, 'crossorigin', crossOrigin);
       }
 
       elm.onload = done;

--- a/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginTest.ts
@@ -24,7 +24,7 @@ describe('browser.tinymce.core.dom.CrossOriginTest', () => {
   const isScript = SugarNode.isTag('script');
 
   const pLoadScript = async (url: string, timeout: number = 1000) => {
-    let resolve: (scripts: SugarElement<HTMLScriptElement>) => void;
+    let resolve: (script: SugarElement<HTMLScriptElement>) => void;
     let reject: (reason: Error) => void;
     const time = Date.now();
     const observePromise = new Promise<SugarElement<HTMLScriptElement>>((res, rej) => {

--- a/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginTest.ts
@@ -7,8 +7,7 @@ import { assert } from 'chai';
 import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
-
-type CrossOrigin = 'anonymous' | 'use-credentials' | '';
+import * as OptionTypes from 'tinymce/core/api/OptionTypes';
 
 describe('browser.tinymce.core.dom.CrossOriginTest', () => {
   const settings = {
@@ -72,7 +71,7 @@ describe('browser.tinymce.core.dom.CrossOriginTest', () => {
   });
 
   context('Using global setter', () => {
-    const pTestCrossOriginSetter = async (crossOrigin: CrossOrigin) => {
+    const pTestCrossOriginSetter = async (crossOrigin: OptionTypes.CrossOrigin) => {
       ScriptLoader.ScriptLoader._setCrossOrigin(crossOrigin);
       assertCrossOriginAttribute(await pLoadScript(scriptUrl), crossOrigin);
     };
@@ -105,7 +104,7 @@ describe('browser.tinymce.core.dom.CrossOriginTest', () => {
   });
 
   context('Using overrideDefaults', () => {
-    const pTestCrossOriginEditorOption = async (crossOrigin: CrossOrigin) => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: OptionTypes.CrossOrigin) => {
       EditorManager.overrideDefaults({
         crossorigin: crossOrigin
       });

--- a/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginTest.ts
@@ -1,0 +1,90 @@
+import { after, context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Attribute, SugarElement, SugarNode } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.dom.CrossOriginTest', () => {
+  const settings = {
+    base_url: '/project/tinymce/js/tinymce',
+    menubar: false,
+    toolbar: false
+  };
+  const scriptUrl = '/project/tinymce/src/core/test/assets/js/test.js';
+
+  after(() => {
+    ScriptLoader.ScriptLoader._setCrossOrigin('');
+  });
+
+  const isScript = SugarNode.isTag('script');
+
+  const pLoadScript = async (url: string, timeout: number = 1000) => {
+    let resolve: (scripts: SugarElement<HTMLScriptElement>) => void;
+    let reject: (reason: Error) => void;
+    const time = Date.now();
+    const observePromise = new Promise<SugarElement<HTMLScriptElement>>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        Arr.each(mutation.addedNodes, (node) => {
+          const sugarNode = SugarElement.fromDom(node);
+          if (isScript(sugarNode) && Attribute.get(sugarNode, 'src') === url) {
+            clearTimeout(timer);
+            observer.disconnect();
+            resolve(sugarNode);
+          }
+        });
+      });
+    });
+
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+
+    const timer = setTimeout(() => {
+      observer.disconnect();
+      reject(new Error(`Timed out waiting for script to appear in the dom after ${Date.now() - time}ms`));
+    }, timeout);
+
+    await ScriptLoader.ScriptLoader.loadScript(url);
+
+    return observePromise;
+  };
+
+  const assertCrossOriginAttribute = (script: SugarElement<HTMLScriptElement>, crossOrigin: string) => {
+    if (crossOrigin === '') {
+      assert.isFalse(Attribute.has(script, 'crossorigin'), 'Crossorigin attribute should not be set');
+    } else {
+      assert.equal(Attribute.get(script, 'crossorigin'), crossOrigin, `Crossorigin attribute should be set to "${crossOrigin}"`);
+    }
+  };
+
+  context('Using global setter', () => {
+    const pTestCrossOriginSetter = async (crossOrigin: string) => {
+      ScriptLoader.ScriptLoader._setCrossOrigin(crossOrigin);
+      assertCrossOriginAttribute(await pLoadScript(scriptUrl), crossOrigin);
+    };
+
+    it('TINY-12228: Should support setting anonymous crossorigin', () => pTestCrossOriginSetter('anonymous'));
+    it('TINY-12228: Should support setting use-credentials crossorigin', () => pTestCrossOriginSetter('use-credentials'));
+    it('TINY-12228: Should support setting empty crossorigin', () => pTestCrossOriginSetter(''));
+  });
+
+  context('Using editor option', () => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: string) => {
+      const editor = await McEditor.pFromSettings<Editor>({ ...settings, crossorigin: crossOrigin });
+
+      assertCrossOriginAttribute(await pLoadScript(scriptUrl), crossOrigin);
+
+      McEditor.remove(editor);
+    };
+
+    it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption('anonymous'));
+    it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption('use-credentials'));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(''));
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-12228

Description of Changes:
* Adds new `crossorigin` option

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to set the cross-origin attribute on scripts loaded by the editor, enhancing control over external script fetching.
- **Tests**
  - Added tests to ensure proper behavior of the cross-origin attribute on dynamically loaded script elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->