### PR TITLE
TINY-12054: Tooltips can now close when pressing escape.

### DIFF
--- a/.changes/unreleased/alloy-TINY-12054-2025-06-11.yaml
+++ b/.changes/unreleased/alloy-TINY-12054-2025-06-11.yaml
@@ -1,0 +1,6 @@
+project: alloy
+kind: Improved
+body: Tooltips close when recieving a message in the close tooltips channel.
+time: 2025-06-11T06:53:35.140151+02:00
+custom:
+    Issue: TINY-12054

--- a/.changes/unreleased/tinymce-TINY-12054-2025-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-12054-2025-06-11.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Tooltips can be closed by pressing escape.
+time: 2025-06-11T06:53:35.140164+02:00
+custom:
+    Issue: TINY-12054

--- a/.changes/unreleased/tinymce-TINY-12054-2025-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-12054-2025-06-11.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Tooltips can be closed by pressing escape.
+body: Tooltips can now be closed by pressing the escape key.
 time: 2025-06-11T06:53:35.140164+02:00
 custom:
     Issue: TINY-12054

--- a/modules/alloy/src/main/ts/ephox/alloy/api/messages/Channels.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/api/messages/Channels.ts
@@ -1,11 +1,13 @@
 import { Fun } from '@ephox/katamari';
 
+const closeTooltips = Fun.constant('tooltipping.close.all');
 const dismissPopups = Fun.constant('dismiss.popups');
 const repositionPopups = Fun.constant('reposition.popups');
 const mouseReleased = Fun.constant('mouse.released');
 
 export {
+  closeTooltips,
   dismissPopups,
-  repositionPopups,
-  mouseReleased
+  mouseReleased,
+  repositionPopups
 };

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
@@ -10,6 +10,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
+import { closeTooltips } from '../../api/messages/Channels';
 import * as Attachment from '../../api/system/Attachment';
 import { ReceivingInternalEvent } from '../../events/SimulatedEvent';
 
@@ -190,7 +191,11 @@ const events = (tooltipConfig: TooltippingConfig, state: TooltippingState): Allo
         // to rely on receiving.
         const receivingData = message as unknown as ReceivingInternalEvent;
         if (!receivingData.universal) {
-          if (Arr.contains(receivingData.channels, ExclusivityChannel)) {
+          if (Arr.contains(receivingData.channels, ExclusivityChannel) || Arr.contains(receivingData.channels, closeTooltips())) {
+            if (receivingData.data.closedTooltip && state.isShowing()) {
+              receivingData.data.closedTooltip();
+            }
+
             hide(comp);
           }
         }

--- a/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/behaviour/tooltipping/ActiveTooltipping.ts
@@ -10,7 +10,7 @@ import * as AlloyEvents from '../../api/events/AlloyEvents';
 import * as AlloyTriggers from '../../api/events/AlloyTriggers';
 import * as NativeEvents from '../../api/events/NativeEvents';
 import * as SystemEvents from '../../api/events/SystemEvents';
-import { closeTooltips } from '../../api/messages/Channels';
+import * as Channels from '../../api/messages/Channels';
 import * as Attachment from '../../api/system/Attachment';
 import { ReceivingInternalEvent } from '../../events/SimulatedEvent';
 
@@ -191,7 +191,7 @@ const events = (tooltipConfig: TooltippingConfig, state: TooltippingState): Allo
         // to rely on receiving.
         const receivingData = message as unknown as ReceivingInternalEvent;
         if (!receivingData.universal) {
-          if (Arr.contains(receivingData.channels, ExclusivityChannel) || Arr.contains(receivingData.channels, closeTooltips())) {
+          if (Arr.contains(receivingData.channels, ExclusivityChannel) || Arr.contains(receivingData.channels, Channels.closeTooltips())) {
             if (receivingData.data.closedTooltip && state.isShowing()) {
               receivingData.data.closedTooltip();
             }

--- a/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/keying/TabbingTypes.ts
@@ -4,7 +4,7 @@ import { Compare, Height, SelectorFilter, SelectorFind, SugarElement, Traverse }
 
 import * as Keys from '../alien/Keys';
 import { AlloyComponent } from '../api/component/ComponentApi';
-import { closeTooltips } from '../api/messages/Channels';
+import * as Channels from '../api/messages/Channels';
 import { NoState, Stateless } from '../behaviour/common/BehaviourState';
 import { NativeSimulatedEvent } from '../events/SimulatedEvent';
 import * as ArrNavigation from '../navigation/ArrNavigation';
@@ -116,7 +116,7 @@ const create = (cyclicField: FieldProcessor): KeyingType.KeyingType<TabbingConfi
     tabbingConfig.onEnter.bind((f) => f(component, simulatedEvent));
 
   const exit: KeyRuleStatelessHandler<TabbingConfig> = (component, simulatedEvent, tabbingConfig) => {
-    component.getSystem().broadcastOn([ closeTooltips() ], {
+    component.getSystem().broadcastOn([ Channels.closeTooltips() ], {
       closedTooltip: () => {
         simulatedEvent.stop();
       }

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -108,7 +108,7 @@ const fireDisabledStateChange = (editor: Editor, state: boolean): EditorEvent<Di
   editor.dispatch('DisabledStateChange', { state });
 
 const fireCloseTooltips = (editor: Editor): EditorEvent<DisabledStateChangeEvent> =>
-  editor.dispatch('CloseActivePopups');
+  editor.dispatch('CloseActiveTooltips');
 
 export {
   firePreProcess,

--- a/modules/tinymce/src/core/main/ts/api/Events.ts
+++ b/modules/tinymce/src/core/main/ts/api/Events.ts
@@ -107,6 +107,9 @@ const fireEditableRootStateChange = (editor: Editor, state: boolean): EditorEven
 const fireDisabledStateChange = (editor: Editor, state: boolean): EditorEvent<DisabledStateChangeEvent> =>
   editor.dispatch('DisabledStateChange', { state });
 
+const fireCloseTooltips = (editor: Editor): EditorEvent<DisabledStateChangeEvent> =>
+  editor.dispatch('CloseActivePopups');
+
 export {
   firePreProcess,
   firePostProcess,
@@ -134,5 +137,6 @@ export {
   firePastePostProcess,
   firePastePreProcess,
   fireEditableRootStateChange,
-  fireDisabledStateChange
+  fireDisabledStateChange,
+  fireCloseTooltips
 };

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -3,7 +3,7 @@ import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 import { AddOnConstructor } from '../api/AddOnManager';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
-import { fireCloseTooltips } from '../api/Events';
+import * as Events from '../api/Events';
 import IconManager from '../api/IconManager';
 import ModelManager, { Model } from '../api/ModelManager';
 import * as Options from '../api/Options';
@@ -51,7 +51,7 @@ const initPlugin = (editor: Editor, initializedPlugins: string[], plugin: string
 const initTooltipClosing = (editor: Editor) => {
   const closeTooltipsListener = (event: KeyboardEvent | EditorEvent<KeyboardEvent>) => {
     if (event.keyCode === VK.ESC && !event.defaultPrevented) {
-      if (fireCloseTooltips(editor).isDefaultPrevented()) {
+      if (Events.fireCloseTooltips(editor).isDefaultPrevented()) {
         event.preventDefault();
       }
     }

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -3,6 +3,7 @@ import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 import { AddOnConstructor } from '../api/AddOnManager';
 import DOMUtils from '../api/dom/DOMUtils';
 import Editor from '../api/Editor';
+import { fireCloseTooltips } from '../api/Events';
 import IconManager from '../api/IconManager';
 import ModelManager, { Model } from '../api/ModelManager';
 import * as Options from '../api/Options';
@@ -10,7 +11,9 @@ import { ThemeInitFunc } from '../api/OptionTypes';
 import PluginManager from '../api/PluginManager';
 import ThemeManager, { Theme } from '../api/ThemeManager';
 import { EditorUiApi } from '../api/ui/Ui';
+import { EditorEvent } from '../api/util/EventDispatcher';
 import Tools from '../api/util/Tools';
+import VK from '../api/util/VK';
 import * as ErrorReporter from '../ErrorReporter';
 import * as Disabled from '../mode/Disabled';
 
@@ -43,6 +46,28 @@ const initPlugin = (editor: Editor, initializedPlugins: string[], plugin: string
       ErrorReporter.pluginInitError(editor, plugin, e);
     }
   }
+};
+
+const initTooltipClosing = (editor: Editor) => {
+  const closeTooltipsListener = (event: KeyboardEvent | EditorEvent<KeyboardEvent>) => {
+    if (event.keyCode === VK.ESC && !event.defaultPrevented) {
+      if (fireCloseTooltips(editor).isDefaultPrevented()) {
+        event.preventDefault();
+      }
+    }
+  };
+
+  document.addEventListener('keyup', closeTooltipsListener);
+  if (!editor.inline) {
+    editor.on('keyup', closeTooltipsListener);
+  }
+
+  editor.on('remove', () => {
+    document.removeEventListener('keyup', closeTooltipsListener);
+    if (!editor.inline) {
+      editor.off('keyup', closeTooltipsListener);
+    }
+  });
 };
 
 const trimLegacyPrefix = (name: string) => {
@@ -175,6 +200,7 @@ const init = async (editor: Editor): Promise<void> => {
   editor.dispatch('ScriptsLoaded');
 
   initIcons(editor);
+  initTooltipClosing(editor);
   initTheme(editor);
   initModel(editor);
   initPlugins(editor);

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -120,7 +120,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     editor.on('ResizeEditor', onEditorResize);
     editor.on('AfterProgressState', onEditorProgress);
     editor.on('DismissPopups', onDismissPopups);
-    editor.on('CloseActivePopups', fireCloseTooltips);
+    editor.on('CloseActiveTooltips', fireCloseTooltips);
 
     Arr.each([ mothership, ...uiMotherships ], (gui) => {
       gui.element.dom.addEventListener('focusin', onFocusIn);
@@ -139,7 +139,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     editor.off('ResizeEditor', onEditorResize);
     editor.off('AfterProgressState', onEditorProgress);
     editor.off('DismissPopups', onDismissPopups);
-    editor.off('CloseActivePopups', fireCloseTooltips);
+    editor.off('CloseActiveTooltips', fireCloseTooltips);
 
     Arr.each([ mothership, ...uiMotherships ], (gui) => {
       gui.element.dom.removeEventListener('focusin', onFocusIn);

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -26,6 +26,14 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     { target: evt.target }
   );
 
+  const fireCloseTooltips = (event: Event) => {
+    broadcastOn(Channels.closeTooltips(), {
+      closedTooltip: () => {
+        event.preventDefault();
+      }
+    });
+  };
+
   // Document touch events
   const doc = SugarDocument.getDocument();
   const onTouchstart = DomEvent.bind(doc, 'touchstart', fireDismissPopups);
@@ -112,6 +120,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     editor.on('ResizeEditor', onEditorResize);
     editor.on('AfterProgressState', onEditorProgress);
     editor.on('DismissPopups', onDismissPopups);
+    editor.on('CloseActivePopups', fireCloseTooltips);
 
     Arr.each([ mothership, ...uiMotherships ], (gui) => {
       gui.element.dom.addEventListener('focusin', onFocusIn);
@@ -130,6 +139,7 @@ const setup = (editor: Editor, mothership: Gui.GuiSystem, uiMotherships: Gui.Gui
     editor.off('ResizeEditor', onEditorResize);
     editor.off('AfterProgressState', onEditorProgress);
     editor.off('DismissPopups', onDismissPopups);
+    editor.off('CloseActivePopups', fireCloseTooltips);
 
     Arr.each([ mothership, ...uiMotherships ], (gui) => {
       gui.element.dom.removeEventListener('focusin', onFocusIn);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
@@ -1,8 +1,8 @@
-import { Waiter } from '@ephox/agar';
+import { Keys, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarElement, TextContent } from '@ephox/sugar';
-import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
@@ -128,6 +128,14 @@ describe('browser.tinymce.themes.silver.editor.TooltipTest', () => {
         const buttonSelector = 'div[data-mce-name="split-button"]';
         await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
         await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+      });
+
+      it(`TINY-12054: Should trigger tooltip with ${test.label} - And escape closes it.`, async () => {
+        const editor = hook.editor();
+        const buttonSelector = 'div[data-mce-name="split-button"]';
+        await TooltipUtils.pAssertTooltip(editor, () => test.pTriggerTooltip(editor, buttonSelector), 'Split Button');
+        TinyContentActions.keyup(editor, Keys.escape());
+        await TooltipUtils.pAssertNoTooltipShown();
       });
 
       it(`TINY-10453: Should trigger tooltip with ${test.label} - Toolbar Split Button Menu - forecolor`, async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
@@ -20,6 +20,12 @@ const pAssertNoTooltip = async (_: Editor, pTriggerTooltip: () => Promise<void>,
   UiFinder.notExists(SugarBody.body(), tooltipSelector);
 };
 
+const pAssertNoTooltipShown = async (): Promise<void> => {
+  await Waiter.pTryUntil('Tooltip is not shown', () =>
+    UiFinder.notExists(SugarBody.body(), tooltipSelector)
+  );
+};
+
 const pTriggerTooltipWithMouse = async (editor: Editor, selector: string): Promise<void> => {
   const button = await TinyUiActions.pWaitForUi(editor, selector) as SugarElement<HTMLElement>;
   Mouse.mouseOver(button);
@@ -54,6 +60,7 @@ const pOpenMenu = (editor: Editor, buttonSelector: string): Promise<SugarElement
 export {
   pAssertTooltip,
   pAssertNoTooltip,
+  pAssertNoTooltipShown,
   pTriggerTooltipWithMouse,
   pTriggerTooltipWithKeyboard,
   pCloseTooltip,


### PR DESCRIPTION
Related Ticket: TINY-12054

Description of Changes:
Make tooltips close when pressing escape, if possible. If any closed the event should be default-prevented. Listens to both root document and editor ( if not inline ).
Dialogs in the ui will perform the same check on their own as the UI deals with keys in a different manner ( not through the rest of the editor ).

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tooltips now close automatically when the Escape key is pressed or when a close message is received.
- **Bug Fixes**
  - Improved tooltip dismissal behavior to ensure consistent closing via keyboard interaction.
- **Tests**
  - Added tests verifying tooltips close upon pressing the Escape key.
- **Chores**
  - Enhanced internal event handling and cleanup related to tooltip closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->