### PR TITLE
TINY-11692: Deprecated 'setContent' method in EditorSelection class

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11692-2025-06-17.yaml
+++ b/.changes/unreleased/tinymce-TINY-11692-2025-06-17.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Deprecated
+body: Deprecated 'setContent' method in EditorSelection class.
+time: 2025-06-17T14:26:32.309574+02:00
+custom:
+  Issue: TINY-11692

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -125,7 +125,8 @@ const logWarnings = (rawOptions: RawEditorOptions, normalizedOptions: Normalized
 };
 
 const deprecatedFeatures = {
-  fire: 'The "fire" event api has been deprecated and will be removed in TinyMCE 9. Use "dispatch" instead.'
+  fire: 'The "fire" event api has been deprecated and will be removed in TinyMCE 9. Use "dispatch" instead.',
+  selectionSetContent: 'The "setContent" method has been deprecated and will be removed in TinyMCE 9.'
 };
 
 const logFeatureDeprecationWarning = (feature: keyof typeof deprecatedFeatures): void => {

--- a/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SetSelectionContent.ts
@@ -9,6 +9,7 @@ import CaretPosition from '../caret/CaretPosition';
 import { SetSelectionContentArgs } from '../content/ContentTypes';
 import { postProcessSetContent, preProcessSetContent } from '../content/PrePostProcess';
 import * as MergeText from '../delete/MergeText';
+import * as Deprecations from '../Deprecations';
 import * as ScrollIntoView from '../dom/ScrollIntoView';
 import { needsToBeNbspLeft, needsToBeNbspRight } from '../keyboard/Nbsps';
 
@@ -104,6 +105,7 @@ const cleanContent = (editor: Editor, args: SetSelectionContentArgs) => {
 };
 
 const setContent = (editor: Editor, content: string, args: Partial<SetSelectionContentArgs> = {}): void => {
+  Deprecations.logFeatureDeprecationWarning('selectionSetContent');
   const defaultedArgs = setupArgs(args, content);
   preProcessSetContent(editor, defaultedArgs).each((updatedArgs) => {
     // Sanitize the content


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
