### PR TITLE
TINY-12272: Show `suggestededits` plugin in core editor

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/data/PluginUrls.ts
@@ -77,6 +77,7 @@ const urls = Arr.map<PartialPluginUrl, PluginUrl>([
   { key: 'powerpaste', name: 'PowerPaste', type: PluginType.Premium, slug: 'introduction-to-powerpaste' },
   { key: 'revisionhistory', name: 'Revision History', type: PluginType.Premium },
   { key: 'tinymcespellchecker', name: 'Spell Checker', type: PluginType.Premium, slug: 'introduction-to-tiny-spellchecker' },
+  { key: 'suggestededits', name: 'Suggested Edits', type: PluginType.Premium },
   { key: 'autocorrect', name: 'Spelling Autocorrect', type: PluginType.Premium },
   { key: 'tableofcontents', name: 'Table of Contents', type: PluginType.Premium },
   { key: 'advtemplate', name: 'Templates', type: PluginType.Premium, slug: 'advanced-templates' },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -23,7 +23,7 @@ const defaultMenubar = 'file edit view insert format tools table help';
 const defaultMenus: Record<string, MenuSpec> = {
   file: { title: 'File', items: 'newdocument restoredraft | preview | importword exportpdf exportword | export print | deleteallconversations' },
   edit: { title: 'Edit', items: 'undo redo | cut copy paste pastetext | selectall | searchreplace' },
-  view: { title: 'View', items: 'code revisionhistory | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
+  view: { title: 'View', items: 'code suggestededits revisionhistory | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments' },
   insert: { title: 'Insert', items: 'image link media addcomment pageembed inserttemplate codesample inserttable accordion math | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents footnotes | mergetags | insertdatetime' },
   format: { title: 'Format', items: 'bold italic underline strikethrough superscript subscript codeformat | styles blocks fontfamily fontsize align lineheight | forecolor backcolor | language | removeformat' },
   tools: { title: 'Tools', items: 'aidialog aishortcuts | spellchecker spellcheckerlanguage | autocorrect capitalization | a11ycheck code typography wordcount addtemplate' },


### PR DESCRIPTION
Related Ticket: [TINY-12272](https://ephocks.atlassian.net/browse/TINY-12272)

Description of Changes:
* When you open the `Help` dialog and navigate to `Plugin` tab, you are presented with a list of installed plugins. The `suggestededits` plugin should now appear in the list of `Premium plugins`.
* There is now a button for `Review changes` directly above `Revision history` in the default `View` menu.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
