### PR TITLE
TINY-12220: Added new `allow_html_in_comments`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12220-2025-06-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-12220-2025-06-24.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Added
+body: New `allow_html_in_comments` option to allow HTML like contents inside comment
+  data.
+time: 2025-06-24T07:48:32.222278+02:00
+custom:
+  Issue: TINY-12220

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -1054,7 +1054,6 @@ const isSmartPasteEnabled = option('smart_paste');
 const isPasteAsTextEnabled = option('paste_as_text');
 const getPasteTabSpaces = option('paste_tab_spaces');
 const shouldAllowHtmlDataUrls = option('allow_html_data_urls');
-const shouldAllowHtmlInComments = option('allow_html_in_comments');
 const getTextPatterns = option('text_patterns');
 const getTextPatternsLookup = option('text_patterns_lookup');
 const getNonEditableClass = option('noneditable_class');
@@ -1179,7 +1178,6 @@ export {
   isPasteAsTextEnabled,
   getPasteTabSpaces,
   shouldAllowHtmlDataUrls,
-  shouldAllowHtmlInComments,
   getAllowedImageFileTypes,
   getTextPatterns,
   getTextPatternsLookup,

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -580,6 +580,11 @@ const register = (editor: Editor): void => {
     default: false
   });
 
+  registerOption('allow_html_in_comments', {
+    processor: 'boolean',
+    default: false
+  });
+
   registerOption('allow_script_urls', {
     processor: 'boolean',
     default: false
@@ -1049,6 +1054,7 @@ const isSmartPasteEnabled = option('smart_paste');
 const isPasteAsTextEnabled = option('paste_as_text');
 const getPasteTabSpaces = option('paste_tab_spaces');
 const shouldAllowHtmlDataUrls = option('allow_html_data_urls');
+const shouldAllowHtmlInComments = option('allow_html_in_comments');
 const getTextPatterns = option('text_patterns');
 const getTextPatternsLookup = option('text_patterns_lookup');
 const getNonEditableClass = option('noneditable_class');
@@ -1173,6 +1179,7 @@ export {
   isPasteAsTextEnabled,
   getPasteTabSpaces,
   shouldAllowHtmlDataUrls,
+  shouldAllowHtmlInComments,
   getAllowedImageFileTypes,
   getTextPatterns,
   getTextPatternsLookup,

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -6,6 +6,7 @@ import * as NodeType from '../../dom/NodeType';
 import * as FilterNode from '../../html/FilterNode';
 import * as FilterRegistry from '../../html/FilterRegistry';
 import * as InvalidNodes from '../../html/InvalidNodes';
+import * as KeepHtmlComments from '../../html/KeepHtmlComments';
 import * as LegacyFilter from '../../html/LegacyFilter';
 import * as Namespace from '../../html/Namespace';
 import * as ParserFilters from '../../html/ParserFilters';
@@ -56,6 +57,7 @@ export interface DomParserSettings {
   allow_html_data_urls?: boolean;
   allow_svg_data_urls?: boolean;
   allow_conditional_comments?: boolean;
+  allow_html_in_comments?: boolean;
   allow_html_in_named_anchor?: boolean;
   allow_script_urls?: boolean;
   allow_unsafe_link_target?: boolean;
@@ -93,7 +95,13 @@ interface DomParser {
 
 type WalkerCallback = (node: AstNode) => void;
 
-const transferChildren = (parent: AstNode, nativeParent: Node, specialElements: SchemaRegExpMap, nsSanitizer: (el: Element) => void) => {
+const transferChildren = (
+  parent: AstNode,
+  nativeParent: Node,
+  specialElements: SchemaRegExpMap,
+  nsSanitizer: (el: Element) => void,
+  decodeComments: boolean
+) => {
   const parentName = parent.name;
   // Exclude the special elements where the content is RCDATA as their content needs to be parsed instead of being left as plain text
   // See: https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
@@ -120,7 +128,9 @@ const transferChildren = (parent: AstNode, nativeParent: Node, specialElements: 
       if (isSpecial) {
         child.raw = true;
       }
-    } else if (NodeType.isComment(nativeChild) || NodeType.isCData(nativeChild) || NodeType.isPi(nativeChild)) {
+    } else if (NodeType.isComment(nativeChild)) {
+      child.value = decodeComments ? KeepHtmlComments.decodeData(nativeChild.data) : nativeChild.data;
+    } else if (NodeType.isCData(nativeChild) || NodeType.isPi(nativeChild)) {
       child.value = nativeChild.data;
     }
 
@@ -130,7 +140,7 @@ const transferChildren = (parent: AstNode, nativeParent: Node, specialElements: 
       content.raw = true;
       child.append(content);
     } else if (!Namespace.isNonHtmlElementRootName(child.name)) {
-      transferChildren(child, nativeChild, specialElements, nsSanitizer);
+      transferChildren(child, nativeChild, specialElements, nsSanitizer, decodeComments);
     }
 
     parent.append(child);
@@ -292,6 +302,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     validate: true,
     root_name: 'body',
     sanitize: true,
+    allow_html_in_comments: false,
     ...settings
   };
 
@@ -472,7 +483,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
 
     // Create the AST representation
     const rootNode = new AstNode(rootName, 11);
-    transferChildren(rootNode, element, schema.getSpecialElements(), sanitizer.sanitizeNamespaceElement);
+    transferChildren(rootNode, element, schema.getSpecialElements(), sanitizer.sanitizeNamespaceElement, defaultedSettings.sanitize && defaultedSettings.allow_html_in_comments);
 
     // This next line is needed to fix a memory leak in chrome and firefox.
     // For more information see TINY-9186

--- a/modules/tinymce/src/core/main/ts/html/KeepHtmlComments.ts
+++ b/modules/tinymce/src/core/main/ts/html/KeepHtmlComments.ts
@@ -4,13 +4,3 @@ export const encodeData = (data: string): string =>
 export const decodeData = (data: string): string =>
   data.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
 
-export const encodeComments = (target: HTMLElement): void => {
-  const walker = document.createTreeWalker(target, NodeFilter.SHOW_COMMENT);
-  let node: Node | null;
-
-  while ((node = walker.nextNode())) {
-    const commentNode = node as Comment;
-    commentNode.data = encodeData(commentNode.data);
-  }
-};
-

--- a/modules/tinymce/src/core/main/ts/html/KeepHtmlComments.ts
+++ b/modules/tinymce/src/core/main/ts/html/KeepHtmlComments.ts
@@ -1,0 +1,16 @@
+export const encodeData = (data: string): string =>
+  data.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+export const decodeData = (data: string): string =>
+  data.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+
+export const encodeComments = (target: HTMLElement): void => {
+  const walker = document.createTreeWalker(target, NodeFilter.SHOW_COMMENT);
+  let node: Node | null;
+
+  while ((node = walker.nextNode())) {
+    const commentNode = node as Comment;
+    commentNode.data = encodeData(commentNode.data);
+  }
+};
+

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -33,7 +33,7 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, sc
       node.nodeValue = ' ' + node.nodeValue;
     }
 
-    if (settings.allow_html_in_comments && Type.isString(node.nodeValue)) {
+    if (settings.sanitize && settings.allow_html_in_comments && Type.isString(node.nodeValue)) {
       node.nodeValue = KeepHtmlComments.encodeData(node.nodeValue);
     }
   }

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -8,6 +8,7 @@ import Tools from '../api/util/Tools';
 import * as URI from '../api/util/URI';
 import * as NodeType from '../dom/NodeType';
 
+import * as KeepHtmlComments from './KeepHtmlComments';
 import * as Namespace from './Namespace';
 
 export type MimeType = 'text/html' | 'application/xhtml+xml';
@@ -26,9 +27,15 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, sc
   const validate = settings.validate;
   const specialElements = schema.getSpecialElements();
 
-  // Pad conditional comments if they aren't allowed
-  if (node.nodeType === NodeTypes.COMMENT && !settings.allow_conditional_comments && /^\[if/i.test(node.nodeValue ?? '')) {
-    node.nodeValue = ' ' + node.nodeValue;
+  if (node.nodeType === NodeTypes.COMMENT) {
+    // Pad conditional comments if they aren't allowed
+    if (!settings.allow_conditional_comments && /^\[if/i.test(node.nodeValue ?? '')) {
+      node.nodeValue = ' ' + node.nodeValue;
+    }
+
+    if (settings.allow_html_in_comments && Type.isString(node.nodeValue)) {
+      node.nodeValue = KeepHtmlComments.encodeData(node.nodeValue);
+    }
   }
 
   const lcTagName = evt?.tagName ?? node.nodeName.toLowerCase();

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -76,6 +76,7 @@ const mkParserSettings = (editor: Editor): DomParserSettings => {
     allow_svg_data_urls: getOption('allow_svg_data_urls'),
     allow_html_in_named_anchor: getOption('allow_html_in_named_anchor'),
     allow_script_urls: getOption('allow_script_urls'),
+    allow_html_in_comments: getOption('allow_html_in_comments'),
     allow_mathml_annotation_encodings: getOption('allow_mathml_annotation_encodings'),
     allow_unsafe_link_target: getOption('allow_unsafe_link_target'),
     convert_unsafe_embeds: getOption('convert_unsafe_embeds'),

--- a/modules/tinymce/src/core/test/ts/atomic/html/KeepHtmlCommentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/KeepHtmlCommentsTest.ts
@@ -1,0 +1,28 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+
+import * as KeepHtmlComments from 'tinymce/core/html/KeepHtmlComments';
+
+describe('atomic.tinymce.core.html.KeepHtmlComments', () => {
+  it('encodeData/decodeData', () => {
+    assert.equal(KeepHtmlComments.encodeData('<>&'), '&lt;&gt;&amp;', 'Encoding data with special characters');
+    assert.equal(KeepHtmlComments.encodeData('<>&&amp;&lt;&gt;'), '&lt;&gt;&amp;&amp;amp;&amp;lt;&amp;gt;', 'Encoding data existing encoding');
+    assert.equal(KeepHtmlComments.encodeData('<>&abc<>&'), '&lt;&gt;&amp;abc&lt;&gt;&amp;', 'Encoding data with mixed content');
+
+    assert.equal(KeepHtmlComments.decodeData('&lt;&gt;&amp;'), '<>&', 'Decoding data with special characters');
+    assert.equal(KeepHtmlComments.decodeData('&lt;&gt;&amp;abc&lt;&gt;&amp;'), '<>&abc<>&', 'Decoding data with mixed content');
+    assert.equal(KeepHtmlComments.decodeData(KeepHtmlComments.decodeData('<>&abc<>&')), '<>&abc<>&', 'Decoding should decode encoded data');
+  });
+
+  it('property test encodeData/decodeData', () => {
+    fc.assert(fc.property(
+      fc.string(),
+      (text) => {
+        const decoded = KeepHtmlComments.decodeData(KeepHtmlComments.encodeData(text));
+        assert.equal(decoded, text, `Decoding should always return original text for "${text}"`);
+      }
+    ));
+  });
+});
+

--- a/modules/tinymce/src/core/test/ts/atomic/html/KeepHtmlCommentsTest.ts
+++ b/modules/tinymce/src/core/test/ts/atomic/html/KeepHtmlCommentsTest.ts
@@ -5,7 +5,7 @@ import * as fc from 'fast-check';
 import * as KeepHtmlComments from 'tinymce/core/html/KeepHtmlComments';
 
 describe('atomic.tinymce.core.html.KeepHtmlComments', () => {
-  it('encodeData/decodeData', () => {
+  it('TINY-12220: encodeData/decodeData', () => {
     assert.equal(KeepHtmlComments.encodeData('<>&'), '&lt;&gt;&amp;', 'Encoding data with special characters');
     assert.equal(KeepHtmlComments.encodeData('<>&&amp;&lt;&gt;'), '&lt;&gt;&amp;&amp;amp;&amp;lt;&amp;gt;', 'Encoding data existing encoding');
     assert.equal(KeepHtmlComments.encodeData('<>&abc<>&'), '&lt;&gt;&amp;abc&lt;&gt;&amp;', 'Encoding data with mixed content');
@@ -15,7 +15,7 @@ describe('atomic.tinymce.core.html.KeepHtmlComments', () => {
     assert.equal(KeepHtmlComments.decodeData(KeepHtmlComments.decodeData('<>&abc<>&')), '<>&abc<>&', 'Decoding should decode encoded data');
   });
 
-  it('property test encodeData/decodeData', () => {
+  it('TINY-12220: property test encodeData/decodeData', () => {
     fc.assert(fc.property(
       fc.string(),
       (text) => {

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -846,5 +846,20 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         TinyAssertions.assertContent(editor, '<template>foo</template><p><template>bar</template></p>');
       });
     });
+
+    context('allow_html_in_comments', () => {
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        allow_html_in_comments: true,
+        indent: false
+      }, []);
+
+      it('TINY-12220: Should retain HTML like data in comments', () => {
+        const editor = hook.editor();
+
+        editor.setContent('<!-- <b>foo</b> -->');
+        TinyAssertions.assertContent(editor, '<!-- <b>foo</b> -->');
+      });
+    });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -848,17 +848,45 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
     });
 
     context('allow_html_in_comments', () => {
-      const hook = TinyHooks.bddSetupLight<Editor>({
-        base_url: '/project/tinymce/js/tinymce',
-        allow_html_in_comments: true,
-        indent: false
-      }, []);
+      context('allow_html_in_comments: true', () => {
+        const hook = TinyHooks.bddSetupLight<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          allow_html_in_comments: true
+        }, []);
 
-      it('TINY-12220: Should retain HTML like data in comments', () => {
-        const editor = hook.editor();
+        it('TINY-12220: Should retain HTML like data in comments', () => {
+          const editor = hook.editor();
 
-        editor.setContent('<!-- <b>foo</b> -->');
-        TinyAssertions.assertContent(editor, '<!-- <b>foo</b> -->');
+          editor.setContent('<!-- <b>foo</b> -->');
+          TinyAssertions.assertContent(editor, '<!-- <b>foo</b> -->');
+        });
+      });
+
+      context('allow_html_in_comments: false', () => {
+        const hook = TinyHooks.bddSetupLight<Editor>({
+          base_url: '/project/tinymce/js/tinymce',
+          allow_html_in_comments: false
+        }, []);
+
+        it('TINY-12220: Should NOT retain HTML like data in comments', () => {
+          const editor = hook.editor();
+
+          editor.setContent('<!-- <b>foo</b> -->');
+          TinyAssertions.assertContent(editor, '');
+        });
+      });
+
+      context('allow_html_in_comments default', () => {
+        const hook = TinyHooks.bddSetupLight<Editor>({
+          base_url: '/project/tinymce/js/tinymce'
+        }, []);
+
+        it('TINY-12220: Should NOT retain HTML like data in comments', () => {
+          const editor = hook.editor();
+
+          editor.setContent('<!-- <b>foo</b> -->');
+          TinyAssertions.assertContent(editor, '');
+        });
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -857,8 +857,8 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         it('TINY-12220: Should retain HTML like data in comments', () => {
           const editor = hook.editor();
 
-          editor.setContent('<!-- <b>foo</b> -->');
-          TinyAssertions.assertContent(editor, '<!-- <b>foo</b> -->');
+          editor.setContent('<p><!-- <b>foo</b> -->foo</p>');
+          TinyAssertions.assertContent(editor, '<p><!-- <b>foo</b> -->foo</p>');
         });
       });
 
@@ -871,8 +871,8 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         it('TINY-12220: Should NOT retain HTML like data in comments', () => {
           const editor = hook.editor();
 
-          editor.setContent('<!-- <b>foo</b> -->');
-          TinyAssertions.assertContent(editor, '');
+          editor.setContent('<p><!-- <b>foo</b> -->foo</p>');
+          TinyAssertions.assertContent(editor, '<p>foo</p>');
         });
       });
 
@@ -884,8 +884,8 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
         it('TINY-12220: Should NOT retain HTML like data in comments', () => {
           const editor = hook.editor();
 
-          editor.setContent('<!-- <b>foo</b> -->');
-          TinyAssertions.assertContent(editor, '');
+          editor.setContent('<p><!-- <b>foo</b> -->foo</p>');
+          TinyAssertions.assertContent(editor, '<p>foo</p>');
         });
       });
     });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1700,8 +1700,6 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         const initialHtml = '<p>foo<!-- <b>bar</b> --></p><!-- <b>baz</b> -->';
         const fragment = parser.parse(initialHtml);
         const serializedHtml = serializer.serialize(fragment);
-
-        // TODO: Fix this when TINY-12056 is merged
         const expectedHtml = scenario.isSanitizeEnabled ? '<p>foo</p>' : initialHtml;
 
         assert.equal(serializedHtml, expectedHtml, 'Should match the expected HTML');

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1682,7 +1682,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
     });
 
     context('allow_html_in_comments', () => {
-      it('TINY-11019: Should allow html in comment elements', () => {
+      it('TINY-12220: Should allow html in comment elements', () => {
         const parser = DomParser({ ...scenario.settings, allow_html_in_comments: true }, schema);
         const serializer = HtmlSerializer({}, schema);
 
@@ -1693,7 +1693,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         assert.equal(serializedHtml, initialHtml, 'Should match the initial HTML');
       });
 
-      it('TINY-11019: Should allow html in comment if sanitize is set to false', () => {
+      it('TINY-12220: Should allow html in comment if sanitize is set to false', () => {
         const parser = DomParser({ ...scenario.settings }, schema);
         const serializer = HtmlSerializer({}, schema);
 

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -1680,6 +1680,33 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         });
       });
     });
+
+    context('allow_html_in_comments', () => {
+      it('TINY-11019: Should allow html in comment elements', () => {
+        const parser = DomParser({ ...scenario.settings, allow_html_in_comments: true }, schema);
+        const serializer = HtmlSerializer({}, schema);
+
+        const initialHtml = '<!-- <b>test</b> -->';
+        const fragment = parser.parse(initialHtml);
+        const serializedHtml = serializer.serialize(fragment);
+
+        assert.equal(serializedHtml, initialHtml, 'Should match the initial HTML');
+      });
+
+      it('TINY-11019: Should allow html in comment if sanitize is set to false', () => {
+        const parser = DomParser({ ...scenario.settings }, schema);
+        const serializer = HtmlSerializer({}, schema);
+
+        const initialHtml = '<p>foo<!-- <b>bar</b> --></p><!-- <b>baz</b> -->';
+        const fragment = parser.parse(initialHtml);
+        const serializedHtml = serializer.serialize(fragment);
+
+        // TODO: Fix this when TINY-12056 is merged
+        const expectedHtml = scenario.isSanitizeEnabled ? '<p>foo</p>' : initialHtml;
+
+        assert.equal(serializedHtml, expectedHtml, 'Should match the expected HTML');
+      });
+    });
   });
 
   context('TINY-9600: sanitize: false with unsafe input', () => {


### PR DESCRIPTION
Related Ticket: TINY-12220

Description of Changes:
* Added the new `allow_html_in_comments` option to opt-out of the HTML comment filtering

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
