### PR TITLE
TINY-12142: Oxide now ships with ts definitions for css files

### DIFF
--- a/modules/oxide-components/.storybook/preview.tsx
+++ b/modules/oxide-components/.storybook/preview.tsx
@@ -1,23 +1,26 @@
-import type { Preview } from '@storybook/react-vite';
-import '@tinymce/oxide/build/skins/ui/default/skin.css';
-
 import {
-    Controls,
-    Description,
-    Primary,
-    Subtitle,
-    Title,
+  Controls,
+  Description,
+  Primary,
+  Subtitle,
+  Title
 } from '@storybook/addon-docs/blocks';
+import type { Preview, ReactRenderer } from '@storybook/react-vite';
+import styles from '@tinymce/oxide/skins/ui/default/skin.ts';
+import type { PartialStoryFn } from 'storybook/internal/csf';
+
+// @ts-expect-error the bundler handles this just fine but tsc is not happy with it
+import '@tinymce/oxide/build/skins/ui/default/skin.css';
 
 const preview: Preview = {
   decorators: [
-    (Story) => <div className='tox'><Story /></div>
+    (Story: PartialStoryFn<ReactRenderer>): JSX.Element => <div className={styles.tox}><Story /></div>
   ],
   parameters: {
     controls: {
       matchers: {
-       color: /(background|color)$/i,
-       date: /Date$/i,
+        color: /(background|color)$/i,
+        date: /Date$/i,
       },
     },
 
@@ -28,16 +31,16 @@ const preview: Preview = {
       test: 'todo'
     },
     docs: {
-          page: () => (
-            <>
-              <Title />
-              <Subtitle />
-              <Description />
-              <Primary />
-              <Controls />
-            </>
-          ),
-        },
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls />
+        </>
+      ),
+    },
   },
 };
 

--- a/modules/oxide-components/.storybook/preview.tsx
+++ b/modules/oxide-components/.storybook/preview.tsx
@@ -6,15 +6,15 @@ import {
   Title
 } from '@storybook/addon-docs/blocks';
 import type { Preview, ReactRenderer } from '@storybook/react-vite';
-import styles from '@tinymce/oxide/skins/ui/default/skin.ts';
 import type { PartialStoryFn } from 'storybook/internal/csf';
 
 // @ts-expect-error the bundler handles this just fine but tsc is not happy with it
 import '@tinymce/oxide/build/skins/ui/default/skin.css';
+import { classes } from '../src/main/ts/utils/Styles';
 
 const preview: Preview = {
   decorators: [
-    (Story: PartialStoryFn<ReactRenderer>): JSX.Element => <div className={styles.tox}><Story /></div>
+    (Story: PartialStoryFn<ReactRenderer>): JSX.Element => <div className={classes([ 'tox' ])}><Story /></div>
   ],
   parameters: {
     controls: {

--- a/modules/oxide-components/package.json
+++ b/modules/oxide-components/package.json
@@ -71,7 +71,7 @@
     "vite": "^6.3.5",
     "vitest": "^3.1.4"
   },
-  "workspaces":{
+  "workspaces": {
     "nohoist": [
       "**/storybook",
       "**/@storybook/**",

--- a/modules/oxide-components/src/main/ts/Button/Button.component.tsx
+++ b/modules/oxide-components/src/main/ts/Button/Button.component.tsx
@@ -1,5 +1,6 @@
-import styles from '@tinymce/oxide/skins/ui/default/skin.ts';
 import type { ButtonHTMLAttributes } from 'react';
+
+import { classes } from '../utils/Styles';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
@@ -13,7 +14,7 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       type={type}
-      className={styles['tox-button']}
+      className={classes([ 'tox-button' ])}
       {...props}
     >
       {children}

--- a/modules/oxide-components/src/main/ts/Button/Button.component.tsx
+++ b/modules/oxide-components/src/main/ts/Button/Button.component.tsx
@@ -1,3 +1,4 @@
+import styles from '@tinymce/oxide/skins/ui/default/skin.ts';
 import type { ButtonHTMLAttributes } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -12,7 +13,7 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       type={type}
-      className={'tox-button'}
+      className={styles['tox-button']}
       {...props}
     >
       {children}

--- a/modules/oxide-components/src/main/ts/utils/Styles.ts
+++ b/modules/oxide-components/src/main/ts/utils/Styles.ts
@@ -1,0 +1,3 @@
+import { type Classes } from '@tinymce/oxide/skins/ui/default/skin.ts';
+
+export const classes = (classNames: Array<keyof Classes>): string => classNames.join(' ');

--- a/modules/oxide-components/tsconfig.app.json
+++ b/modules/oxide-components/tsconfig.app.json
@@ -26,7 +26,8 @@
     "noUncheckedSideEffectImports": true
   },
   "include": [
-    "src/main/ts"
+    "src/main/ts",
+    ".storybook/preview.tsx"
   ],
   "exclude": [
     "src/**/*.stories.*"

--- a/modules/oxide/Gruntfile.js
+++ b/modules/oxide/Gruntfile.js
@@ -2,6 +2,11 @@ module.exports = function (grunt) {
   grunt.loadTasks('./tasks');
 
   grunt.initConfig({
+    shell: {
+      generateTsDefinitions: {
+        command: 'node ./tasks/ts-skins.js ./build'
+      }
+    },
     // Clean specified directories
     clean: {
       build: ['./build'],
@@ -94,7 +99,8 @@ module.exports = function (grunt) {
     'compileLess',
     'cssmin',
     'generateJsSkins',
-    'addLicenseHeaders'
+    'addLicenseHeaders',
+    'shell:generateTsDefinitions'
   ]);
 
   grunt.registerTask('start', [

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -20,10 +20,23 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc",
   "license": "GPL-2.0-or-later",
   "sideEffects": false,
+  "exports": {
+    "./skins/ui/default/skin.ts": "./build/skins/ui/default/skin.ts",
+    "./skins/ui/default/skin.css": "./build/skins/ui/default/skin.css",
+    "./build/*": "./build/*"
+  },
+  "typesVersions": {
+    "*": {
+      "./skins/ui/default/skin.ts": ["./build/skins/ui/default/skin.ts"],
+      "./skins/ui/default/skin.css": ["./build/skins/ui/default/skin.css"]
+    }
+  },
   "files": [
     "build/skins/content/**/*.css",
+    "build/skins/content/**/*.d.css.ts",
     "build/skins/content/**/*.css.map",
     "build/skins/ui/**/*.css",
+    "build/skins/ui/**/*.d.css.ts",
     "build/skins/ui/**/*.css.map",
     "build/skins/ui/**/*.woff",
     "src/less/**/*",
@@ -40,6 +53,7 @@
   "devDependencies": {
     "connect": "^3.7.0",
     "connect-livereload": "^0.6.1",
-    "stylelint-config-recommended-less": "^3.0.1"
+    "stylelint-config-recommended-less": "^3.0.1",
+    "typed-css-modules": "^0.9.1"
   }
 }

--- a/modules/oxide/tasks/ts-skins.js
+++ b/modules/oxide/tasks/ts-skins.js
@@ -10,9 +10,9 @@ const files = fs.readdirSync(process.argv[2], {
 files.forEach(file => {
   if (file.endsWith('.css')) {
     creator.create(process.argv[2] + '/' + file).then(content => {
-      let result = 'export default {\n';
+      let result = 'export interface Classes {\n';
       content.tokens.forEach((token) => {
-        result += `  "${token}": "${token}",\n`;
+        result += `  "${token}": string;\n`;
       });
       result += '};\n';
       fs.writeFileSync(process.argv[2] + '/' + file.replace('.css', '.ts'), result);

--- a/modules/oxide/tasks/ts-skins.js
+++ b/modules/oxide/tasks/ts-skins.js
@@ -1,23 +1,23 @@
-const fs = require('node:fs/promises');
+const fs = require('node:fs');
 const { default: DtsCreator } = require('typed-css-modules');
 
 let creator = new DtsCreator();
 
-fs.readdir(process.argv[2], {
+const files = fs.readdirSync(process.argv[2], {
   recursive: true,
-}).then(files => {
-  files.forEach(file => {
-    if (file.endsWith('.css')) {
-      creator.create(process.argv[2] + '/' + file).then(content => {
-        let result = 'export default {\n';
-        content.tokens.forEach((token) => {
-          result += `  "${token}": "${token}",\n`;
-        });
-        result += '};\n';
-        fs.writeFile(process.argv[2] + '/' + file.replace('.css', '.ts'), result);
-      }).catch(err => {
-        console.error(`Error creating CSS module for ${file.name}:`, err);
+});
+
+files.forEach(file => {
+  if (file.endsWith('.css')) {
+    creator.create(process.argv[2] + '/' + file).then(content => {
+      let result = 'export default {\n';
+      content.tokens.forEach((token) => {
+        result += `  "${token}": "${token}",\n`;
       });
-    }
-  })
+      result += '};\n';
+      fs.writeFileSync(process.argv[2] + '/' + file.replace('.css', '.ts'), result);
+    }).catch(err => {
+      console.error(`Error creating CSS module for ${file.name}:`, err);
+    });
+  }
 });


### PR DESCRIPTION
# CSS Modules Integration for Oxide Components

## Description of Changes:
* Added TypeScript support for CSS modules in the Oxide package
* Created a script to generate TypeScript definitions for CSS files
* Updated imports in Oxide Components to use CSS modules
* Fixed TypeScript configuration to support CSS modules
* Added proper exports and type definitions in the Oxide package.json

## Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

## Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)