### PR TITLE
TINY-12301: add toggle component in oxide

### DIFF
--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -89,19 +89,6 @@
         text-align: center;
         white-space: nowrap;
       }
-
-      .tox-suggestededits__toggle {
-        color: @suggestededits-text-color;
-        font-weight: 400;
-        line-height: 24px;
-        padding: 4px 16px;
-        text-align: center;
-        white-space: nowrap;
-      }
-
-      .tox-suggestededits__toggle .tox-suggestededits__toggle--label {
-        padding-bottom: 1px;
-      }
     }
 
     .tox-suggestededits {
@@ -380,74 +367,6 @@
           box-shadow: 0 4px 8px 0 @suggestededits-card-hover-shadow-color;
         }
       }
-    }
-
-    .tox-suggestededits__toggle {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .tox-suggestededits__switch {
-      position: relative;
-      display: inline-block;
-      width: 30px;
-      height: 17px;
-    }
-
-    .tox-suggestededits__switch input {
-      opacity: 0;
-      width: 0;
-      height: 0;
-    }
-
-    .tox-suggestededits__switch input:checked + .tox-suggestededits__slider {
-      background-color: @suggestededits-color-tint;
-    }
-
-    .tox-suggestededits__switch input:focus + .tox-suggestededits__slider {
-      box-shadow: 0 0 1px @suggestededits-color-tint;
-    }
-
-    .tox-suggestededits__switch input:checked + .tox-suggestededits__slider:before {
-      -webkit-transform: translateX(13px);
-      -ms-transform: translateX(13px);
-      transform: translateX(13px);
-      background-color: @suggestededits-background-color;
-    }
-
-    .tox-suggestededits__slider {
-      position: absolute;
-      cursor: pointer;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: @suggestededits-sidebar-background-color;
-      -webkit-transition: .4s;
-      transition: .4s;
-      border-radius: 17px;
-    }
-
-    .tox-suggestededits__slider:before {
-      position: absolute;
-      content: "";
-      height: 13px;
-      width: 13px;
-      left: 2px;
-      bottom: 2px;
-      background-color: @suggestededits-color-tint;
-      -webkit-transition: .4s;
-      transition: .4s;
-      border-radius: 50%;
-    }
-
-    .tox-suggestededits__slider.round {
-      border-radius: 34px;
-    }
-
-    .tox-suggestededits__slider.round:before {
-      border-radius: 50%;
     }
   }
 }

--- a/modules/oxide/src/less/theme/components/toggle/toggle.less
+++ b/modules/oxide/src/less/theme/components/toggle/toggle.less
@@ -36,7 +36,7 @@
     border: 1px solid var(--tox-private-slider-border-color);
   }
 
-  .tox-toggle__slider:before {
+  .tox-toggle__slider::before {
     position: absolute;
     content: "";
     height: 12px;
@@ -58,14 +58,14 @@
     box-shadow: 0 0 0 1px @background-color, 0 0 0 3px @keyboard-focus-outline-color;
   }
   
-  input:checked + .tox-toggle__slider:before {
+  input:checked + .tox-toggle__slider::before {
     -webkit-transform: translateX(12px);
     -ms-transform: translateX(12px);
     transform: translateX(12px);
     --tox-private-slider-handle-background-color: @color-white;
   }
 
-  input:disabled + .tox-toggle__slider:before {
+  input:disabled + .tox-toggle__slider::before {
     opacity: 50%;
   }
 }

--- a/modules/oxide/src/less/theme/components/toggle/toggle.less
+++ b/modules/oxide/src/less/theme/components/toggle/toggle.less
@@ -18,9 +18,12 @@
     color: @text-color;
 
     input {
-      display: none;
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
     }
-    
+
     .tox-toggle__slider {
       position: relative;
       cursor: pointer;
@@ -53,7 +56,7 @@
     }
     
     input:focus + .tox-toggle__slider {
-      box-shadow: 0 0 1px @color-tint;
+      box-shadow: 0 0 0 1px @background-color, 0 0 0 3px @keyboard-focus-outline-color;
     }
     
     input:checked + .tox-toggle__slider:before {

--- a/modules/oxide/src/less/theme/components/toggle/toggle.less
+++ b/modules/oxide/src/less/theme/components/toggle/toggle.less
@@ -1,11 +1,9 @@
 .tox {
   .tox-toggle {
     // private variables scoped to tox-toggle class
-    --slider-height: 16px;
-    --slider-width: 28px;
-    --slider-background-color: @background-color;
-    --slider-border-color: .bg-luma-checker(hsl(from @color-white h s calc(l - 11)), hsla(from @color-white h s l / 15%))[@result]; // to be figured out after the spike with conditionals in CSS
-    --slider-handle-background-color: @text-color;
+    --tox-private-slider-background-color: @background-color;
+    --tox-private-slider-border-color: .bg-luma-checker(hsl(from @color-white h s calc(l - 11)), hsla(from @color-white h s l / 15%))[@result]; // to be figured out after the spike with conditionals in CSS
+    --tox-private-slider-handle-background-color: @text-color;
 
     display: flex;
     align-items: center;
@@ -24,20 +22,20 @@
       height: 0;
     }
 
-    .tox-toggle__slider {
+    &__slider {
       position: relative;
       cursor: pointer;
       box-sizing: border-box;
       -webkit-transition: 0.4s;
       transition: 0.4s;
       border-radius: 34px; 
-      width: var(--slider-width);
-      height: var(--slider-height);
-      background-color: var(--slider-background-color);
-      border: 1px solid var(--slider-border-color);
+      width: 28px;
+      height: 16px;
+      background-color: var(--tox-private-slider-background-color);
+      border: 1px solid var(--tox-private-slider-border-color);
     }
 
-    .tox-toggle__slider:before {
+    &__slider:before {
       position: absolute;
       content: "";
       height: 12px;
@@ -47,27 +45,27 @@
       -webkit-transition: 0.4s;
       transition: 0.4s;
       border-radius: 50%;
-      background-color: var(--slider-handle-background-color);
+      background-color: var(--tox-private-slider-handle-background-color);
     }
+  }
     
-    input:checked + .tox-toggle__slider {
-      --slider-background-color: @color-tint;
-      --slider-border-color: @color-tint;
-    }
-    
-    input:focus + .tox-toggle__slider {
-      box-shadow: 0 0 0 1px @background-color, 0 0 0 3px @keyboard-focus-outline-color;
-    }
-    
-    input:checked + .tox-toggle__slider:before {
-      -webkit-transform: translateX(12px);
-      -ms-transform: translateX(12px);
-      transform: translateX(12px);
-      --slider-handle-background-color: @color-white;
-    }
+  input:checked + .tox-toggle__slider {
+    --tox-private-slider-background-color: @color-tint;
+    --tox-private-slider-border-color: @color-tint;
+  }
+  
+  input:focus + .tox-toggle__slider {
+    box-shadow: 0 0 0 1px @background-color, 0 0 0 3px @keyboard-focus-outline-color;
+  }
+  
+  input:checked + .tox-toggle__slider:before {
+    -webkit-transform: translateX(12px);
+    -ms-transform: translateX(12px);
+    transform: translateX(12px);
+    --tox-private-slider-handle-background-color: @color-white;
+  }
 
-    input:disabled + .tox-toggle__slider:before {
-      opacity: 50%;
-    }
-  } 
+  input:disabled + .tox-toggle__slider:before {
+    opacity: 50%;
+  }
 }

--- a/modules/oxide/src/less/theme/components/toggle/toggle.less
+++ b/modules/oxide/src/less/theme/components/toggle/toggle.less
@@ -1,0 +1,70 @@
+.tox {
+  .tox-toggle {
+    // private variables scoped to tox-toggle class
+    --slider-height: 16px;
+    --slider-width: 28px;
+    --slider-background-color: @background-color;
+    --slider-border-color: .bg-luma-checker(hsl(from @color-white h s calc(l - 11)), hsla(from @color-white h s l / 15%))[@result]; // to be figured out after the spike with conditionals in CSS
+    --slider-handle-background-color: @text-color;
+
+    display: flex;
+    align-items: center;
+    gap: @pad-xs;
+    padding: @pad-xs;
+    font-weight: @font-weight-normal;
+    line-height: 24px; // the same as in button and textfield. Button component is referencing the textfield variable so maybe it should be a global API? The textfield has a fixed value for line-height
+    white-space: nowrap;
+    background-color: @background-color;
+    color: @text-color;
+
+    input {
+      display: none;
+    }
+    
+    .tox-toggle__slider {
+      position: relative;
+      cursor: pointer;
+      box-sizing: border-box;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 34px; 
+      width: var(--slider-width);
+      height: var(--slider-height);
+      background-color: var(--slider-background-color);
+      border: 1px solid var(--slider-border-color);
+    }
+
+    .tox-toggle__slider:before {
+      position: absolute;
+      content: "";
+      height: 12px;
+      width: 12px;
+      left: 1px;
+      bottom: 1px;
+      -webkit-transition: 0.4s;
+      transition: 0.4s;
+      border-radius: 50%;
+      background-color: var(--slider-handle-background-color);
+    }
+    
+    input:checked + .tox-toggle__slider {
+      --slider-background-color: @color-tint;
+      --slider-border-color: @color-tint;
+    }
+    
+    input:focus + .tox-toggle__slider {
+      box-shadow: 0 0 1px @color-tint;
+    }
+    
+    input:checked + .tox-toggle__slider:before {
+      -webkit-transform: translateX(12px);
+      -ms-transform: translateX(12px);
+      transform: translateX(12px);
+      --slider-handle-background-color: @color-white;
+    }
+
+    input:disabled + .tox-toggle__slider:before {
+      opacity: 50%;
+    }
+  } 
+}

--- a/modules/oxide/src/less/theme/components/toggle/toggle.less
+++ b/modules/oxide/src/less/theme/components/toggle/toggle.less
@@ -21,32 +21,32 @@
       width: 0;
       height: 0;
     }
+  }
 
-    &__slider {
-      position: relative;
-      cursor: pointer;
-      box-sizing: border-box;
-      -webkit-transition: 0.4s;
-      transition: 0.4s;
-      border-radius: 34px; 
-      width: 28px;
-      height: 16px;
-      background-color: var(--tox-private-slider-background-color);
-      border: 1px solid var(--tox-private-slider-border-color);
-    }
+  .tox-toggle__slider {
+    position: relative;
+    cursor: pointer;
+    box-sizing: border-box;
+    -webkit-transition: 0.4s;
+    transition: 0.4s;
+    border-radius: 34px; 
+    width: 28px;
+    height: 16px;
+    background-color: var(--tox-private-slider-background-color);
+    border: 1px solid var(--tox-private-slider-border-color);
+  }
 
-    &__slider:before {
-      position: absolute;
-      content: "";
-      height: 12px;
-      width: 12px;
-      left: 1px;
-      bottom: 1px;
-      -webkit-transition: 0.4s;
-      transition: 0.4s;
-      border-radius: 50%;
-      background-color: var(--tox-private-slider-handle-background-color);
-    }
+  .tox-toggle__slider:before {
+    position: absolute;
+    content: "";
+    height: 12px;
+    width: 12px;
+    left: 1px;
+    bottom: 1px;
+    -webkit-transition: 0.4s;
+    transition: 0.4s;
+    border-radius: 50%;
+    background-color: var(--tox-private-slider-handle-background-color);
   }
     
   input:checked + .tox-toggle__slider {

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -67,6 +67,7 @@
 @import 'components/spinner/spinner';
 @import 'components/statusbar/statusbar';
 @import 'components/throbber/throbber';
+@import 'components/toggle/toggle';
 @import 'components/toolbar-button/toolbar-button';
 @import 'components/toolbar-button/toolbar-label';
 @import 'components/toolbar-button/toolbar-number-input';


### PR DESCRIPTION
Related Ticket: TINY-12301

Description of Changes:
* Extracted toggle component from suggested edits into its own reusable component
* Implemented disabled state styling
* Added CSS variables and used CSS color calculations instead of using less functions (one thing to figure out later is .bg-luma-checker checker function)

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new toggle switch component with updated styles for a more modern and interactive appearance.

* **Style**
  * Removed legacy styles for the previous suggested edits toggle and switch components.
  * Integrated the new toggle switch styles into the overall theme for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->