### PR TITLE
TINY-12326: Changed crossorigin to a function that returns the value

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -322,7 +322,15 @@ class Editor implements EditorObservable {
       DOMUtils.DOM.styleSheetLoader._setReferrerPolicy(referrerPolicy);
     }
 
-    ScriptLoader.ScriptLoader._setCrossOrigin(Options.getCrossOrigin(self));
+    ScriptLoader.ScriptLoader._setCrossOrigin((url) => {
+      const crossOrigin = Options.getCrossOrigin(self);
+      return crossOrigin(url, 'script');
+    });
+
+    DOMUtils.DOM.styleSheetLoader._setCrossOrigin((url) => {
+      const crossOrigin = Options.getCrossOrigin(self);
+      return crossOrigin(url, 'stylesheet');
+    });
 
     const contentCssCors = Options.hasContentCssCors(self);
     if (Type.isNonNullable(contentCssCors)) {

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -1,4 +1,3 @@
-
 import { UploadHandler } from '../file/Uploader';
 import { ExpectedUser } from '../lookup/UserLookup';
 import { DynamicPatternsLookup, Pattern, RawDynamicPatternsLookup, RawPattern } from '../textpatterns/core/PatternTypes';
@@ -47,7 +46,7 @@ export interface ToolbarGroup {
 export type ToolbarMode = 'floating' | 'sliding' | 'scrolling' | 'wrap';
 export type ToolbarLocation = 'top' | 'bottom' | 'auto';
 
-export type CrossOrigin = '' | 'anonymous' | 'use-credentials';
+export type CrossOrigin = (url: string, resourceType: 'script' | 'stylesheet') => '' | 'anonymous' | 'use-credentials';
 
 interface BaseEditorOptions {
   a11y_advanced_options?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -1,4 +1,4 @@
-import { Arr, Obj, Optional, Strings, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Strings, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 import * as Pattern from '../textpatterns/core/Pattern';
@@ -82,8 +82,8 @@ const register = (editor: Editor): void => {
   });
 
   registerOption('crossorigin', {
-    processor: 'string',
-    default: ''
+    processor: 'function',
+    default: Fun.constant('')
   });
 
   registerOption('language_load', {

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -65,6 +65,7 @@ export interface DOMUtilsSettings {
   onSetAttrib: (event: SetAttribEvent) => void;
   contentCssCors: boolean;
   referrerPolicy: ReferrerPolicy;
+  crossOrigin: (url: string, resourceType: 'script' | 'stylesheet') => string;
 }
 
 export type Target = Node | Window;
@@ -332,7 +333,16 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
   const boxModel = true;
   const styleSheetLoader = StyleSheetLoaderRegistry.instance.forElement(SugarElement.fromDom(doc), {
     contentCssCors: settings.contentCssCors,
-    referrerPolicy: settings.referrerPolicy
+    referrerPolicy: settings.referrerPolicy,
+    crossOrigin: (url) => {
+      const crossOrigin = settings.crossOrigin;
+
+      if (Type.isFunction(crossOrigin)) {
+        return crossOrigin(url, 'stylesheet');
+      } else {
+        return '';
+      }
+    }
   });
   const boundEvents: Array<[ Target, string, Callback<any>, any ]> = [];
   const schema = settings.schema ? settings.schema : Schema({});

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -32,7 +32,7 @@ const DOM = DOMUtils.DOM;
 
 export interface ScriptLoaderSettings {
   referrerPolicy?: ReferrerPolicy;
-  crossOrigin?: string;
+  crossOrigin?: (url: string) => string;
 }
 
 export interface ScriptLoaderConstructor {
@@ -66,7 +66,7 @@ class ScriptLoader {
     this.settings.referrerPolicy = referrerPolicy;
   }
 
-  public _setCrossOrigin(crossOrigin: string): void {
+  public _setCrossOrigin(crossOrigin: (url: string) => string): void {
     this.settings.crossOrigin = crossOrigin;
   }
 
@@ -117,8 +117,8 @@ class ScriptLoader {
       }
 
       const crossOrigin = this.settings.crossOrigin;
-      if (Type.isString(crossOrigin)) {
-        dom.setAttrib(elm, 'crossorigin', crossOrigin);
+      if (Type.isFunction(crossOrigin)) {
+        dom.setAttrib(elm, 'crossorigin', crossOrigin(url));
       }
 
       elm.onload = done;

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Obj } from '@ephox/katamari';
+import { Arr, Fun, Obj, Type } from '@ephox/katamari';
 import { Attribute, Insert, Remove, SelectorFind, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
 
 import Tools from '../util/Tools';
@@ -18,11 +18,13 @@ interface StyleSheetLoader {
   unloadAll: (urls: string[]) => void;
   _setReferrerPolicy: (referrerPolicy: ReferrerPolicy) => void;
   _setContentCssCors: (contentCssCors: boolean) => void;
+  _setCrossOrigin: (crossOrigin: (url: string) => string) => void;
 }
 
 export interface StyleSheetLoaderSettings {
   maxLoadTime?: number;
   contentCssCors?: boolean;
+  crossOrigin?: (url: string) => string;
   referrerPolicy?: ReferrerPolicy;
 }
 
@@ -33,6 +35,18 @@ interface StyleState {
   failed: Array<() => void>;
   count: number;
 }
+
+const getCrossOrigin = (url: string, settings: StyleSheetLoaderSettings) => {
+  const crossOriginFn = settings.crossOrigin;
+
+  if (settings.contentCssCors) {
+    return 'anonymous';
+  } else if (Type.isFunction(crossOriginFn)) {
+    return crossOriginFn(url);
+  } else {
+    return '';
+  }
+};
 
 const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings: StyleSheetLoaderSettings = {}): StyleSheetLoader => {
   let idCount = 0;
@@ -47,6 +61,10 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
 
   const _setContentCssCors = (contentCssCors: boolean) => {
     settings.contentCssCors = contentCssCors;
+  };
+
+  const _setCrossOrigin = (crossOrigin: (url: string) => string) => {
+    settings.crossOrigin = crossOrigin;
   };
 
   const addStyle = (element: SugarElement<HTMLStyleElement>) => {
@@ -134,9 +152,10 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
         id: state.id
       });
 
-      if (settings.contentCssCors) {
-        Attribute.set(linkElem, 'crossOrigin', 'anonymous');
-      }
+      const crossorigin = getCrossOrigin(url, settings);
+      if (crossorigin !== '') {
+        Attribute.set(linkElem, 'crossOrigin', crossorigin);
+      };
 
       if (settings.referrerPolicy) {
         // Note: Don't use link.referrerPolicy = ... here as it doesn't work on Safari
@@ -250,7 +269,8 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
     unloadRawCss,
     unloadAll,
     _setReferrerPolicy,
-    _setContentCssCors
+    _setContentCssCors,
+    _setCrossOrigin
   };
 };
 

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -455,6 +455,7 @@ const contentBodyLoaded = (editor: Editor): void => {
     schema: editor.schema,
     contentCssCors: Options.shouldUseContentCssCors(editor),
     referrerPolicy: Options.getReferrerPolicy(editor),
+    crossOrigin: Options.getCrossOrigin(editor),
     onSetAttrib: (e) => {
       editor.dispatch('SetAttrib', e);
     },

--- a/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginStylesheetTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginStylesheetTest.ts
@@ -1,0 +1,197 @@
+import { UiFinder } from '@ephox/agar';
+import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { Attribute, SugarElement, SugarHead } from '@ephox/sugar';
+import { McEditor } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
+import StyleSheetLoader from 'tinymce/core/api/dom/StyleSheetLoader';
+import Editor from 'tinymce/core/api/Editor';
+import EditorManager from 'tinymce/core/api/EditorManager';
+import * as OptionTypes from 'tinymce/core/api/OptionTypes';
+import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+
+describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
+  const settings = {
+    base_url: '/project/tinymce/js/tinymce',
+    menubar: false,
+    toolbar: false
+  };
+  const cssUrl = '/project/tinymce/js/tinymce/skins/content/default/content.css';
+
+  after(() => {
+    DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant(''));
+  });
+
+  const pLoadStylesheet = async (url: string) => {
+    await DOMUtils.DOM.styleSheetLoader.load(url);
+    return UiFinder.findIn<HTMLLinkElement>(SugarHead.head(), `link[href="${url}"]`).getOrDie();
+  };
+
+  const assertCrossOriginAttribute = (link: SugarElement<HTMLLinkElement>, expectedCrossOrigin: string) => {
+    if (expectedCrossOrigin === '') {
+      assert.isFalse(Attribute.has(link, 'crossorigin'), 'Crossorigin attribute should not be set');
+    } else {
+      assert.equal(Attribute.get(link, 'crossorigin'), expectedCrossOrigin, `Crossorigin attribute should be set to "${expectedCrossOrigin}"`);
+    }
+  };
+
+  afterEach(() => {
+    DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant(''));
+    EditorManager.overrideDefaults({ crossorigin: undefined });
+    DOMUtils.DOM.styleSheetLoader.unload(cssUrl);
+  });
+
+  context('Using global setter', () => {
+    const pTestCrossOriginSetter = async (crossOrigin: string) => {
+      let crossOriginUrl: string | undefined;
+
+      DOMUtils.DOM.styleSheetLoader._setCrossOrigin((url) => {
+        crossOriginUrl = url;
+        return crossOrigin;
+      });
+
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), crossOrigin);
+      assert.equal(crossOriginUrl, cssUrl, 'Cross origin url should be set');
+    };
+
+    it('TINY-12228: Should support setting anonymous crossorigin', () => pTestCrossOriginSetter('anonymous'));
+    it('TINY-12228: Should support setting use-credentials crossorigin', () => pTestCrossOriginSetter('use-credentials'));
+    it('TINY-12228: Should support setting empty crossorigin', () => pTestCrossOriginSetter(''));
+  });
+
+  context('Using editor option', () => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: string) => {
+      let crossOriginUrl: string | undefined;
+      const editor = await McEditor.pFromSettings<Editor>({
+        ...settings,
+        crossorigin: (url: string) => {
+          crossOriginUrl = url;
+          return crossOrigin;
+        }
+      });
+
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), crossOrigin);
+      assert.equal(crossOriginUrl, cssUrl, 'Cross origin url should be set');
+
+      McEditor.remove(editor);
+    };
+
+    it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption('anonymous'));
+    it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption('use-credentials'));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(''));
+    it('TINY-12228: Not setting a value removes the crossorigin global state', async () => {
+      DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant('anonymous'));
+
+      const editor = await McEditor.pFromSettings<Editor>(settings);
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), '');
+
+      McEditor.remove(editor);
+    });
+  });
+
+  context('Using overrideDefaults', () => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: OptionTypes.CrossOrigin, expectedCrossOrigin: string) => {
+      let crossOriginUrl: string | undefined;
+      let crossOriginResourceType: string | undefined;
+
+      EditorManager.overrideDefaults({
+        crossorigin: (url, resourceType) => {
+          crossOriginUrl = url;
+          crossOriginResourceType = resourceType;
+
+          return crossOrigin(url, resourceType);
+        }
+      });
+
+      const editor = await McEditor.pFromSettings<Editor>(settings);
+
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), expectedCrossOrigin);
+      assert.equal(crossOriginUrl, cssUrl, 'Cross origin url should be set');
+      assert.equal(crossOriginResourceType, 'stylesheet', 'Cross origin resource type should be stylesheet');
+
+      McEditor.remove(editor);
+    };
+
+    it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant('anonymous'), 'anonymous'));
+    it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant('use-credentials'), 'use-credentials'));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant(''), ''));
+    it('TINY-12228: Not setting a value does not override defaults value for crossorigin', async () => {
+      EditorManager.overrideDefaults({
+        crossorigin: Fun.constant('anonymous')
+      });
+
+      const editor = await McEditor.pFromSettings<Editor>(settings);
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), 'anonymous');
+
+      McEditor.remove(editor);
+    });
+  });
+
+  context('Using AddEditor event patch', () => {
+    let patchedCrossOrigin: '' | 'anonymous' | 'use-credentials' = '';
+
+    const patchCrossOrigin = (e: EditorEvent<{ editor: Editor }>) => {
+      e.editor.options.set('crossorigin', () => {
+        return patchedCrossOrigin;
+      });
+    };
+
+    before(() => {
+      EditorManager.on('AddEditor', patchCrossOrigin);
+    });
+
+    after(() => {
+      EditorManager.off('AddEditor', patchCrossOrigin);
+    });
+
+    const pTestCrossOriginAddEventPatch = async (crossOrigin: '' | 'anonymous' | 'use-credentials') => {
+      patchedCrossOrigin = crossOrigin;
+
+      const editor = await McEditor.pFromSettings<Editor>(settings);
+
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), crossOrigin);
+
+      McEditor.remove(editor);
+    };
+
+    it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginAddEventPatch('anonymous'));
+    it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginAddEventPatch('use-credentials'));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginAddEventPatch(''));
+  });
+
+  context('Cross origin with contentCssCors set to true', () => {
+    let loader: StyleSheetLoader;
+
+    before(() => {
+      loader = StyleSheetLoader(document, {
+        maxLoadTime: 500,
+        contentCssCors: true
+      });
+    });
+
+    afterEach(() => {
+      loader.unload(cssUrl);
+    });
+
+    const pTestCrossOriginAttribute = async (crossOrigin: string) => {
+      let crossOriginCalled = false;
+
+      loader._setCrossOrigin(() => {
+        crossOriginCalled = true;
+
+        return crossOrigin;
+      });
+
+      await loader.load(cssUrl);
+
+      assert.isFalse(crossOriginCalled, 'Cross origin handler should not have been called when contentCssCors is true');
+      UiFinder.exists(SugarHead.head(), `link[href="${cssUrl}"][crossorigin="anonymous"]`); // Should always be anonymous when contentCssCors is true
+    };
+
+    it('TINY-12326: Load stylesheet with crossorigin anonymous', () => pTestCrossOriginAttribute('anonymous'));
+    it('TINY-12326: Load stylesheet with crossorigin use-credentials', () => pTestCrossOriginAttribute('use-credentials'));
+    it('TINY-12326: Load stylesheet with crossorigin empty string', () => pTestCrossOriginAttribute(''));
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-12326

Follow up PR to: TINY-12228

Description of Changes:
* Changes the crossorigin so that it's a function that returns the value based on the URL and resource type
* Added it to the StyleSheetLoader as well.
* Branch is failing CI due to a webdriver issue not related to this PR needs to be fixed on `main`

Pre-checks:
* [x] ~~Changelog entry added~~ No changelog since the previous PR had one
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamically setting the cross-origin attribute for scripts and stylesheets based on their URL and resource type.

* **Bug Fixes**
  * Improved handling of cross-origin attributes to ensure correct application for both scripts and stylesheets in various scenarios.

* **Tests**
  * Enhanced and expanded test coverage for cross-origin attribute handling, including new tests for stylesheets and dynamic option settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->