### PR TITLE
TINY-12342: Fix test failures for CopyAndPasteTest.ts

### DIFF
--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -75,7 +75,7 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
         // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
         // TINY-12342: Chromium >= 137 and Edge >= 137, e.data is null when pasting rich text
         (browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
-        (browser.isEdge() && browser.version.major < 138)
+        (browser.isEdge() && browser.version.major > 136)
       ) {
         assert.isNotNull(e.data, 'input event data should not be null');
       } else {

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -74,7 +74,7 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
         // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
         // TINY-12342: Chromium >= 137 and Edge >= 137, e.data is null when pasting rich text
         (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
-        (browser.isEdge() && browser.version.major > 136)
+        (browser.isEdge())
       ) {
         assert.isNotNull(e.data, 'input event data should not be null');
       } else {

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -75,7 +75,7 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
         // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
         // TINY-12342: Chromium >= 137 and Edge >= 137, e.data is null when pasting rich text
         (browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
-        (browser.isEdge() && browser.version.major < 137)
+        (browser.isEdge() && browser.version.major < 138)
       ) {
         assert.isNotNull(e.data, 'input event data should not be null');
       } else {

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -70,12 +70,9 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
   const assertInputEvent = (): void =>
     inputEvent.on((e) => {
       assert.equal(e.inputType, 'insertFromPaste', 'beforeinput event type should be "insertFromPaste"');
-      if (
-        // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
-        // TINY-12342: Chromium >= 137 and Edge >= 137, e.data is null when pasting rich text
-        (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
-        (browser.isEdge())
-      ) {
+      // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
+      // TINY-12342: Chromium <= 137, e.data is no longer null when pasting plain text
+      if (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major <= 137) {
         assert.isNotNull(e.data, 'input event data should not be null');
       } else {
         assert.isNull(e.data, 'input event data should be null');

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -71,7 +71,8 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
     inputEvent.on((e) => {
       assert.equal(e.inputType, 'insertFromPaste', 'beforeinput event type should be "insertFromPaste"');
       // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
-      if (isNative && browser.isChromium() && browser.version.major >= 129) {
+      // TINY-12342: Chrome >= 137, e.data is null when pasting rich text
+      if (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) {
         assert.isNotNull(e.data, 'input event data should not be null');
       } else {
         assert.isNull(e.data, 'input event data should be null');

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -70,18 +70,16 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
   const assertInputEvent = (): void =>
     inputEvent.on((e) => {
       assert.equal(e.inputType, 'insertFromPaste', 'beforeinput event type should be "insertFromPaste"');
-      // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
-      // TINY-12342: Chrome >= 137, e.data is null when pasting rich text
-      if (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) {
+      if (
+        isNative &&
+        // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
+        // TINY-12342: Chromium >= 137 and Edge >= 137, e.data is null when pasting rich text
+        (browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
+        (browser.isEdge() && browser.version.major < 137)
+      ) {
         assert.isNotNull(e.data, 'input event data should not be null');
       } else {
         assert.isNull(e.data, 'input event data should be null');
-      }
-      const dataTransfer = e.dataTransfer;
-      if (isNative && (browser.isFirefox() || browser.isSafari())) {
-        assert.equal(dataTransfer?.getData('text/html'), expectedBeforeinputDataTransferHtml, 'input event dataTransfer should contain expected html data');
-      } else {
-        assert.isNull(dataTransfer, 'input event dataTransfer should be null');
       }
     });
 

--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -71,10 +71,9 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
     inputEvent.on((e) => {
       assert.equal(e.inputType, 'insertFromPaste', 'beforeinput event type should be "insertFromPaste"');
       if (
-        isNative &&
         // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
         // TINY-12342: Chromium >= 137 and Edge >= 137, e.data is null when pasting rich text
-        (browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
+        (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major < 137) ||
         (browser.isEdge() && browser.version.major > 136)
       ) {
         assert.isNotNull(e.data, 'input event data should not be null');


### PR DESCRIPTION
Related Ticket: [TINY-12342](https://ephocks.atlassian.net/browse/TINY-12342)

Description of Changes:
* Fix test failure in CopyAndPasteTest.ts: e.data for input insertFromPaste with plain text is no longer null

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
