### PR TITLE
TINY-12379: fix broken preserve attributes with self closed HTML tags test on Firefox

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/content/EditorContentTest.ts
@@ -289,7 +289,7 @@ describe('browser.tinymce.core.content.EditorContentTest', () => {
           const content = '<div data-some-attribute="title=<br/>">abc</div>';
           const editor = hook.editor();
           editor.setContent(content);
-          TinyAssertions.assertContent(editor, content, { format: 'raw' });
+          TinyAssertions.assertContent(editor, '<div data-some-attribute="title=&lt;br/&gt;">abc</div>');
         });
 
         const initialContent = '<p>initial</p>';


### PR DESCRIPTION
Related Ticket: TINY-12379

Description of Changes:
A quick story of this problem:
1. During `setContent` we encode attribute values. `<` is replaced by `&lt;` and `>` is replaced by `&gt;`
2. During `getContent({ type: 'raw' })` we return `innerHTML` from editor's `body`
3. Different browsers return different results in this case
4. The recent firefox update on CI from 139 to 140 had to change this behavior. Also `chrome-headless` and `chrome` handle those differently.

Proof:
Run this line on Firefox, Safari, Chrome, compare results.
```
new DOMParser().parseFromString('<div data-some-attribute="title=&lt;br/&gt;"></div>', 'text/html').body.innerHTML;
```

Fix explained:
1. In the test case I removed `{ type: 'raw' }`
2. This is causing the editor to use our own serializer instead of browser-dependent `innerHTML`
3. This produces the same output throughout different browsers.

Pre-checks:
~~* [ ] Changelog entry added~~
~~* [ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
~~* [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):
