### PR TITLE
TINY-12377: Change crossorigin function to return undefined instead of empty string

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -46,7 +46,7 @@ export interface ToolbarGroup {
 export type ToolbarMode = 'floating' | 'sliding' | 'scrolling' | 'wrap';
 export type ToolbarLocation = 'top' | 'bottom' | 'auto';
 
-export type CrossOrigin = (url: string, resourceType: 'script' | 'stylesheet') => '' | 'anonymous' | 'use-credentials';
+export type CrossOrigin = (url: string, resourceType: 'script' | 'stylesheet') => 'anonymous' | 'use-credentials' | undefined;
 
 interface BaseEditorOptions {
   a11y_advanced_options?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -83,7 +83,7 @@ const register = (editor: Editor): void => {
 
   registerOption('crossorigin', {
     processor: 'function',
-    default: Fun.constant('')
+    default: Fun.constant(undefined)
   });
 
   registerOption('language_load', {

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -65,7 +65,7 @@ export interface DOMUtilsSettings {
   onSetAttrib: (event: SetAttribEvent) => void;
   contentCssCors: boolean;
   referrerPolicy: ReferrerPolicy;
-  crossOrigin: (url: string, resourceType: 'script' | 'stylesheet') => string;
+  crossOrigin: (url: string, resourceType: 'script' | 'stylesheet') => string | undefined;
 }
 
 export type Target = Node | Window;
@@ -340,7 +340,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
       if (Type.isFunction(crossOrigin)) {
         return crossOrigin(url, 'stylesheet');
       } else {
-        return '';
+        return undefined;
       }
     }
   });

--- a/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ScriptLoader.ts
@@ -32,7 +32,7 @@ const DOM = DOMUtils.DOM;
 
 export interface ScriptLoaderSettings {
   referrerPolicy?: ReferrerPolicy;
-  crossOrigin?: (url: string) => string;
+  crossOrigin?: (url: string) => string | undefined;
 }
 
 export interface ScriptLoaderConstructor {
@@ -66,7 +66,7 @@ class ScriptLoader {
     this.settings.referrerPolicy = referrerPolicy;
   }
 
-  public _setCrossOrigin(crossOrigin: (url: string) => string): void {
+  public _setCrossOrigin(crossOrigin: (url: string) => string | undefined): void {
     this.settings.crossOrigin = crossOrigin;
   }
 
@@ -118,7 +118,10 @@ class ScriptLoader {
 
       const crossOrigin = this.settings.crossOrigin;
       if (Type.isFunction(crossOrigin)) {
-        dom.setAttrib(elm, 'crossorigin', crossOrigin(url));
+        const resultCrossOrigin = crossOrigin(url);
+        if (resultCrossOrigin !== undefined) {
+          dom.setAttrib(elm, 'crossorigin', resultCrossOrigin);
+        }
       }
 
       elm.onload = done;

--- a/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/StyleSheetLoader.ts
@@ -18,13 +18,13 @@ interface StyleSheetLoader {
   unloadAll: (urls: string[]) => void;
   _setReferrerPolicy: (referrerPolicy: ReferrerPolicy) => void;
   _setContentCssCors: (contentCssCors: boolean) => void;
-  _setCrossOrigin: (crossOrigin: (url: string) => string) => void;
+  _setCrossOrigin: (crossOrigin: (url: string) => string | undefined) => void;
 }
 
 export interface StyleSheetLoaderSettings {
   maxLoadTime?: number;
   contentCssCors?: boolean;
-  crossOrigin?: (url: string) => string;
+  crossOrigin?: (url: string) => string | undefined;
   referrerPolicy?: ReferrerPolicy;
 }
 
@@ -44,7 +44,7 @@ const getCrossOrigin = (url: string, settings: StyleSheetLoaderSettings) => {
   } else if (Type.isFunction(crossOriginFn)) {
     return crossOriginFn(url);
   } else {
-    return '';
+    return undefined;
   }
 };
 
@@ -63,7 +63,7 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
     settings.contentCssCors = contentCssCors;
   };
 
-  const _setCrossOrigin = (crossOrigin: (url: string) => string) => {
+  const _setCrossOrigin = (crossOrigin: (url: string) => string | undefined) => {
     settings.crossOrigin = crossOrigin;
   };
 
@@ -153,7 +153,7 @@ const StyleSheetLoader = (documentOrShadowRoot: Document | ShadowRoot, settings:
       });
 
       const crossorigin = getCrossOrigin(url, settings);
-      if (crossorigin !== '') {
+      if (crossorigin !== undefined) {
         Attribute.set(linkElem, 'crossOrigin', crossorigin);
       };
 

--- a/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginScriptTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginScriptTest.ts
@@ -58,8 +58,8 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
     return observePromise;
   };
 
-  const assertCrossOriginAttribute = (script: SugarElement<HTMLScriptElement>, expectedCrossOrigin: string) => {
-    if (expectedCrossOrigin === '') {
+  const assertCrossOriginAttribute = (script: SugarElement<HTMLScriptElement>, expectedCrossOrigin: string | undefined) => {
+    if (expectedCrossOrigin === undefined) {
       assert.isFalse(Attribute.has(script, 'crossorigin'), 'Crossorigin attribute should not be set');
     } else {
       assert.equal(Attribute.get(script, 'crossorigin'), expectedCrossOrigin, `Crossorigin attribute should be set to "${expectedCrossOrigin}"`);
@@ -67,12 +67,12 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
   };
 
   afterEach(() => {
-    ScriptLoader.ScriptLoader._setCrossOrigin(Fun.constant(''));
+    ScriptLoader.ScriptLoader._setCrossOrigin(Fun.constant(undefined));
     EditorManager.overrideDefaults({ crossorigin: undefined });
   });
 
   context('Using global setter', () => {
-    const pTestCrossOriginSetter = async (crossOrigin: string) => {
+    const pTestCrossOriginSetter = async (crossOrigin: string | undefined) => {
       let crossOriginUrl: string | undefined;
 
       ScriptLoader.ScriptLoader._setCrossOrigin((url) => {
@@ -86,11 +86,11 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
 
     it('TINY-12228: Should support setting anonymous crossorigin', () => pTestCrossOriginSetter('anonymous'));
     it('TINY-12228: Should support setting use-credentials crossorigin', () => pTestCrossOriginSetter('use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin', () => pTestCrossOriginSetter(''));
+    it('TINY-12228: Should support setting empty crossorigin', () => pTestCrossOriginSetter(undefined));
   });
 
   context('Using editor option', () => {
-    const pTestCrossOriginEditorOption = async (crossOrigin: string) => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: string | undefined) => {
       let crossOriginUrl: string | undefined;
       const editor = await McEditor.pFromSettings<Editor>({
         ...settings,
@@ -108,19 +108,19 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
 
     it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption('anonymous'));
     it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption('use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(''));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(undefined));
     it('TINY-12228: Not setting a value removes the crossorigin global state', async () => {
       ScriptLoader.ScriptLoader._setCrossOrigin(Fun.constant('anonymous'));
 
       const editor = await McEditor.pFromSettings<Editor>(settings);
-      assertCrossOriginAttribute(await pLoadScript(scriptUrl), '');
+      assertCrossOriginAttribute(await pLoadScript(scriptUrl), undefined);
 
       McEditor.remove(editor);
     });
   });
 
   context('Using overrideDefaults', () => {
-    const pTestCrossOriginEditorOption = async (crossOrigin: OptionTypes.CrossOrigin, expectedCrossOrigin: string) => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: OptionTypes.CrossOrigin, expectedCrossOrigin: string | undefined) => {
       let crossOriginUrl: string | undefined;
       let crossOriginResourceType: string | undefined;
 
@@ -144,7 +144,7 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
 
     it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant('anonymous'), 'anonymous'));
     it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant('use-credentials'), 'use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant(''), ''));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant(undefined), undefined));
     it('TINY-12228: Not setting a value does not override defaults value for crossorigin', async () => {
       EditorManager.overrideDefaults({
         crossorigin: Fun.constant('anonymous')
@@ -158,7 +158,7 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
   });
 
   context('Using AddEditor event patch', () => {
-    let patchedCrossOrigin: '' | 'anonymous' | 'use-credentials' = '';
+    let patchedCrossOrigin: 'anonymous' | 'use-credentials' | undefined;
 
     const patchCrossOrigin = (e: EditorEvent<{ editor: Editor }>) => {
       e.editor.options.set('crossorigin', () => {
@@ -174,7 +174,7 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
       EditorManager.off('AddEditor', patchCrossOrigin);
     });
 
-    const pTestCrossOriginAddEventPatch = async (crossOrigin: '' | 'anonymous' | 'use-credentials') => {
+    const pTestCrossOriginAddEventPatch = async (crossOrigin: 'anonymous' | 'use-credentials' | undefined) => {
       patchedCrossOrigin = crossOrigin;
 
       const editor = await McEditor.pFromSettings<Editor>(settings);
@@ -186,6 +186,6 @@ describe('browser.tinymce.core.dom.CrossOriginScriptTest', () => {
 
     it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginAddEventPatch('anonymous'));
     it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginAddEventPatch('use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginAddEventPatch(''));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginAddEventPatch(undefined));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginStylesheetTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/CrossOriginStylesheetTest.ts
@@ -21,7 +21,7 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
   const cssUrl = '/project/tinymce/js/tinymce/skins/content/default/content.css';
 
   after(() => {
-    DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant(''));
+    DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant(undefined));
   });
 
   const pLoadStylesheet = async (url: string) => {
@@ -29,8 +29,8 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
     return UiFinder.findIn<HTMLLinkElement>(SugarHead.head(), `link[href="${url}"]`).getOrDie();
   };
 
-  const assertCrossOriginAttribute = (link: SugarElement<HTMLLinkElement>, expectedCrossOrigin: string) => {
-    if (expectedCrossOrigin === '') {
+  const assertCrossOriginAttribute = (link: SugarElement<HTMLLinkElement>, expectedCrossOrigin: string | undefined) => {
+    if (expectedCrossOrigin === undefined) {
       assert.isFalse(Attribute.has(link, 'crossorigin'), 'Crossorigin attribute should not be set');
     } else {
       assert.equal(Attribute.get(link, 'crossorigin'), expectedCrossOrigin, `Crossorigin attribute should be set to "${expectedCrossOrigin}"`);
@@ -38,13 +38,13 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
   };
 
   afterEach(() => {
-    DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant(''));
+    DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant(undefined));
     EditorManager.overrideDefaults({ crossorigin: undefined });
     DOMUtils.DOM.styleSheetLoader.unload(cssUrl);
   });
 
   context('Using global setter', () => {
-    const pTestCrossOriginSetter = async (crossOrigin: string) => {
+    const pTestCrossOriginSetter = async (crossOrigin: string | undefined) => {
       let crossOriginUrl: string | undefined;
 
       DOMUtils.DOM.styleSheetLoader._setCrossOrigin((url) => {
@@ -58,11 +58,11 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
 
     it('TINY-12228: Should support setting anonymous crossorigin', () => pTestCrossOriginSetter('anonymous'));
     it('TINY-12228: Should support setting use-credentials crossorigin', () => pTestCrossOriginSetter('use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin', () => pTestCrossOriginSetter(''));
+    it('TINY-12228: Should support setting empty crossorigin', () => pTestCrossOriginSetter(undefined));
   });
 
   context('Using editor option', () => {
-    const pTestCrossOriginEditorOption = async (crossOrigin: string) => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: string | undefined) => {
       let crossOriginUrl: string | undefined;
       const editor = await McEditor.pFromSettings<Editor>({
         ...settings,
@@ -80,19 +80,19 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
 
     it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption('anonymous'));
     it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption('use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(''));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(undefined));
     it('TINY-12228: Not setting a value removes the crossorigin global state', async () => {
       DOMUtils.DOM.styleSheetLoader._setCrossOrigin(Fun.constant('anonymous'));
 
       const editor = await McEditor.pFromSettings<Editor>(settings);
-      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), '');
+      assertCrossOriginAttribute(await pLoadStylesheet(cssUrl), undefined);
 
       McEditor.remove(editor);
     });
   });
 
   context('Using overrideDefaults', () => {
-    const pTestCrossOriginEditorOption = async (crossOrigin: OptionTypes.CrossOrigin, expectedCrossOrigin: string) => {
+    const pTestCrossOriginEditorOption = async (crossOrigin: OptionTypes.CrossOrigin, expectedCrossOrigin: string | undefined) => {
       let crossOriginUrl: string | undefined;
       let crossOriginResourceType: string | undefined;
 
@@ -116,7 +116,7 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
 
     it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant('anonymous'), 'anonymous'));
     it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant('use-credentials'), 'use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant(''), ''));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginEditorOption(Fun.constant(undefined), undefined));
     it('TINY-12228: Not setting a value does not override defaults value for crossorigin', async () => {
       EditorManager.overrideDefaults({
         crossorigin: Fun.constant('anonymous')
@@ -130,7 +130,7 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
   });
 
   context('Using AddEditor event patch', () => {
-    let patchedCrossOrigin: '' | 'anonymous' | 'use-credentials' = '';
+    let patchedCrossOrigin: 'anonymous' | 'use-credentials' | undefined;
 
     const patchCrossOrigin = (e: EditorEvent<{ editor: Editor }>) => {
       e.editor.options.set('crossorigin', () => {
@@ -146,7 +146,7 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
       EditorManager.off('AddEditor', patchCrossOrigin);
     });
 
-    const pTestCrossOriginAddEventPatch = async (crossOrigin: '' | 'anonymous' | 'use-credentials') => {
+    const pTestCrossOriginAddEventPatch = async (crossOrigin: 'anonymous' | 'use-credentials' | undefined) => {
       patchedCrossOrigin = crossOrigin;
 
       const editor = await McEditor.pFromSettings<Editor>(settings);
@@ -158,7 +158,7 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
 
     it('TINY-12228: Should support anonymous in crossorigin option', () => pTestCrossOriginAddEventPatch('anonymous'));
     it('TINY-12228: Should support use-credentials crossorigin option', () => pTestCrossOriginAddEventPatch('use-credentials'));
-    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginAddEventPatch(''));
+    it('TINY-12228: Should support setting empty crossorigin option', () => pTestCrossOriginAddEventPatch(undefined));
   });
 
   context('Cross origin with contentCssCors set to true', () => {
@@ -175,7 +175,7 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
       loader.unload(cssUrl);
     });
 
-    const pTestCrossOriginAttribute = async (crossOrigin: string) => {
+    const pTestCrossOriginAttribute = async (crossOrigin: string | undefined) => {
       let crossOriginCalled = false;
 
       loader._setCrossOrigin(() => {
@@ -192,6 +192,6 @@ describe('browser.tinymce.core.dom.CrossOriginStylesheetTest', () => {
 
     it('TINY-12326: Load stylesheet with crossorigin anonymous', () => pTestCrossOriginAttribute('anonymous'));
     it('TINY-12326: Load stylesheet with crossorigin use-credentials', () => pTestCrossOriginAttribute('use-credentials'));
-    it('TINY-12326: Load stylesheet with crossorigin empty string', () => pTestCrossOriginAttribute(''));
+    it('TINY-12326: Load stylesheet with crossorigin empty string', () => pTestCrossOriginAttribute(undefined));
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-12377

Description of Changes:
* Changed the `CrossOrigin` type to return `'anonymous' | 'use-credentials' | undefined` instead of `'' | 'anonymous' | 'use-credentials'`
* Updated the default crossorigin function to return `undefined` instead of an empty string
* Modified script and stylesheet loaders to only set the crossorigin attribute when a non-undefined value is returned
* Updated all tests to reflect these changes

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cross-origin attributes for scripts and stylesheets, ensuring that the absence of a value is treated as undefined rather than an empty string.

* **Tests**
  * Updated test cases for cross-origin script and stylesheet loading to align with the new handling of undefined values instead of empty strings. 

These changes provide more consistent and predictable behavior when configuring cross-origin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->