### PR TITLE
TINY-12313: Various CSS fixes for Suggested Edits

### DIFF
--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -69,31 +69,34 @@ video,
 iframe {
   &.tox-suggestededits__annotation--added__highlight {
     outline: 0.25em solid @added-background-color;
+    padding: 0.25em;
   }
 
   &.tox-suggestededits__annotation--added__selected {
     border: 0.25em solid @added-background-color;
     outline: 0.125em solid @selected-outline-color;
-    padding: 0.25em;
+    padding: 0em;
   }
 
   &.tox-suggestededits__annotation--modified__highlight {
     outline: 0.25em solid @modified-background-color;
+    padding: 0.25em;
   }
 
   &.tox-suggestededits__annotation--modified__selected {
     border: 0.25em solid @modified-background-color;
     outline: 0.125em solid @selected-outline-color;
-    padding: 0.25em;
+    padding: 0em;
   }
 
   &.tox-suggestededits__annotation--removed__highlight {
     outline: 0.25em solid @removed-background-color;
+    padding: 0.25em;
   }
 
   &.tox-suggestededits__annotation--removed__selected {
     border: 0.25em solid @removed-background-color;
     outline: 0.125em solid @selected-outline-color;
-    padding: 0.25em;
+    padding: 0em;
   }
 }

--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -39,13 +39,13 @@
 
 .tox-suggestededits__annotation--removed__highlight {
 	background-color: @removed-background-color;
-	text-decoration: 'strike-through';
+	text-decoration: line-through;
 }
 
 .tox-suggestededits__annotation--removed__selected {
 	background-color: @removed-background-color;
 	box-shadow: @selected-box-shadow;
-	text-decoration: 'strike-through';
+	text-decoration: line-through;
 }
 
 .tox-suggestededits__annotation--added.tox-suggestededits__annotation--added__hidden,
@@ -65,13 +65,16 @@
 }
 
 img,
-video {
+video,
+iframe {
   &.tox-suggestededits__annotation--added__highlight {
     outline: 0.25em solid @added-background-color;
   }
 
   &.tox-suggestededits__annotation--added__selected {
-    outline: 0.25em solid @color-success;
+    border: 0.25em solid @added-background-color;
+    outline: 0.125em solid @selected-outline-color;
+    padding: 0.25em;
   }
 
   &.tox-suggestededits__annotation--modified__highlight {
@@ -79,7 +82,9 @@ video {
   }
 
   &.tox-suggestededits__annotation--modified__selected {
-    outline: 0.25em solid @color-tint;
+    border: 0.25em solid @modified-background-color;
+    outline: 0.125em solid @selected-outline-color;
+    padding: 0.25em;
   }
 
   &.tox-suggestededits__annotation--removed__highlight {
@@ -87,6 +92,8 @@ video {
   }
 
   &.tox-suggestededits__annotation--removed__selected {
-    outline: 0.25em solid @color-error;
+    border: 0.25em solid @removed-background-color;
+    outline: 0.125em solid @selected-outline-color;
+    padding: 0.25em;
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-12313

Description of Changes:
* Improved selected highlight of images, videos, iframes to be consistent with selected text highlighting
  * Styles will be reassessed again post-release, current implementation has limitations
* Added border to iframes
* Fixed invalid text decoration with 'line-through'
* Padding on highlighted images, videos, iframes is adjusted when selecting to account for the added border, so that they don't change in size when selected

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling for removed text by updating to a standard line-through effect.
  * Enhanced appearance of annotated images, videos, and iframes with clearer borders, outlines, and padding when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->