### PR TITLE
TINY-12388: Prevent cards being cut off at the bottom of the sidebar

### DIFF
--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -138,7 +138,7 @@
         flex-direction: column;
         gap: 12px;
         overflow: auto;
-        padding: 0px 12px;
+        padding: 0px 12px 12px 12px;
         position: relative;
 
         .tox-suggestededits__card {


### PR DESCRIPTION
Related Ticket: [TINY-12388](https://ephocks.atlassian.net/browse/TINY-12388)

Description of Changes:
* Quick PR to address cards being slightly cut off at the bottom of the sidebar.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12388]: https://ephocks.atlassian.net/browse/TINY-12388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing by adding bottom padding to the suggested edits sidebar content for a more visually balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->