### PR TITLE
TINY-12462: Change default value of `pagebreak_split_block`  to true

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12462-2025-07-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-12462-2025-07-07.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: The default value of `pagebreak_split_block` to true
+time: 2025-07-07T22:26:20.509659+01:00
+custom:
+    Issue: TINY-12462

--- a/.changes/unreleased/tinymce-TINY-12462-2025-07-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-12462-2025-07-07.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Changed
-body: The default value of `pagebreak_split_block` to true
+body: The default value of `pagebreak_split_block` is now `true` to match the new `pagebreak_separator` default.
 time: 2025-07-07T22:26:20.509659+01:00
 custom:
     Issue: TINY-12462

--- a/modules/tinymce/src/plugins/pagebreak/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/pagebreak/main/ts/api/Options.ts
@@ -17,7 +17,7 @@ const register = (editor: Editor): void => {
 
   registerOption('pagebreak_split_block', {
     processor: 'boolean',
-    default: false
+    default: true
   });
 };
 


### PR DESCRIPTION
Related Ticket: TINY-12462

Description of Changes:
* Change default value of `pagebreak_split_block`  to true

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
