### PR TITLE
TINY-12469: Update demos to include license_key: 'gpl'

### DIFF
--- a/modules/oxide/src/demo/index.html
+++ b/modules/oxide/src/demo/index.html
@@ -41,6 +41,7 @@
 
         tinymce.init({
             selector:'textarea',
+            license_key: 'gpl',
             plugins: [
               'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
               'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',

--- a/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/AnnotationsDemo.ts
@@ -14,6 +14,7 @@ export default (): void => {
   tinymce.init({
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     selector: 'div.tinymce',
+    license_key: 'gpl',
     toolbar: 'annotate-alpha get-all-alpha remove-all-alpha remove-alpha',
     plugins: [ ],
 

--- a/modules/tinymce/src/core/demo/ts/demo/BundledCssDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/BundledCssDemo.ts
@@ -5,6 +5,7 @@ declare let tinymce: TinyMCE;
 export default (): void => {
   tinymce.init({
     selector: 'textarea',
+    license_key: 'gpl',
     plugins: [ 'code' ],
     // Enable scripts in bundled_css_demo.html before uncommenting below lines
     // skin: 'oxide-dark',

--- a/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/CommandsDemo.ts
@@ -103,6 +103,7 @@ export default (): void => {
   tinymce.init({
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     selector: 'textarea.tinymce',
+    license_key: 'gpl',
     plugins: [
       'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
       'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',

--- a/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
@@ -66,6 +66,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tinymce',
+    license_key: 'gpl',
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     add_unload_trigger: false,
     toolbar: 'insertfile undo redo | styles | bold italic | alignleft aligncenter alignright alignjustify' +
@@ -77,6 +78,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'div.tinymce',
+    license_key: 'gpl',
     inline: true,
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     add_unload_trigger: false,

--- a/modules/tinymce/src/core/demo/ts/demo/ContentSecurityPolicyDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContentSecurityPolicyDemo.ts
@@ -36,6 +36,7 @@ const settings: RawEditorOptions = {
   content_css: '../../../../js/tinymce/skins/content/default/content.css',
   images_upload_url: 'd',
   selector: 'textarea',
+  license_key: 'gpl',
   // rtl_ui: true,
   link_list: [
     { title: 'My page 1', value: 'http://www.tinymce.com' },

--- a/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextFormDemo.ts
@@ -137,6 +137,7 @@ export default (): void => {
     ],
     images_upload_url: 'd',
     selector: 'textarea',
+    license_key: 'gpl',
     // rtl_ui: true,
     link_list: [
       { title: 'My page 1', value: 'http://www.tinymce.com' },

--- a/modules/tinymce/src/core/demo/ts/demo/ContextToolbarDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ContextToolbarDemo.ts
@@ -9,6 +9,7 @@ export default (): void => {
   const settings: RawEditorOptions = {
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     selector: 'textarea',
+    license_key: 'gpl',
     plugins: [
       'advlist', 'autolink', 'link', 'image', 'lists', 'charmap', 'preview', 'anchor', 'pagebreak',
       'searchreplace', 'wordcount', 'visualblocks', 'visualchars', 'code', 'fullscreen', 'insertdatetime', 'media', 'nonbreaking',

--- a/modules/tinymce/src/core/demo/ts/demo/CustomThemeDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/CustomThemeDemo.ts
@@ -15,6 +15,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea',
+    license_key: 'gpl',
     theme: (editor, target) => {
       const dom = tinymce.DOM;
 

--- a/modules/tinymce/src/core/demo/ts/demo/DisabledDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/DisabledDemo.ts
@@ -29,6 +29,7 @@ export default (): void => {
   tinymce.init({
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     selector: 'div.tinymce',
+    license_key: 'gpl',
     height: 1000,
     plugins: 'accordion image table emoticons charmap codesample insertdatetime',
     // eslint-disable-next-line max-len

--- a/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
@@ -5,6 +5,7 @@ declare let tinymce: TinyMCE;
 export default (): void => {
   tinymce.init({
     selector: '#editor',
+    license_key: 'gpl',
     inline: true,
     fixed_toolbar_container: '#toolbar',
   });

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -69,6 +69,7 @@ export default (): void => {
     ],
     images_upload_url: 'd',
     selector: 'textarea',
+    license_key: 'gpl',
     // rtl_ui: true,
     link_list: [
       { title: 'My page 1', value: 'http://www.tinymce.com' },
@@ -109,7 +110,6 @@ export default (): void => {
     },
     image_caption: true,
     theme: 'silver',
-    license_key: 'gpl',
     setup: (ed) => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
       makeSidebar(ed, 'sidebar2', 'green', 200);

--- a/modules/tinymce/src/core/demo/ts/demo/IframeDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/IframeDemo.ts
@@ -33,6 +33,7 @@ export default (): void => {
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     selector: 'textarea',
+    license_key: 'gpl',
     setup: (ed) => {
       makeSidebar(ed, 'sidebar1', 'green', 200);
     },

--- a/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/InlineDemo.ts
@@ -6,6 +6,7 @@ export default (): void => {
 
   const settings: RawEditorOptions = {
     selector: '.tinymce',
+    license_key: 'gpl',
     inline: true,
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     images_upload_url: 'd',

--- a/modules/tinymce/src/core/demo/ts/demo/ReadOnlyDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ReadOnlyDemo.ts
@@ -77,6 +77,7 @@ export default (): void => {
     ],
     images_upload_url: 'd',
     selector: 'textarea',
+    license_key: 'gpl',
     // rtl_ui: true,
     link_list: [
       { title: 'My page 1', value: 'http://www.tinymce.com' },

--- a/modules/tinymce/src/core/demo/ts/demo/ResponsiveDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ResponsiveDemo.ts
@@ -27,6 +27,7 @@ export default (): void => {
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     images_upload_url: 'd',
     selector: '#ephox-ui textarea',
+    license_key: 'gpl',
     // rtl_ui: true,
     link_list: [
       { title: 'My page 1', value: 'http://www.tinymce.com' },

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomDemo.ts
@@ -17,6 +17,7 @@ export default (init: ShadowRootInit): void => {
 
   tinymce.init({
     target: node.dom,
+    license_key: 'gpl',
     plugins: 'advlist charmap code codesample emoticons fullscreen image link lists media preview searchreplace table wordcount'
   });
 };

--- a/modules/tinymce/src/core/demo/ts/demo/ShadowDomInlineDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ShadowDomInlineDemo.ts
@@ -17,6 +17,7 @@ export default (init: ShadowRootInit): void => {
     Insert.append(shadow, node);
     tinymce.init({
       target: node.dom,
+      license_key: 'gpl',
       inline: true
     });
   };

--- a/modules/tinymce/src/core/demo/ts/demo/SourceDumpDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/SourceDumpDemo.ts
@@ -7,6 +7,7 @@ declare let tinymce: TinyMCE;
 export default (): void => {
   tinymce.init({
     selector: 'textarea#editor',
+    license_key: 'gpl',
     skin_url: '../../../../js/tinymce/skins/ui/oxide',
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     image_caption: true,

--- a/modules/tinymce/src/core/demo/ts/demo/StickyToolbarDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/StickyToolbarDemo.ts
@@ -31,6 +31,7 @@ export default (): void => {
     content_css: '../../../../js/tinymce/skins/content/default/content.css',
     images_upload_url: 'd',
     selector: 'textarea',
+    license_key: 'gpl',
     // rtl_ui: true,
     link_list: [
       { title: 'My page 1', value: 'http://www.tinymce.com' },

--- a/modules/tinymce/src/core/demo/ts/demo/TinyMceDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/TinyMceDemo.ts
@@ -30,6 +30,7 @@ export default (): void => {
     },
 
     selector: 'textarea.tinymce',
+    license_key: 'gpl',
     toolbar1: 'demoButton bold italic',
     menubar: false
   });

--- a/modules/tinymce/src/core/demo/ts/demo/ViewDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/ViewDemo.ts
@@ -8,6 +8,7 @@ declare let tinymce: TinyMCE;
 export default (): void => {
   const settings: RawEditorOptions = {
     selector: 'textarea',
+    license_key: 'gpl',
     setup: (ed) => {
       let isToggled = false;
       let isToggled2 = false;

--- a/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'div.tinymce',
+  license_key: 'gpl',
   setup: (ed) => {
     ed.on('init', () => {
       const runtimeModel = ed.model;

--- a/modules/tinymce/src/plugins/accordion/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/accordion/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'table lists image accordion code',
   toolbar: 'table | numlist bullist | image | accordion | code',
   menu: { insert: { title: 'Insert', items: 'table | image | accordion' }},

--- a/modules/tinymce/src/plugins/advlist/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/advlist/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'lists advlist code',
   toolbar: 'bullist numlist | outdent indent | code',
   height: 600

--- a/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/anchor/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'anchor code',
   toolbar: 'anchor code',
   height: 600

--- a/modules/tinymce/src/plugins/autolink/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/autolink/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'autolink code',
   toolbar: 'autolink code',
   height: 600

--- a/modules/tinymce/src/plugins/autoresize/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/autoresize/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   theme: 'silver',
   plugins: 'autoresize code',
   toolbar: 'autoresize code',

--- a/modules/tinymce/src/plugins/autosave/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/autosave/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'autosave code',
   toolbar: 'restoredraft code',
   height: 600,

--- a/modules/tinymce/src/plugins/charmap/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/charmap/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'charmap',
   toolbar: 'charmap',
   height: 600,

--- a/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/code/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'code',
   toolbar: 'code',
   height: 600

--- a/modules/tinymce/src/plugins/codesample/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/codesample/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'codesample code',
   toolbar: 'codesample code',
   content_css: '../../../../../js/tinymce/skins/content/default/content.css',
@@ -12,6 +13,7 @@ tinymce.init({
 
 tinymce.init({
   selector: 'div.tinymce',
+  license_key: 'gpl',
   inline: true,
   plugins: 'codesample code',
   toolbar: 'codesample code',

--- a/modules/tinymce/src/plugins/directionality/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/directionality/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'directionality code lists',
   toolbar: 'ltr rtl code | bullist numlist',
   height: 600

--- a/modules/tinymce/src/plugins/emoticons/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/emoticons/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'emoticons code',
   toolbar: 'emoticons code',
   emoticons_database_url: '/src/plugins/emoticons/main/js/emojis.js',

--- a/modules/tinymce/src/plugins/fullscreen/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/fullscreen/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'fullscreen code',
   toolbar: 'fullscreen code',
   height: 600,
@@ -12,6 +13,7 @@ tinymce.init({
 
 tinymce.init({
   selector: 'textarea.tinymce2',
+  license_key: 'gpl',
   plugins: 'fullscreen code',
   toolbar: 'fullscreen code',
   height: 600

--- a/modules/tinymce/src/plugins/help/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/help/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'help link table code emoticons fullscreen advlist anchor',
   toolbar: 'help',
   height: 300,
@@ -11,6 +12,7 @@ tinymce.init({
 });
 
 tinymce.init({
+  license_key: 'gpl',
   selector: 'textarea.tinymce2',
   plugins: 'help link table code emoticons fullscreen advlist anchor',
   toolbar: 'help',
@@ -39,6 +41,7 @@ tinymce.init({
 });
 
 tinymce.init({
+  license_key: 'gpl',
   selector: 'textarea.tinymce3',
   plugins: 'help link table code emoticons fullscreen advlist anchor',
   toolbar: 'help addTab',
@@ -73,6 +76,7 @@ tinymce.init({
 });
 
 tinymce.init({
+  license_key: 'gpl',
   selector: 'textarea.tinymce4',
   plugins: 'help link table code emoticons fullscreen advlist anchor',
   toolbar: 'help addTab',

--- a/modules/tinymce/src/plugins/image/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/image/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'image code',
   toolbar: 'undo redo | image code',
   image_caption: true,

--- a/modules/tinymce/src/plugins/importcss/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/importcss/demo/ts/demo/Demo.ts
@@ -7,6 +7,7 @@ elm.value = 'The format menu should show "red"';
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'importcss code',
   toolbar: 'styles code',
   height: 600,

--- a/modules/tinymce/src/plugins/insertdatetime/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/insertdatetime/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'insertdatetime code',
   toolbar: 'insertdatetime code',
   height: 600,

--- a/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/link/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'link code',
   toolbar: 'link unlink openlink code',
   menubar: 'view insert tools custom',

--- a/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/lists/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'lists code',
   toolbar: 'numlist bullist | outdent indent | code',
   height: 600,

--- a/modules/tinymce/src/plugins/media/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/media/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'media',
   toolbar: 'undo redo | media',
   // media_dimensions: false,

--- a/modules/tinymce/src/plugins/nonbreaking/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/nonbreaking/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   theme: 'silver',
   skin_url: '../../../../../js/tinymce/skins/ui/oxide',
   plugins: 'nonbreaking code',

--- a/modules/tinymce/src/plugins/pagebreak/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/pagebreak/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   theme: 'silver',
   skin_url: '../../../../../js/tinymce/skins/ui/oxide',
   plugins: 'pagebreak code',

--- a/modules/tinymce/src/plugins/preview/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/preview/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   theme: 'silver',
   skin_url: '../../../../../js/tinymce/skins/ui/oxide',
   plugins: 'preview code',

--- a/modules/tinymce/src/plugins/quickbars/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/quickbars/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 const quickbarsClassicConfig: RawEditorOptions = {
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'quickbars link code',
   toolbar: 'quickbars code',
   menubar: 'view insert tools custom',
@@ -22,6 +23,7 @@ const quickbarsClassicConfig: RawEditorOptions = {
 };
 
 const dfreeHeaderConfig: RawEditorOptions = {
+  license_key: 'gpl',
   selector: '.dfree-header',
   plugins: [ 'quickbars' ],
   toolbar: false,
@@ -31,6 +33,7 @@ const dfreeHeaderConfig: RawEditorOptions = {
 };
 
 const dfreeBodyConfig: RawEditorOptions = {
+  license_key: 'gpl',
   selector: '.dfree-body',
   menubar: false,
   inline: true,

--- a/modules/tinymce/src/plugins/save/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/save/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   theme: 'silver',
   skin_url: '../../../../../js/tinymce/skins/ui/oxide',
   plugins: 'save code',

--- a/modules/tinymce/src/plugins/searchreplace/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/searchreplace/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'searchreplace',
   toolbar: 'searchreplace',
   height: 600,

--- a/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'div.tinymce',
+  license_key: 'gpl',
   plugins: 'table',
   toolbar: 'table tableprops tablecellprops tablerowprops | tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter |' +
   ' tableclass tablecellclass | tablecellvalign | tablecellborderwidth tablecellborderstyle | tablecaption | tablecellbackgroundcolor tablecellbordercolor | tablerowheader tablecolheader',

--- a/modules/tinymce/src/plugins/visualblocks/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/visualblocks/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'visualblocks code',
   toolbar: 'visualblocks code',
   content_css: '../../../../../js/tinymce/skins/content/default/content.css',

--- a/modules/tinymce/src/plugins/visualchars/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/visualchars/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'visualchars code',
   toolbar: 'visualchars code',
   visualchars_default_state: true,

--- a/modules/tinymce/src/plugins/wordcount/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/wordcount/demo/ts/demo/Demo.ts
@@ -4,6 +4,7 @@ declare let tinymce: TinyMCE;
 
 tinymce.init({
   selector: 'textarea.tinymce',
+  license_key: 'gpl',
   plugins: 'wordcount code',
   toolbar: 'wordcount',
   height: 600

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
@@ -6,6 +6,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tiny-text',
+    license_key: 'gpl',
     theme: 'silver',
     toolbar: 'styles',
     plugins: [ 'lists', 'autolink', 'autosave', 'insertdatetime' ],
@@ -62,6 +63,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tiny-text2',
+    license_key: 'gpl',
     theme: 'silver',
     toolbar: 'styles',
     block_formats: 'Paragraph=p;Heading 1=h1;Heading 2=h2;Separator Name=|;Heading 3=h3',

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
@@ -14,6 +14,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tiny-text',
+    license_key: 'gpl',
     theme: 'silver',
     // toolbar: [ 'basic-button-1', 'basic-button-2', 'menu-button-1', 'panel-button-1', 'dialog-button', 'MagicButton' ],
     plugins: [

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -11,6 +11,7 @@ export default (): void => {
   tinymce.init({
     // TODO: Investigate. Should this get the styles (e.g. margin) of the div/textarea?
     selector: 'div.tiny-text',
+    license_key: 'gpl',
     inline: false,
     theme: 'silver',
     toolbar: [ 'styles', 'MagicButton', 'code', 'undo', 'redo', 'preview', '|', 'help', 'link', '|', 'align', 'alignleft', 'alignright', 'aligncenter',

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
@@ -30,6 +30,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tiny-text',
+    license_key: 'gpl',
     theme: 'silver',
     toolbar: 'sidebar1 sidebar2 sidebar3',
     plugins: [

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
@@ -32,6 +32,7 @@ export default (): void => {
 
   tinymce.init({
     selector: 'textarea.tiny-text',
+    license_key: 'gpl',
     theme: 'silver',
     toolbar: [ 'disabled-button', 'icon-button', 'icon-button-toggle' ].concat(generatedNames).join(' '),
     plugins: [

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -11,6 +11,7 @@ interface Data {
 export default (): void => {
   tinymce.init({
     selector: 'textarea.tinymce',
+    license_key: 'gpl',
     toolbar: 'tree',
     height: 600,
     setup: (ed) => {


### PR DESCRIPTION
Related Ticket: TINY-12469

Description of Changes:
* Update demos to include `license_key: 'gpl'` so they don't require a commercial license key manager

Pre-checks:
* ~~[ ] Changelog entry added~~
* ~~[ ] Tests have been added (if applicable)~~
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [X] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit license key configuration to all TinyMCE demo editor initializations. This ensures the license key is set for each demo instance without affecting other settings or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->