### PR TITLE
TINY-12245: fix scroll behavior for an edge case

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12245-2025-07-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-12245-2025-07-14.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Now clicking on a non selectable element when there is already a selection doesn't scroll back to top
+time: 2025-07-14T09:15:42.517772534+02:00
+custom:
+    Issue: TINY-12245

--- a/.changes/unreleased/tinymce-TINY-12245-2025-07-14.yaml
+++ b/.changes/unreleased/tinymce-TINY-12245-2025-07-14.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Now clicking on a non selectable element when there is already a selection doesn't scroll back to top
+body: Clicking on a non selectable element when the selection is off screen no longer scrolls to the selection
 time: 2025-07-14T09:15:42.517772534+02:00
 custom:
     Issue: TINY-12245

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -150,7 +150,9 @@ const Quirks = (editor: Editor): Quirks => {
           rng = selection.getRng();
           // TINY-12245: this is needed to avoid the scroll back to the top when the content is scrolled, there is no selection and the user is clicking on a non selectable editor element
           // example content scrolled by browser search and user click on the horizontal scroll bar
-          editor.getBody().focus({ preventScroll: editor.getDoc().getSelection()?.anchorNode === null });
+          if (editor.getDoc().getSelection()?.anchorNode !== null) {
+            editor.getBody().focus();
+          }
 
           if (e.type === 'mousedown') {
             if (CaretContainer.isCaretContainer(rng.startContainer)) {

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -148,7 +148,7 @@ const Quirks = (editor: Editor): Quirks => {
 
         if (e.target === editor.getDoc().documentElement) {
           rng = selection.getRng();
-          editor.getBody().focus();
+          editor.getBody().focus({ preventScroll: editor.getDoc().getSelection()?.anchorNode === null });
 
           if (e.type === 'mousedown') {
             if (CaretContainer.isCaretContainer(rng.startContainer)) {
@@ -260,7 +260,7 @@ const Quirks = (editor: Editor): Quirks => {
     editor.on('mousedown', (e) => {
       Optionals.lift2(Optional.from(e.clientX), Optional.from(e.clientY), (clientX, clientY) => {
         const caretPos = editor.getDoc().caretPositionFromPoint(clientX, clientY);
-        const img = caretPos?.offsetNode.childNodes[caretPos.offset - (caretPos.offset > 0 ? 1 : 0)] || caretPos?.offsetNode;
+        const img = caretPos?.offsetNode?.childNodes[caretPos.offset - (caretPos.offset > 0 ? 1 : 0)] || caretPos?.offsetNode;
 
         if (img && isEditableImage(img)) {
           const rect = img.getBoundingClientRect();

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -148,6 +148,8 @@ const Quirks = (editor: Editor): Quirks => {
 
         if (e.target === editor.getDoc().documentElement) {
           rng = selection.getRng();
+          // TINY-12245: this is needed to avoid the scroll back to the top when the content is scrolled, there is no selection and the user is clicking on a non selectable editor element
+          // example content scrolled by browser search and user click on the horizontal scroll bar
           editor.getBody().focus({ preventScroll: editor.getDoc().getSelection()?.anchorNode === null });
 
           if (e.type === 'mousedown') {

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -1,4 +1,4 @@
-import { Fun, Optional, Optionals } from '@ephox/katamari';
+import { Fun, Optional, Optionals, Type } from '@ephox/katamari';
 import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import Editor from '../api/Editor';
@@ -266,7 +266,7 @@ const Quirks = (editor: Editor): Quirks => {
         const caretPos = editor.getDoc().caretPositionFromPoint(clientX, clientY);
         const img = caretPos?.offsetNode?.childNodes[caretPos.offset - (caretPos.offset > 0 ? 1 : 0)] || caretPos?.offsetNode;
 
-        if (img && isEditableImage(img)) {
+        if (Type.isNonNullable(img) && isEditableImage(img)) {
           const rect = img.getBoundingClientRect();
           e.preventDefault();
 


### PR DESCRIPTION
Related Ticket: TINY-12245

Description of Changes:
- [x] avoid scroll to top when the editor is scrolled via "browser search" and the user clicks on the horizontal scroll bar
- [x] enforce a check on a FirerFox quirk that cause an error in the case described in the row below

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where clicking on a non-selectable element while a selection exists would cause the editor viewport to scroll to the top.
  * Improved handling to prevent unwanted scrolling when focusing the editor body in certain scenarios.
  * Enhanced stability when interacting with image selections to avoid potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->