### PR TITLE
TINY-12340: global CSS Custom Properties

### DIFF
--- a/modules/oxide/src/less/theme/globals/feature-flags.less
+++ b/modules/oxide/src/less/theme/globals/feature-flags.less
@@ -1,2 +1,2 @@
 // Global feature flag for future custom properties skinning, modern CSS functions and native light/dark modes
-@custom-properties-enabled: true;
+@custom-properties-enabled: false;

--- a/modules/oxide/src/less/theme/globals/feature-flags.less
+++ b/modules/oxide/src/less/theme/globals/feature-flags.less
@@ -1,0 +1,2 @@
+// Global feature flag for future custom properties skinning, modern CSS functions and native light/dark modes
+@custom-properties-enabled: true;

--- a/modules/oxide/src/less/theme/globals/global-custom-properties.less
+++ b/modules/oxide/src/less/theme/globals/global-custom-properties.less
@@ -46,7 +46,7 @@
   --tox-private-keyboard-focus-outline-width: 2px;
   --tox-private-keyboard-focus-outline-color: light-dark(
       var(--tox-private-color-tint),
-      var(var(--tox-private-color-white))
+      var(--tox-private-color-white)
     );
 
   // Font

--- a/modules/oxide/src/less/theme/globals/global-custom-properties.less
+++ b/modules/oxide/src/less/theme/globals/global-custom-properties.less
@@ -1,0 +1,87 @@
+.tox when (@custom-properties-enabled = true) {
+  --tox-private-color-scheme: light dark;
+  // Root variables
+  // Begin customization by changing these variables as most other variables are derivatives of these.
+  --tox-private-background-color: light-dark(#fff, #222F3E);
+  --tox-private-base-value: 16px;
+  --tox-private-color-black: #222f3e;
+  --tox-private-color-tint: #006ce7;
+  --tox-private-color-white: #fff;
+  --tox-private-color-error: #c00;
+  --tox-private-color-error-element-focus-color: #f00;
+  --tox-private-color-success: #78AB46;
+  --tox-private-color-warning: #FFCC00;
+  --tox-private-color-active: light-dark(#ffcf30, #006ce7);
+
+  --tox-private-font-stack: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+
+  // Content;
+
+  --tox-private-content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
+
+  // Colors
+  --tox-private-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 6.5));
+  --tox-private-separator-color: light-dark(
+    hsl( from var(--tox-private-border-color) h s calc(l - 4.5)),
+    hsla(0, 0%, 100%, 0.15);
+  );
+
+  // used only in toolbar-split-button -> should not be a global 
+  // --tox-private-border-color-light: light-dark(
+  //     hsl(from var(--tox-private-background-color) h s calc( l - 11)), 
+  //     hsl(from var(--tox-private-background-color) h s calc( l + 11))
+  //   );
+
+  --tox-private-text-color: light-dark(var(--tox-private-color-black), var(--tox-private-color-white));
+  --tox-private-text-color-muted: light-dark(
+      hsl(from var(--tox-private-color-black) h s l / 70%), 
+      hsl(from var(--tox-private-color-white) h s l / 50%)
+    );
+
+  // Some useful generic variables
+  --tox-private-panel-border-radius: 6px; // Dialogs, menues etc.
+  --tox-private-control-border-radius: 6px; // Buttons, input fields etc.
+
+  // Focus outline
+  --tox-private-keyboard-focus-outline-width: 2px;
+  --tox-private-keyboard-focus-outline-color: light-dark(
+      var(--tox-private-color-tint),
+      var(var(--tox-private-color-white))
+    );
+
+  // Font
+  --tox-private-line-height-base: 1.3;
+  --tox-private-font-weight-normal: normal;
+  --tox-private-font-weight-bold: bold;
+  --tox-private-font-size-base: var(--tox-private-base-value);
+  --tox-private-font-size-xs: 12px; // Absolute value to not make it too small
+  --tox-private-font-size-sm: calc(var(--tox-private-font-size-base) * .875);
+  --tox-private-font-size-md: var(--tox-private-font-size-base);
+  --tox-private-font-size-lg: calc(var(--tox-private-font-size-base) * 1.25);
+
+  // Spacings
+  --tox-private-pad-xs: calc(var(--tox-private-base-value) / 4);
+  --tox-private-pad-sm: calc(var(--tox-private-base-value) / 2);
+  --tox-private-pad-md: var(--tox-private-base-value);
+  --tox-private-pad-lg: calc(var(--tox-private-base-value) * 1.5);
+  --tox-private-pad-xl: calc(var(--tox-private-base-value) * 2);
+
+  // z-index stack (reserved range 1000-10000)
+  --tox-private-z-index-fullscreen: 1200;
+  --tox-private-z-index-resize-handle: 1298;
+  --tox-private-z-index-throbber: 1299;
+  --tox-private-z-index-sink: 1300;
+
+  // sink z-index stack
+  // Note: these are rendered inside the sink so aren't affected by the other global z-index variables
+  --tox-private-z-index-loading: 1000;
+  --tox-private-z-index-dialogs: 1100;
+  --tox-private-z-index-menu: 1150;
+
+  // Responsive breakpoints -> do we need them as a global variables?
+  --tox-private-breakpoint-sm-value: 767px;
+  --tox-private-breakpoint-md: ~"only screen and (min-width:1000px)";
+  --tox-private-breakpoint-sm: ~"only screen and (max-width: var(--tox-private-breakpoint-sm-value))";
+  --tox-private-breakpoint-gt-sm: ~"only screen and (min-width: calc(var(--tox-private-breakpoint-sm-value) + 1px))";
+
+}

--- a/modules/oxide/src/less/theme/globals/reset.less
+++ b/modules/oxide/src/less/theme/globals/reset.less
@@ -5,10 +5,7 @@
 .tox {
   box-shadow: none;
   box-sizing: content-box;
-  color: @color-black;
   cursor: auto;
-  font-family: @font-stack;
-  font-size: @font-size-base;
   font-style: normal;
   font-weight: normal;
   line-height: normal;
@@ -63,4 +60,15 @@
 .tox[dir=rtl] {
   direction: rtl;
   text-align: right;
+}
+
+// Reset focus states
+.tox-tinymce *:focus,
+.tox-tinymce-aux *:focus {
+  outline: none;
+}
+
+// Reset firefox focus states
+button::-moz-focus-inner {
+  border: 0;
 }

--- a/modules/oxide/src/less/theme/globals/tinymce.less
+++ b/modules/oxide/src/less/theme/globals/tinymce.less
@@ -2,12 +2,22 @@
 // Global styling
 //
 
+// To be decided if we want CSS Custom Properties out of these.
 @tinymce-border-color: @border-color;
 @tinymce-border-radius: 10px;
 @tinymce-border-width: 2px;
 @tinymce-box-shadow: none;
-@tinymce-separator-color: darken(@border-color, 4.5%);
-@editor-header-inline-background-color: @background-color;
+
+@tinymce-separator-color: darken(@border-color, 4.5%); // created global Custom Property as this is used in multiple different components
+
+@editor-header-inline-background-color: @background-color; 
+
+
+.tox {
+  color: var(--tox-private-color-black, @color-black);
+  font-family: var(--tox-private-font-stack, @font-stack);
+  font-size: var(--tox-private-font-size-base, @font-size-base);
+}
 
 .tox-tinymce {
   border: @tinymce-border-width solid @tinymce-border-color;
@@ -16,7 +26,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  font-family: @font-stack;
+  font-family: var(--tox-private-font-stack, @font-stack);
   overflow: hidden;
   position: relative;
   visibility: inherit !important;
@@ -42,14 +52,8 @@
 }
 
 .tox-tinymce-aux {
-  font-family: @font-stack;
-  z-index: @z-index-sink;
-}
-
-// Reset focus states
-.tox-tinymce *:focus,
-.tox-tinymce-aux *:focus {
-  outline: none;
+  font-family: var(--tox-private-font-stack, @font-stack);
+  z-index: var(--tox-private-z-index-sink, @z-index-sink);
 }
 
 .keyboard-focus-outline-mixin(@_inset: ~'') {
@@ -65,11 +69,6 @@
   @media (forced-colors: active) {
     border: 2px solid highlight;
   }
-}
-
-// Reset firefox focus states
-button::-moz-focus-inner {
-  border: 0;
 }
 
 // RTL

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -1,12 +1,17 @@
 //
 // Oxide Theme
 //
+@import 'globals/feature-flags';
+
+@import 'globals/reset';
 
 @import 'globals/utils';
-@import 'globals/reset';
 @import 'globals/global-variables';
-@import 'globals/global';
+@import 'globals/global-custom-properties';
 @import 'globals/animations';
+
+@import 'globals/tinymce';
+@import 'components/editor/editor';
 
 @import 'components/accessibility-checker/accessibility-checker';
 @import 'components/advcode/advcode.less';
@@ -32,7 +37,6 @@
 @import 'components/dropzone/dropzone';
 @import 'components/edit-area/edit-area';
 @import 'components/edit-area/inline-edit-area';
-@import 'components/editor/editor';
 @import 'components/form/control-wrap';
 @import 'components/form/custom-preview';
 @import 'components/form/autocomplete';


### PR DESCRIPTION
Related Ticket: TINY-12340

Description of Changes:
* Added feature flag for enabling CSS custom properties
* Created global custom properties for theming
* Reorganized global styling files for better structure
* Moved reset focus states to reset.less
* Updated variable references to use custom properties with fallbacks

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a global feature flag to enable advanced theming capabilities.
  * Added a comprehensive set of CSS custom properties for dynamic theming, including support for light and dark modes, color schemes, font settings, spacing, and responsive breakpoints.

* **Style**
  * Updated styles to use CSS custom properties for font, color, and z-index, allowing for easier customization and theme changes.
  * Adjusted and centralized theming variables for improved consistency across the UI.
  * Improved focus outline and border reset styles for better accessibility and browser consistency.

* **Refactor**
  * Reorganized import order in theme files for better structure and maintainability.
  * Removed redundant style declarations and streamlined focus reset rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->