### PR TITLE
TINY-12507: introduce reset layer

### DIFF
--- a/modules/oxide/src/less/theme/globals/reset.less
+++ b/modules/oxide/src/less/theme/globals/reset.less
@@ -2,73 +2,75 @@
 // Resets
 //
 
-.tox {
-  box-shadow: none;
-  box-sizing: content-box;
-  cursor: auto;
-  font-style: normal;
-  font-weight: normal;
-  line-height: normal;
-  -webkit-tap-highlight-color: transparent;
-  text-decoration: none;
-  text-shadow: none;
-  text-transform: none;
-  vertical-align: initial;
-  white-space: normal;
-
-  *:not(svg):not(rect) {
-    // inherit everything in the tox selector, so components have a chance to override it
-    box-sizing: inherit;
-    color: inherit;
-    cursor: inherit;
-    direction: inherit;
-    font-family: inherit;
-    font-size: inherit;
-    font-style: inherit;
-    font-weight: inherit;
-    line-height: inherit;
-    -webkit-tap-highlight-color: inherit;
-    text-align: inherit;
-    text-decoration: inherit;
-    text-shadow: inherit;
-    text-transform: inherit;
-    vertical-align: inherit;
-    white-space: inherit;
-  }
-
-  *:not(svg):not(rect) { /* stylelint-disable-line no-duplicate-selectors */
-    // remaining specific reset styles for properties that shouldn't be inherited
-    background: transparent;
-    border: 0;
+@layer reset {
+  .tox {
     box-shadow: none;
-    float: none;
-    height: auto;
-    margin: 0;
-    max-width: none;
-    outline: 0;
-    padding: 0;
-    position: static;
-    width: auto;
+    box-sizing: content-box;
+    cursor: auto;
+    font-style: normal;
+    font-weight: normal;
+    line-height: normal;
+    -webkit-tap-highlight-color: transparent;
+    text-decoration: none;
+    text-shadow: none;
+    text-transform: none;
+    vertical-align: initial;
+    white-space: normal;
+    
+    *:not(svg):not(rect) {
+      // inherit everything in the tox selector, so components have a chance to override it
+      box-sizing: inherit;
+      color: inherit;
+      cursor: inherit;
+      direction: inherit;
+      font-family: inherit;
+      font-size: inherit;
+      font-style: inherit;
+      font-weight: inherit;
+      line-height: inherit;
+      -webkit-tap-highlight-color: inherit;
+      text-align: inherit;
+      text-decoration: inherit;
+      text-shadow: inherit;
+      text-transform: inherit;
+      vertical-align: inherit;
+      white-space: inherit;
+    }
+    
+    *:not(svg):not(rect) { /* stylelint-disable-line no-duplicate-selectors */
+      // remaining specific reset styles for properties that shouldn't be inherited
+      background: transparent;
+      border: 0;
+      box-shadow: none;
+      float: none;
+      height: auto;
+      margin: 0;
+      max-width: none;
+      outline: 0;
+      padding: 0;
+      position: static;
+      width: auto;
+    }
   }
-}
-
-.tox:not([dir=rtl]) {
-  direction: ltr;
-  text-align: left;
-}
-
-.tox[dir=rtl] {
-  direction: rtl;
-  text-align: right;
-}
-
-// Reset focus states
-.tox-tinymce *:focus,
-.tox-tinymce-aux *:focus {
-  outline: none;
-}
-
-// Reset firefox focus states
-button::-moz-focus-inner {
-  border: 0;
+  
+  .tox:not([dir=rtl]) {
+    direction: ltr;
+    text-align: left;
+  }
+  
+  .tox[dir=rtl] {
+    direction: rtl;
+    text-align: right;
+  }
+  
+  // Reset focus states
+  .tox-tinymce *:focus,
+  .tox-tinymce-aux *:focus {
+    outline: none;
+  }
+  
+  // Reset firefox focus states
+  button::-moz-focus-inner {
+    border: 0;
+  } 
 }

--- a/modules/oxide/src/less/theme/globals/reset.less
+++ b/modules/oxide/src/less/theme/globals/reset.less
@@ -2,7 +2,7 @@
 // Resets
 //
 
-@layer reset {
+@layer tox-reset {
   .tox {
     box-shadow: none;
     box-sizing: content-box;


### PR DESCRIPTION
Related Ticket: TINY-12507

Description of Changes:
Added CSS layer to the reset styles by wrapping all reset styles in `@layer reset {}`. This will guarantee that the reset is applied before all of the other, unlayered styles and will not fight for specificity with them. 

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced CSS structure by grouping `.tox` reset styles into a dedicated layer for better style management without affecting the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->