### PR TITLE
TINY-12289: Add a z-index to views, moving them above sink elements

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12289-2025-07-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-12289-2025-07-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: 'Tooltips no longer show above editor views'
+time: 2025-07-15T10:29:27.169269+10:00
+custom:
+    Issue: TINY-12289

--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -47,7 +47,6 @@
     display: flex;
     flex: 1;
     height: 100%;
-    margin-top: 8px;
     overflow-x: auto;
     overflow-y: hidden;
     position: relative;

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -28,6 +28,10 @@
 @suggestededits-card-resolved-background-color: @suggestededits-dark-transparent-color;
 @suggestededits-card-selected-border-color: @suggestededits-color-tint;
 
+// this file is imported above `view.less`, but we need a variable from it
+// TODO: replace `.tox-suggestededits__toolbar` with `.tox-view__toolbar`
+@view-header-padding: (@pad-sm + @keyboard-focus-outline-width);
+
 .tox {
   [data-mce-name="suggestededits"] .tox-icon .tox-icon--badge {
     fill: @color-tint;
@@ -62,7 +66,7 @@
       gap: 8px;
       justify-content: space-between;
       overflow-x: auto;
-      padding: 10px 10px 2px 10px;
+      padding: @view-header-padding;
       width: 100%;
 
       .tox-suggestededits__toolbar--start {
@@ -98,7 +102,6 @@
       display: flex;
       flex: 1;
       height: inherit;
-      margin-top: 8px;
       overflow-x: auto;
       overflow-y: hidden;
       position: relative;

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -29,7 +29,7 @@
 @suggestededits-card-selected-border-color: @suggestededits-color-tint;
 
 // this file is imported above `view.less`, but we need a variable from it
-// TODO: replace `.tox-suggestededits__toolbar` with `.tox-view__toolbar`
+// TODO TINY-12535: replace `.tox-suggestededits__toolbar` with `.tox-view__toolbar`
 @view-header-padding: (@pad-sm + @keyboard-focus-outline-width);
 
 .tox {

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,4 @@
-@view-header-padding: (@pad-sm + @keyboard-focus-outline-width) (@pad-sm + @keyboard-focus-outline-width) @keyboard-focus-outline-width (@pad-sm + @keyboard-focus-outline-width);    // Account for outline/border of the buttons
+@view-header-padding: (@pad-sm + @keyboard-focus-outline-width);
 @view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -21,6 +21,7 @@
     flex-direction: column;
     overflow: hidden;
     z-index: @z-index-view;
+    background-color: @background-color;
   }
 
   .tox-view__header {

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -1,4 +1,4 @@
-@view-header-padding: (@pad-sm + @keyboard-focus-outline-width);
+@view-header-padding: (@pad-sm + @keyboard-focus-outline-width);    // Account for outline/border of the buttons
 @view-header-padding-mobile: @pad-sm;
 @view-pane-padding: @pad-sm;
 

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -20,6 +20,7 @@
     flex: 1 1 auto;
     flex-direction: column;
     overflow: hidden;
+    z-index: @z-index-view;
   }
 
   .tox-view__header {

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -65,6 +65,9 @@
 @z-index-throbber: 1299;
 @z-index-sink: 1300;
 
+// views are rendered inside the editor, not in the sink, so they need to be higher to show above tooltips and menus
+@z-index-view: 1301;
+
 // sink z-index stack
 // Note: these are rendered inside the sink so aren't affected by the other global z-index variables
 @z-index-loading: 1000;


### PR DESCRIPTION
Related Ticket: TINY-12289

Description of Changes:
* Added `z-index` to work around issues where tooltips show on top of a view. The proper fix, to make them hide correctly, will come later.
* Swapped from `margin-top` on view content to `padding-bottom` on the view toolbar (which just means using a single `padding` value)
* Applied those changes to suggested edits manually, since it doesn't leverage the tox view classes

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
