### PR TITLE
TINY-12522: Show onboarding overlay over sink popups

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12522-2025-07-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-12522-2025-07-16.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: '`onboarding` plugin overlay now shows above popups.'
+time: 2025-07-16T10:04:27.570324+10:00
+custom:
+    Issue: TINY-12522

--- a/modules/oxide/src/less/theme/components/onboarding/onboarding.less
+++ b/modules/oxide/src/less/theme/components/onboarding/onboarding.less
@@ -10,7 +10,7 @@
 @onboarding-icon-size: 24px;
 
 @onboarding-promotion-icon-container-size: 56px;
-@onboarding-promotion-icon-size-border-radius: 12px; 
+@onboarding-promotion-icon-size-border-radius: 12px;
 
 @onboarding-promotion-icon-background: linear-gradient(180deg, @dialog-background-color 24%, darken(@dialog-background-color, 6%) 100%);
 
@@ -28,7 +28,7 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: 1;
+    z-index: @z-index-onboarding-overlay;
     overflow: auto;
     display: grid;
     justify-content: center;
@@ -143,7 +143,7 @@
 					font-weight: bold;
 					margin-bottom: @pad-xs;
 				}
-				
+
 				.tox-promotion-dialog-plugin-details {
 					color: @text-color-muted;
 					font-size: @font-size-sm;

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -65,14 +65,16 @@
 @z-index-throbber: 1299;
 @z-index-sink: 1300;
 
-// views are rendered inside the editor, not in the sink, so they need to be higher to show above tooltips and menus
+// views and onboarding overlay are rendered inside the editor, not in the sink, so they need to be higher to show above popups e.g. notifications, tooltips and menus
 @z-index-view: 1301;
+@z-index-onboarding-overlay: 1302;
 
 // sink z-index stack
 // Note: these are rendered inside the sink so aren't affected by the other global z-index variables
 @z-index-loading: 1000;
 @z-index-dialogs: 1100;
 @z-index-menu: 1150;
+
 
 // Responsive breakpoints
 @breakpoint-sm-value: 767px;


### PR DESCRIPTION
Related Ticket: TINY-12522

Description of Changes:
* Added a new z-index variable `@z-index-onboarding-overlay` with value 1302
* Updated the onboarding overlay to use this variable instead of a hardcoded z-index value

Pre-checks:
* [x] Changelog entry added
* [X] Tests have been added (if applicable)
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* ~~[ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):