### PR TITLE
TINY-12536: Loader catches and reports errors from `tinymce.init`

### DIFF
--- a/.changes/unreleased/mcagar-TINY-12536-2025-07-16.yaml
+++ b/.changes/unreleased/mcagar-TINY-12536-2025-07-16.yaml
@@ -1,0 +1,6 @@
+project: mcagar
+kind: Fixed
+body: Loader will catch errors thrown by `tinymce.init` and report them to the caller.
+time: 2025-07-16T14:36:55.407731349+10:00
+custom:
+    Issue: TINY-12536

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -1,5 +1,5 @@
 import { TestLogs } from '@ephox/agar';
-import { Arr, Fun, FutureResult, Global, Id, Optional, Result } from '@ephox/katamari';
+import { Arr, Fun, FutureResult, Global, Id, Optional, Result, Type } from '@ephox/katamari';
 import { Attribute, DomEvent, Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarHead, SugarShadowDom } from '@ephox/sugar';
 
 import { Editor } from '../alien/EditorTypes';
@@ -74,7 +74,8 @@ const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: 
   };
 
   // Agar v. ??? supports logging
-  const onFailure = (err: Error | string, logs?: TestLogs) => {
+  const onFailure = (errU: unknown, logs?: TestLogs) => {
+    const err = Type.isString(errU) || errU instanceof Error ? errU : String(errU);
     // eslint-disable-next-line no-console
     console.log('Tiny Loader error: ', err);
     // Do no teardown so that the failed test still shows the editor. Important for selection
@@ -88,31 +89,34 @@ const setup = (callbacks: Callbacks, settings: Record<string, any>, elementOpt: 
     callbacks.preInit(tinymce, settings);
 
     const targetSettings = SugarShadowDom.isInShadowRoot(target) ? ({ target: target.dom }) : ({ selector: '#' + randomId });
+    try {
+      Promise.resolve(tinymce.init({
+        promotion: false,
+        license_key: 'gpl',
+        ...settings,
+        ...targetSettings,
+        setup: (editor: Editor) => {
+          // Execute the setup called by the test.
+          settingsSetup(editor);
 
-    tinymce.init({
-      promotion: false,
-      license_key: 'gpl',
-      ...settings,
-      ...targetSettings,
-      setup: (editor: Editor) => {
-        // Execute the setup called by the test.
-        settingsSetup(editor);
+          editor.once('SkinLoaded', () => {
+            setTimeout(() => {
+              try {
+                callbacks.run(editor, onSuccess, onFailure);
+              } catch (e: any) {
+                onFailure(e);
+              }
+            }, 100);
+          });
 
-        editor.once('SkinLoaded', () => {
-          setTimeout(() => {
-            try {
-              callbacks.run(editor, onSuccess, onFailure);
-            } catch (e: any) {
-              onFailure(e);
-            }
-          }, 100);
-        });
-
-        editor.once('SkinLoadError', (e) => {
-          callbacks.failure(e.message);
-        });
-      }
-    });
+          editor.once('SkinLoadError', (e) => {
+            callbacks.failure(e.message);
+          });
+        }
+      })).catch(onFailure);
+    } catch (err: unknown) {
+      onFailure(err);
+    }
   };
 
   if (!Global.tinymce) {


### PR DESCRIPTION
Related Ticket: [TINY-12536](https://ephocks.atlassian.net/browse/TINY-12536), [TCLOUD-4737](https://ephocks.atlassian.net/browse/TCLOUD-4737)

Description of Changes:
* Previously mcagar’s Loader did not report errors thrown while running `tinymce.init` which means that any tests waiting for that TinyMCE instance have to timeout to fail. This was a problem for informant recently as in those tests TinyMCE is created in a before hook. As the error was not reported to informant, the before hook would timeout and skip the tests instead of failing them. This change instead attempts to catch errors thrown from `tinymce.init` and any rejected promises returned by it.

Pre-checks:
* [X] Changelog entry added
* [X] Tests have been added (if applicable) - I don't believe it is applicable here as it is a test component
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [X] Docs ticket created (if applicable) - not applicable

GitHub issues (if applicable):


[TINY-12536]: https://ephocks.atlassian.net/browse/TINY-12536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TCLOUD-4737]: https://ephocks.atlassian.net/browse/TCLOUD-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during TinyMCE initialization, ensuring that any errors (both synchronous and asynchronous) are now properly captured and reported back to the caller. This enhances reliability and provides clearer feedback when initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->