### PR TITLE
TINY-12531: convert checkbox to transitional state

### DIFF
--- a/modules/oxide/src/less/theme/alien/unknowns.less
+++ b/modules/oxide/src/less/theme/alien/unknowns.less
@@ -9,7 +9,6 @@
 
 @input-button-focus-border-color: @button-background-color;
 @select-focus-border-color: @button-background-color;
-@checkbox-unfocused-box-shadow: 0 0 0 2px transparent;
 
 .tox {
 

--- a/modules/oxide/src/less/theme/components/checkbox/checkbox.less
+++ b/modules/oxide/src/less/theme/components/checkbox/checkbox.less
@@ -37,8 +37,8 @@
     /* Hide from view but visible to screen readers */
     position: absolute;
     opacity: 0;
-    width: 0;
-    height: 0;
+    width: 1px;
+    height: 1px;
   }
   
   .tox-checkbox__icons {

--- a/modules/oxide/src/less/theme/components/checkbox/checkbox.less
+++ b/modules/oxide/src/less/theme/components/checkbox/checkbox.less
@@ -2,6 +2,19 @@
 // Checkbox
 //
 
+.tox-checkbox when (@custom-properties-enabled = true) {
+  --tox-private-checkbox-unselected-color: light-dark(
+    hsl(from var(--tox-private-color-black) h s l / 30%),
+    hsl(from var(--tox-private-color-white) h s l / 20%)
+  );
+  --tox-private-checkbox-selected-color: var(--tox-private-color-tint);
+  --tox-private-checkbox-indeterminate-color: var(--tox-private-checkbox-selected-color);
+
+  --tox-private-checkbox-border-radius: var(--tox-private-control-border-radius);
+  --tox-private-checkbox-focus-box-shadow: inset 0 0 0 1px var(--tox-private-keyboard-focus-outline-color);
+  --tox-private-checkbox-disabled-text-color: var(--tox-private-text-color-muted);
+}
+
 @checkbox-unselected-color: contrast(@background-color, fade(@color-black, 30%), fade(@color-white, 20%));
 @checkbox-selected-color: @color-tint;
 @checkbox-indeterminate-color: @checkbox-selected-color;
@@ -9,120 +22,110 @@
 @checkbox-disabled-text-color: fade(@text-color, 50%);
 
 @checkbox-focus-box-shadow: inset 0 0 0 1px @button-background-color;
+@checkbox-unfocused-box-shadow: none;
 @checkbox-focus-border-radius: @control-border-radius;
 
-.tox {
-  .tox-checkbox {
-    align-items: center;
-    border-radius: @control-border-radius;
-    cursor: pointer;
-    display: flex;
-    height: 36px;
-    min-width: 36px;
-  }
-
+.tox-checkbox {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  height: var(--tox-private-control-height, 36px);
+  min-width: var(--tox-private-control-height, 36px);
+  border-radius: var(--tox-private-checkbox-border-radius, @control-border-radius);
+  
   .tox-checkbox__input {
     /* Hide from view but visible to screen readers */
-    height: 1px;
-    overflow: hidden;
     position: absolute;
-    top: auto;
-    width: 1px;
+    opacity: 0;
+    width: 0;
+    height: 0;
   }
-
+  
   .tox-checkbox__icons {
-    align-items: center;
-    border-radius: @checkbox-focus-border-radius;
-    box-shadow: @checkbox-unfocused-box-shadow;
-    box-sizing: content-box;
     display: flex;
-    height: @textfield-line-height;
+    align-items: center;
     justify-content: center;
-    padding: calc(@button-padding-y - @button-border-width);
-    width: @textfield-line-height;
-
+    box-sizing: content-box;
+    padding: var(--tox-private-pad-xs, calc(@button-padding-y - @button-border-width));
+    
+    border-radius: var(--tox-private-checkbox-border-radius, @checkbox-focus-border-radius);
+    box-shadow: @checkbox-unfocused-box-shadow;
+    
+    height: var(--tox-private-control-line-height, @textfield-line-height);
+    aspect-ratio: 1 / 1;
+    
     .tox-checkbox-icon__unchecked svg {
       display: block;
-      fill: @checkbox-unselected-color;
-
+      fill: var(--tox-private-checkbox-unselected-color, @checkbox-unselected-color);
+      
       @media (forced-colors: active) {
         fill: currentColor !important;
       }
     }
-
+    
     .tox-checkbox-icon__indeterminate svg {
       display: none;
-      fill: @checkbox-indeterminate-color;
+      fill: var(--tox-private-checkbox-indeterminate-color, @checkbox-indeterminate-color);
     }
-
+    
     .tox-checkbox-icon__checked svg {
       display: none;
-      fill: @checkbox-selected-color;
+      fill: var(--tox-private-checkbox-selected-color, @checkbox-selected-color);
     }
   }
+}
 
-  .tox-checkbox__icon {
-    //
+.tox-checkbox--disabled {
+  color: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
+  cursor: not-allowed;
+}
+
+.tox-checkbox--disabled .tox-checkbox__icons {
+  .tox-checkbox-icon__checked svg {
+    fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
   }
 
-  .tox-checkbox--disabled {
-    color: @checkbox-disabled-text-color;
-    cursor: not-allowed;
+  .tox-checkbox-icon__unchecked svg {
+    fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
+  }
+  
+  .tox-checkbox-icon__indeterminate svg {
+    fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
+  }
+}
+
+input.tox-checkbox__input:checked + .tox-checkbox__icons {
+  .tox-checkbox-icon__unchecked svg {
+    display: none;
   }
 
-  .tox-checkbox--disabled .tox-checkbox__icons {
-    .tox-checkbox-icon__checked svg {
-      fill: @checkbox-disabled-text-color;
-    }
+  .tox-checkbox-icon__checked svg {
+    display: block;
+  }
+}
 
-    .tox-checkbox-icon__unchecked svg {
-      fill: @checkbox-disabled-text-color;
-    }
-
-    .tox-checkbox-icon__indeterminate svg {
-      fill: @checkbox-disabled-text-color;
-    }
+input.tox-checkbox__input:indeterminate + .tox-checkbox__icons {
+  .tox-checkbox-icon__unchecked svg {
+    display: none;
   }
 
-  input.tox-checkbox__input:checked + .tox-checkbox__icons {
-    .tox-checkbox-icon__unchecked svg {
-      display: none;
-    }
-
-    .tox-checkbox-icon__checked svg {
-      display: block;
-    }
+  .tox-checkbox-icon__indeterminate svg {
+    display: block;
   }
+}
 
-  input.tox-checkbox__input:indeterminate + .tox-checkbox__icons {
-    .tox-checkbox-icon__unchecked svg {
-      display: none;
-    }
-
-    .tox-checkbox-icon__indeterminate svg {
-      display: block;
-    }
-  }
-
-  input.tox-checkbox__input:focus + .tox-checkbox__icons {
-    border-radius: @checkbox-focus-border-radius;
-    box-shadow: @checkbox-focus-box-shadow;
-    padding: calc(@button-padding-y - @button-border-width);
-  }
+.tox-checkbox__input:focus + .tox-checkbox__icons {
+  box-shadow: var(--tox-private-checkbox-focus-box-shadow, @checkbox-focus-box-shadow);
 }
 
 .tox:not([dir=rtl]) {
   .tox-checkbox__label {
-    margin-left: @pad-xs;
-  }
-
-  .tox-checkbox__input {
-    left: -10000px;
+    margin-left: var(--tox-private-pad-xs, @pad-xs);
   }
 
   .tox-bar {
     .tox-checkbox {
-      margin-left: @pad-xs;
+      margin-left: var(--tox-private-pad-xs, @pad-xs);
     }
   }
 }
@@ -130,16 +133,12 @@
 // RTL
 .tox[dir=rtl] {
   .tox-checkbox__label {
-    margin-right: @pad-xs;
-  }
-
-  .tox-checkbox__input {
-    right: -10000px;
+    margin-right: var(--tox-private-pad-xs, @pad-xs);
   }
 
   .tox-bar {
     .tox-checkbox {
-      margin-right: @pad-xs;
+      margin-right: var(--tox-private-pad-xs, @pad-xs);
     }
   }
 }

--- a/modules/oxide/src/less/theme/components/checkbox/checkbox.less
+++ b/modules/oxide/src/less/theme/components/checkbox/checkbox.less
@@ -25,97 +25,100 @@
 @checkbox-unfocused-box-shadow: none;
 @checkbox-focus-border-radius: @control-border-radius;
 
-.tox-checkbox {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  height: var(--tox-private-control-height, 36px);
-  min-width: var(--tox-private-control-height, 36px);
-  border-radius: var(--tox-private-checkbox-border-radius, @control-border-radius);
-  
-  .tox-checkbox__input {
-    /* Hide from view but visible to screen readers */
-    position: absolute;
-    opacity: 0;
-    width: 1px;
-    height: 1px;
-  }
-  
-  .tox-checkbox__icons {
+.tox {
+  .tox-checkbox {
+    position: relative;  
     display: flex;
     align-items: center;
-    justify-content: center;
-    box-sizing: content-box;
-    padding: var(--tox-private-pad-xs, calc(@button-padding-y - @button-border-width));
+    cursor: pointer;
+    height: var(--tox-private-control-height, 36px);
+    min-width: var(--tox-private-control-height, 36px);
+    border-radius: var(--tox-private-checkbox-border-radius, @control-border-radius);
     
-    border-radius: var(--tox-private-checkbox-border-radius, @checkbox-focus-border-radius);
-    box-shadow: @checkbox-unfocused-box-shadow;
+    .tox-checkbox__input {
+      /* Hide from view but visible to screen readers */
+      position: absolute;
+      opacity: 0;
+      width: 1px;
+      height: 1px;
+    }
     
-    height: var(--tox-private-control-line-height, @textfield-line-height);
-    aspect-ratio: 1 / 1;
-    
-    .tox-checkbox-icon__unchecked svg {
-      display: block;
-      fill: var(--tox-private-checkbox-unselected-color, @checkbox-unselected-color);
+    .tox-checkbox__icons {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: content-box;
+      padding: var(--tox-private-pad-xs, calc(@button-padding-y - @button-border-width));
       
-      @media (forced-colors: active) {
-        fill: currentColor !important;
+      border-radius: var(--tox-private-checkbox-border-radius, @checkbox-focus-border-radius);
+      box-shadow: @checkbox-unfocused-box-shadow;
+      
+      height: var(--tox-private-control-line-height, @textfield-line-height);
+      aspect-ratio: 1 / 1;
+      
+      .tox-checkbox-icon__unchecked svg {
+        display: block;
+        fill: var(--tox-private-checkbox-unselected-color, @checkbox-unselected-color);
+        
+        @media (forced-colors: active) {
+          fill: currentColor !important;
+        }
       }
+      
+      .tox-checkbox-icon__indeterminate svg {
+        display: none;
+        fill: var(--tox-private-checkbox-indeterminate-color, @checkbox-indeterminate-color);
+      }
+      
+      .tox-checkbox-icon__checked svg {
+        display: none;
+        fill: var(--tox-private-checkbox-selected-color, @checkbox-selected-color);
+      }
+    }
+  }
+  
+  .tox-checkbox--disabled {
+    color: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
+    cursor: not-allowed;
+  }
+  
+  .tox-checkbox--disabled .tox-checkbox__icons {
+    .tox-checkbox-icon__checked svg {
+      fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
+    }
+  
+    .tox-checkbox-icon__unchecked svg {
+      fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
     }
     
     .tox-checkbox-icon__indeterminate svg {
-      display: none;
-      fill: var(--tox-private-checkbox-indeterminate-color, @checkbox-indeterminate-color);
+      fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
     }
-    
-    .tox-checkbox-icon__checked svg {
-      display: none;
-      fill: var(--tox-private-checkbox-selected-color, @checkbox-selected-color);
-    }
-  }
-}
-
-.tox-checkbox--disabled {
-  color: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
-  cursor: not-allowed;
-}
-
-.tox-checkbox--disabled .tox-checkbox__icons {
-  .tox-checkbox-icon__checked svg {
-    fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
-  }
-
-  .tox-checkbox-icon__unchecked svg {
-    fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
   }
   
-  .tox-checkbox-icon__indeterminate svg {
-    fill: var(--tox-private-checkbox-disabled-text-color, @checkbox-disabled-text-color);
+  input.tox-checkbox__input:checked + .tox-checkbox__icons {
+    .tox-checkbox-icon__unchecked svg {
+      display: none;
+    }
+  
+    .tox-checkbox-icon__checked svg {
+      display: block;
+    }
   }
-}
-
-input.tox-checkbox__input:checked + .tox-checkbox__icons {
-  .tox-checkbox-icon__unchecked svg {
-    display: none;
+  
+  input.tox-checkbox__input:indeterminate + .tox-checkbox__icons {
+    .tox-checkbox-icon__unchecked svg {
+      display: none;
+    }
+  
+    .tox-checkbox-icon__indeterminate svg {
+      display: block;
+    }
   }
-
-  .tox-checkbox-icon__checked svg {
-    display: block;
+  
+  .tox-checkbox__input:focus + .tox-checkbox__icons {
+    box-shadow: var(--tox-private-checkbox-focus-box-shadow, @checkbox-focus-box-shadow);
   }
-}
-
-input.tox-checkbox__input:indeterminate + .tox-checkbox__icons {
-  .tox-checkbox-icon__unchecked svg {
-    display: none;
-  }
-
-  .tox-checkbox-icon__indeterminate svg {
-    display: block;
-  }
-}
-
-.tox-checkbox__input:focus + .tox-checkbox__icons {
-  box-shadow: var(--tox-private-checkbox-focus-box-shadow, @checkbox-focus-box-shadow);
 }
 
 .tox:not([dir=rtl]) {

--- a/modules/oxide/src/less/theme/globals/global-custom-properties.less
+++ b/modules/oxide/src/less/theme/globals/global-custom-properties.less
@@ -41,6 +41,7 @@
   // Some useful generic variables
   --tox-private-panel-border-radius: 6px; // Dialogs, menues etc.
   --tox-private-control-border-radius: 6px; // Buttons, input fields etc.
+  --tox-private-control-height: 36px; // In many places there is fixed value or a referance to @textfield-height. That's why the global var is introduced. For inputs, checkbox etc.
 
   // Focus outline
   --tox-private-keyboard-focus-outline-width: 2px;


### PR DESCRIPTION
Related Ticket: TINY-12531

Description of Changes:
* Added CSS custom properties for the checkbox component when custom properties are enabled
* Updated checkbox styling to use custom properties with fallbacks to existing LESS variables
* Updated hidden input implementation
* Added a new global custom property `--tox-private-control-height` for consistent sizing

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new CSS custom properties for checkboxes, allowing for improved theming and customization.
  * Added a global custom property for control height to standardize sizing across components.

* **Style**
  * Updated checkbox styles to use CSS variables instead of hardcoded values or LESS variables.
  * Improved consistency and maintainability of checkbox appearance, including better support for different states and theming options.
  * Removed an unused checkbox box-shadow variable to simplify styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->