### PR TITLE
TINY-11296: set iframe aria text on iframe element or body

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11296-2025-07-23.yaml
+++ b/.changes/unreleased/tinymce-TINY-11296-2025-07-23.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: NVDA would announce iframe_aria_text multiple times.
+time: 2025-07-23T14:03:45.80369+02:00
+custom:
+  Issue: TINY-11296

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -28,7 +28,7 @@ const createIframeElement = (id: string, title: TranslatedString, customAttrs: {
     id: id + '_ifr',
     frameBorder: '0',
     allowTransparency: 'true',
-    title
+    ...Env.browser.isFirefox() ? { title } : {}
   });
 
   Class.add(iframe, 'tox-edit-area__iframe');
@@ -50,13 +50,14 @@ const getIframeHtml = (editor: Editor) => {
   const bodyId = Options.getBodyId(editor);
   const bodyClass = Options.getBodyClass(editor);
   const translatedAriaText = editor.translate(Options.getIframeAriaText(editor));
+  const iframeBodyAriaLabel = Env.browser.isFirefox() ? '' : `aria-label="${translatedAriaText}"`;
 
   if (Options.getContentSecurityPolicy(editor)) {
     iframeHTML += '<meta http-equiv="Content-Security-Policy" content="' + Options.getContentSecurityPolicy(editor) + '" />';
   }
 
   iframeHTML += '</head>' +
-    `<body id="${bodyId}" class="mce-content-body ${bodyClass}" data-id="${editor.id}" aria-label="${translatedAriaText}">` +
+    `<body id="${bodyId}" class="mce-content-body ${bodyClass}" data-id="${editor.id}" ${iframeBodyAriaLabel}>` +
     '<br>' +
     '</body></html>';
 
@@ -64,7 +65,7 @@ const getIframeHtml = (editor: Editor) => {
 };
 
 const createIframe = (editor: Editor, boxInfo: BoxInfo) => {
-  const iframeTitle = Env.browser.isFirefox() ? Options.getIframeAriaText(editor) : 'Rich Text Area';
+  const iframeTitle = Options.getIframeAriaText(editor);
   const translatedTitle = editor.translate(iframeTitle);
   const tabindex = Attribute.getOpt(SugarElement.fromDom(editor.getElement()), 'tabindex').bind(Strings.toInt);
   const ifr = createIframeElement(editor.id, translatedTitle, Options.getIframeAttrs(editor), tabindex).dom;

--- a/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitIframeAriaTextTest.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
-  const defaultIframeTitle = 'Rich Text Area';
   const defaultIframeAriaText = 'Rich Text Area';
   const defaultIframeAriaTextWithHelpPlugin = defaultIframeAriaText.concat('. Press ALT-0 for help.');
   const customIframeAriaText = 'Cupidatat magna aliquip.';
@@ -19,8 +18,8 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), defaultIframeTitle);
-    assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeAriaText);
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? defaultIframeAriaText : undefined);
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), isFirefox ? undefined : defaultIframeAriaText);
     McEditor.remove(editor);
   });
 
@@ -31,8 +30,8 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? defaultIframeAriaTextWithHelpPlugin : defaultIframeTitle);
-    assert.equal(Attribute.get(iframeBody, 'aria-label'), defaultIframeAriaTextWithHelpPlugin);
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? defaultIframeAriaTextWithHelpPlugin : undefined);
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), isFirefox ? undefined : defaultIframeAriaTextWithHelpPlugin);
     McEditor.remove(editor);
   });
 
@@ -43,8 +42,8 @@ describe('browser.tinymce.core.init.InitIframeAriaTextTest', () => {
     });
     const iframe = SugarElement.fromDom(editor.iframeElement as HTMLIFrameElement);
     const iframeBody = TinyDom.body(editor);
-    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? customIframeAriaText : defaultIframeTitle);
-    assert.equal(Attribute.get(iframeBody, 'aria-label'), customIframeAriaText);
+    assert.equal(Attribute.get(iframe, 'title'), isFirefox ? customIframeAriaText : undefined);
+    assert.equal(Attribute.get(iframeBody, 'aria-label'), isFirefox ? undefined : customIframeAriaText);
     McEditor.remove(editor);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-11296

Description of Changes:
* Fixed an issue where NVDA would announce iframe_aria_text multiple times because of the `iframe_aria_text` text set on both iframe element and on the body inside. 
* In Firefox, the title attribute is now set on the iframe element. The aria-label on the body is not set.
* In other browsers, the aria-label is set on the body inside the iframe. The title is not set on the iframe.
* Removed the hardcoded "Rich Text Area" title.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an accessibility issue where screen readers would announce the iframe ARIA text multiple times, ensuring it is only announced once for improved user experience.
  * Adjusted how accessibility attributes are set on the editor iframe and its body for different browsers, enhancing compatibility with screen readers like NVDA.

* **Tests**
  * Updated tests to reflect the new behavior of accessibility attributes across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->