### PR TITLE
TINY-12458: fix broken caret inside figcaption

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12458-2025-07-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-12458-2025-07-24.yaml
@@ -1,7 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Tabbing when a `figure` was selected didn't move the selection on the `figcaption`
-  correctly.
+body: Cursor movement did not operate correctly after a `figure` was selected.
 time: 2025-07-24T09:16:50.556078+02:00
 custom:
   Issue: TINY-12458

--- a/.changes/unreleased/tinymce-TINY-12458-2025-07-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-12458-2025-07-24.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Tabbing when a `figure` was selected didn't move the selection on the `figcaption`
+  correctly.
+time: 2025-07-24T09:16:50.556078+02:00
+custom:
+  Issue: TINY-12458

--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -162,7 +162,11 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
 
     editor.on('focusin', (e) => {
       // for medias the selection is already managed in `MediaFocus.ts`
-      if (editor.selection.isCollapsed() && !NodeType.isMedia(e.target) && editor.getBody().contains(e.target) && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
+      if (NodeType.isMedia(e.target)) {
+        return;
+      }
+
+      if (editor.getBody().contains(e.target) && e.target !== editor.getBody() && !editor.dom.isEditable(e.target.parentNode)) {
         if (fakeCaret.isShowing()) {
           fakeCaret.hide();
         }

--- a/modules/tinymce/src/core/test/ts/browser/selection/FigcaptionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/FigcaptionTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Focus } from '@ephox/sugar';
-import { TinyHooks, TinyAssertions, TinySelections, TinyDom } from '@ephox/wrap-mcagar';
+import { TinyHooks, TinyAssertions, TinySelections, TinyDom, TinyContentActions } from '@ephox/wrap-mcagar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -21,7 +21,13 @@ describe('browser.tinymce.selection.FigcaptionTest', () => {
     TinySelections.setSelection(editor, [], 0, [], 1);
     const figcaption = UiFinder.findIn<HTMLElement>(TinyDom.body(editor), 'figcaption').getOrDie();
     Focus.focus(figcaption);
+    TinyContentActions.type(editor, 'prefix-');
 
-    TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
+    TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 'prefix-'.length);
+    TinyAssertions.assertContent(editor, [
+      '<figure contenteditable="false"><img src="https://www.google.com/logos/google.jpg">',
+      '<figcaption contenteditable="true">prefix-Caption</figcaption>',
+      '</figure>'
+    ].join('\n'));
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/selection/FigcaptionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/selection/FigcaptionTest.ts
@@ -1,0 +1,27 @@
+import { UiFinder } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Focus } from '@ephox/sugar';
+import { TinyHooks, TinyAssertions, TinySelections, TinyDom } from '@ephox/wrap-mcagar';
+
+import Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.selection.FigcaptionTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  it('TINY-12458: should place cursor at start of figcaption when focused', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<figure contenteditable="false">' +
+        '<img src="https://www.google.com/logos/google.jpg" />' +
+        '<figcaption contenteditable="true">Caption</figcaption>' +
+      '</figure>'
+    );
+    TinySelections.setSelection(editor, [], 0, [], 1);
+    const figcaption = UiFinder.findIn<HTMLElement>(TinyDom.body(editor), 'figcaption').getOrDie();
+    Focus.focus(figcaption);
+
+    TinyAssertions.assertCursor(editor, [ 0, 1, 0 ], 0);
+  });
+});

--- a/modules/tinymce/src/plugins/image/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/image/demo/html/demo.html
@@ -9,12 +9,7 @@
 <body>
   <h2>Plugin: image Demo Page</h2>
   <div id="ephox-ui">
-    <textarea cols="30" rows="10" class="tinymce">
-      <figure class="image" contenteditable="false">
-        <img src="https://ucarecdn.com/27b0e0ff-addd-457a-ace9-cde9022c3ed0/-/preview/" alt="Image on UC">
-        <figcaption contenteditable="true">Image on UC</figcaption>
-      </figure>
-    </textarea>
+    <textarea cols="30" rows="10" class="tinymce"><img src="https://www.tiny.cloud/images/glyph-tinymce@2x.png"/></textarea>
   </div>
   <script src="../../../../../js/tinymce/tinymce.js"></script>
   <script src="../../../../../scratch/demos/plugins/image/demo.js"></script>

--- a/modules/tinymce/src/plugins/image/demo/html/demo.html
+++ b/modules/tinymce/src/plugins/image/demo/html/demo.html
@@ -9,7 +9,12 @@
 <body>
   <h2>Plugin: image Demo Page</h2>
   <div id="ephox-ui">
-    <textarea cols="30" rows="10" class="tinymce"><img src="https://www.tiny.cloud/images/glyph-tinymce@2x.png"/></textarea>
+    <textarea cols="30" rows="10" class="tinymce">
+      <figure class="image" contenteditable="false">
+        <img src="https://ucarecdn.com/27b0e0ff-addd-457a-ace9-cde9022c3ed0/-/preview/" alt="Image on UC">
+        <figcaption contenteditable="true">Image on UC</figcaption>
+      </figure>
+    </textarea>
   </div>
   <script src="../../../../../js/tinymce/tinymce.js"></script>
   <script src="../../../../../scratch/demos/plugins/image/demo.js"></script>


### PR DESCRIPTION
Related Ticket: TINY-12458

Description of Changes:
* Fix keyboard navigation for images with caption. We're reverting the change from: https://github.com/tinymce/tinymce/pull/10378 more details in jira ticket TINY-11753

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
~~* [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor movement issues after selecting a figure element to ensure proper behavior.

* **Tests**
  * Added a test verifying correct cursor placement when focusing a figcaption inside a figure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->