### PR TITLE
TINY-12468: Add tests for flow type navigation

### DIFF
--- a/modules/oxide-components/.storybook/main.ts
+++ b/modules/oxide-components/.storybook/main.ts
@@ -27,6 +27,13 @@ const config: StorybookConfig = {
     config.server ??= {}
     config.server.allowedHosts = ['host.docker.internal'];
     return config;
+  },
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      propFilter: (prop) => prop.parent?.fileName.includes("src") ?? false,
+      shouldRemoveUndefinedFromOptional: true,
+    },
   }
 };
 export default config;

--- a/modules/oxide-components/package.json
+++ b/modules/oxide-components/package.json
@@ -39,8 +39,10 @@
     "test-visual-local": "node ./visual-regression-test.mjs",
     "test-visual-local-update": "node ./visual-regression-test.mjs update",
     "test-ci": "vitest --watch=false --reporter=junit --outputFile=scratch/test-results.xml",
-    "test-storybook": "vitest --project storybook",
-    "ci": "yarn lint && yarn build-storybook && yarn build && yarn test"
+    "test-browser-manual": "vitest --watch --project browser --browser.headless false",
+    "test-browser-headless": "vitest run --project browser",
+    "test-storybook": "vitest run --project storybook",
+    "ci": "yarn lint && yarn --cwd ../../ lerna run build --scope @tinymce/oxide-components --include-dependencies && yarn test"
   },
   "peerDependencies": {
     "react": "^18.3.1",
@@ -73,7 +75,8 @@
     "storybook": "^9.0.10",
     "terser": "^5.28.1",
     "vite": "^6.3.5",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "vitest-browser-react": "^1.0.1"
   },
   "workspaces": {
     "nohoist": [

--- a/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
+++ b/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
@@ -2,12 +2,13 @@ import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { useEffect, type RefObject } from 'react';
 
-import * as FlowType from './keyboard/FlowType';
+import * as FlowType from './keyboard/flowtype/FlowType';
 import * as KeyingType from './keyboard/KeyingType';
 import * as SpecialType from './keyboard/SpecialType';
 import * as TabbingType from './keyboard/TabbingType';
 
 interface BaseProps {
+  /** The container element to bind keyboard events to. */
   containerRef: RefObject<HTMLElement>;
 }
 

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/KeyMatch.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/KeyMatch.ts
@@ -1,17 +1,18 @@
 import { Arr } from '@ephox/katamari';
 
+import type { Key } from './Keys';
+
 export type KeyMatcher = (evt: KeyboardEvent) => boolean;
 
-const inSet = (keys: ReadonlyArray<number>): KeyMatcher => (event: KeyboardEvent) => {
-  return Arr.contains(keys, event.which);
+const inSet = (keys: ReadonlyArray<Key>): KeyMatcher => (event: KeyboardEvent) => {
+  return Arr.exists(keys, (key) => key.code === event.code || key.key === event.key || key.which === event.which);
 };
 
 const and = (preds: KeyMatcher[]): KeyMatcher => (event: KeyboardEvent) => Arr.forall(preds, (pred) => pred(event));
 
-const is = (key: number): KeyMatcher => (event: KeyboardEvent) => {
-  // TODO: 'which' is deprecated and ie is not longer supported
-  // should `key` be used instead?
-  return event.which === key;
+const is = (key: Key): KeyMatcher => (event: KeyboardEvent) => {
+  // use key but fallback to which to support @ephox/agar
+  return event.key === key.key || event.code === key.code || event.which === key.which;
 };
 
 const isShift = (event: KeyboardEvent): boolean => {

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/Keys.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/Keys.ts
@@ -1,15 +1,24 @@
 // TODO: This file would need to be updated once we work on https://ephocks.atlassian.net/browse/TINY-8724
 
-const TAB: ReadonlyArray<number> = [ 9 ];
-const ENTER: ReadonlyArray<number> = [ 13 ];
-const SHIFT: ReadonlyArray<number> = [ 16 ];
-const END: ReadonlyArray<number> = [ 35 ];
-const LEFT: ReadonlyArray<number> = [ 37 ];
-const UP: ReadonlyArray<number> = [ 38 ];
-const RIGHT: ReadonlyArray<number> = [ 39 ];
-const DOWN: ReadonlyArray<number> = [ 40 ];
-const SPACE: ReadonlyArray<number> = [ 32 ];
-const ESCAPE: ReadonlyArray<number> = [ 27 ];
+export interface Key {
+  readonly code: string;
+  readonly key: string;
+  readonly which: number;
+}
+
+const TAB: ReadonlyArray<Key> = [{ code: 'Tab', key: 'Tab', which: 9 }];
+const ENTER: ReadonlyArray<Key> = [{ code: 'Enter', key: 'Enter', which: 13 }];
+const SHIFT: ReadonlyArray<Key> = [
+  { code: 'ShiftLeft', key: 'Shift', which: 16 },
+  { code: 'ShiftRight', key: 'Shift', which: 16 },
+];
+const END: ReadonlyArray<Key> = [{ code: 'End', key: 'End', which: 35 }];
+const LEFT: ReadonlyArray<Key> = [{ code: 'ArrowLeft', key: 'ArrowLeft', which: 37 }];
+const UP: ReadonlyArray<Key> = [{ code: 'ArrowUp', key: 'ArrowUp', which: 38 }];
+const RIGHT: ReadonlyArray<Key> = [{ code: 'ArrowRight', key: 'ArrowRight', which: 39 }];
+const DOWN: ReadonlyArray<Key> = [{ code: 'ArrowDown', key: 'ArrowDown', which: 40 }];
+const SPACE: ReadonlyArray<Key> = [{ code: 'Space', key: ' ', which: 32 }];
+const ESCAPE: ReadonlyArray<Key> = [{ code: 'Escape', key: 'Escape', which: 27 }];
 
 export {
   TAB,

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/NavigationTypes.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/NavigationTypes.ts
@@ -1,4 +1,4 @@
-import * as FlowType from './FlowType';
+import * as FlowType from './flowtype/FlowType';
 import * as KeyingType from './KeyingType';
 import * as SpecialType from './SpecialType';
 import * as TabbingType from './TabbingType';

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.stories.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, ReactRenderer, StoryObj } from '@storybook/react-vite';
+import { type ReactElement } from 'react';
+import type { PartialStoryFn } from 'storybook/internal/csf';
+
+import { FlowKeyingWithCycles } from './stories/FlowKeyingWithCycles.story';
+import { FlowKeyingWithoutCycles } from './stories/FlowKeyingWithoutCycles.story';
+import { FlowTypeDemo } from './stories/FlowTypeDemo';
+
+const styles = `.stay:focus {
+    background-color: #cadbee;
+  }
+  .skip:focus {
+    background-color: red;
+  }
+`;
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'KeyboardNavigationHooks/FlowKey',
+  component: FlowTypeDemo,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: 'centered',
+    docs: {
+      story: {
+        autoplay: true
+      }
+    }
+  },
+  tags: [ 'autodocs', 'skip-visual-testing' ],
+  decorators: [
+    (Story: PartialStoryFn<ReactRenderer>): ReactElement => (
+      <>
+        <style>
+          {styles}
+        </style>
+        <Story />
+      </>
+    )
+  ],
+  args: {
+    selector: '.stay',
+  },
+  argTypes: {
+    containerRef: {
+      control: false,
+      type: {
+        required: true,
+        name: 'other',
+        value: 'RefObject<HTMLElement>'
+      },
+      description: 'RefObject<HTMLElement> - Reference to the container element that will handle keyboard navigation',
+      table: {
+        type: { summary: 'RefObject<HTMLElement>' },
+        defaultValue: { summary: 'useRef<HTMLDivElement>(null)' },
+      },
+    }
+  },
+  play: ({ canvasElement, context }) => {
+    const container = canvasElement.ownerDocument.querySelector('.container');
+    if (container) {
+      const firstFocusableItem = container.querySelector(context.args.selector);
+      firstFocusableItem?.focus();
+    }
+  },
+} satisfies Meta;
+
+export default meta;
+export type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export {
+  FlowKeyingWithCycles,
+  FlowKeyingWithoutCycles
+};
+;

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.ts
@@ -1,21 +1,26 @@
 import { Fun, Optional, Optionals } from '@ephox/katamari';
 import { SelectorFind, SugarElement } from '@ephox/sugar';
 
-import * as DomMovement from '../navigation/DomMovement';
-import * as DomNavigation from '../navigation/DomNavigation';
-
-import type { GeneralKeyingConfig, KeyRuleHandler } from './KeyingModeTypes';
-import * as KeyingType from './KeyingType';
-import * as KeyMatch from './KeyMatch';
-import * as KeyRules from './KeyRules';
-import * as Keys from './Keys';
+import * as DomMovement from '../../navigation/DomMovement';
+import * as DomNavigation from '../../navigation/DomNavigation';
+import type { GeneralKeyingConfig, KeyRuleHandler } from '../KeyingModeTypes';
+import * as KeyingType from '../KeyingType';
+import * as KeyMatch from '../KeyMatch';
+import * as KeyRules from '../KeyRules';
+import * as Keys from '../Keys';
 
 export interface FlowConfig {
+  /**  The selector used to find the next element to focus. */
   readonly selector: string;
+  /**  The function to execute when we press enter while the element is focused. */
   readonly execute?: (focused: SugarElement<HTMLElement>) => Optional<boolean>;
+  /** The function to execute when we press escape while the element is focused. */
   readonly escape?: (focused: SugarElement<HTMLElement>) => Optional<boolean>;
+  /** Whether to allow vertical movement.  */
   readonly allowVertical?: boolean;
+  /** Whether to allow horizontal movement. */
   readonly allowHorizontal?: boolean;
+  /** Whether to allow cycling through elements. */
   readonly cycles?: boolean;
   readonly focusIn?: boolean;
   readonly closest?: boolean;
@@ -27,7 +32,7 @@ export const create = (source: SugarElement<HTMLElement>, config: FlowConfig): K
   const defaultExecute = (
     focused: SugarElement<HTMLElement>
   ): Optional<boolean> => {
-    focused.dom.dispatchEvent(new window.Event('click'));
+    focused.dom.click();
     return Optional.some(true);
   };
 

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/Container.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/Container.tsx
@@ -1,0 +1,39 @@
+import { forwardRef } from 'react';
+
+interface ItemProps {
+  classes: string[];
+}
+
+const Item = ({ classes }: ItemProps) =>
+  (
+    <span
+      className={classes.join(' ')}
+      style={{
+        display: 'inline-block',
+        width: '20px',
+        height: '20px',
+        margin: '2px',
+        border: '1px solid ' + (classes.includes('stay') ? 'blue' : 'yellow')
+      }}
+      tabIndex={-1}
+    />
+  );
+
+export const Container = forwardRef<HTMLDivElement, { testId: string }>(({ testId }, ref) => (
+  <div
+    data-testid={testId}
+    ref={ref}
+    className="flow-keying-test"
+    style={{
+      background: 'white',
+      width: '200px',
+      height: '200px'
+    }}
+  >
+    <Item classes={[ 'stay', 'one' ]} />
+    <Item classes={[ 'stay', 'two' ]} />
+    <Item classes={[ 'skip', 'three' ]} />
+    <Item classes={[ 'skip', 'four' ]} />
+    <Item classes={[ 'stay', 'five' ]} />
+  </div>
+));

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithCycles.story.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithCycles.story.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+import { useFlowKeyNavigation } from '../../../KeyboardNavigationHooks';
+import { type Story } from '../FlowType.stories';
+
+import { Container } from './Container';
+
+export default {};
+export const FlowKeyingWithCycles: Story = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    useFlowKeyNavigation({
+      containerRef: ref,
+      selector: '.stay',
+      cycles: true,
+    });
+    useEffect(() => {
+      if (ref.current) {
+        ref.current.querySelector<HTMLDivElement>('.stay')?.focus();
+      }
+    }, []);
+    return (
+      <Container ref={ref} testId='container' />
+    );
+  },
+};

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithoutCycles.story.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithoutCycles.story.tsx
@@ -1,0 +1,27 @@
+
+import { useEffect, useRef } from 'react';
+
+import { useFlowKeyNavigation } from '../../../KeyboardNavigationHooks';
+import { type Story } from '../FlowType.stories';
+
+import { Container } from './Container';
+
+export default {};
+export const FlowKeyingWithoutCycles: Story = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    useFlowKeyNavigation({
+      containerRef: ref,
+      selector: '.stay',
+      cycles: false,
+    });
+    useEffect(() => {
+      if (ref.current) {
+        ref.current.querySelector<HTMLDivElement>('.stay')?.focus();
+      }
+    }, []);
+    return (
+      <Container ref={ref} testId='container' />
+    );
+  },
+};

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowTypeDemo.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowTypeDemo.tsx
@@ -1,0 +1,74 @@
+
+import { Fun, Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
+import { useRef } from 'react';
+
+import { useFlowKeyNavigation, type FlowKeyingProps } from '../../../KeyboardNavigationHooks';
+
+interface ItemProps {
+  classes: string[];
+}
+
+const Item = ({ classes }: ItemProps) =>
+  (
+    <span
+      className={classes.join(' ')}
+      style={{
+        display: 'inline-block',
+        width: '20px',
+        height: '20px',
+        margin: '2px',
+        border: '1px solid ' + (classes.includes('stay') ? 'blue' : 'yellow')
+      }}
+      tabIndex={-1}
+    />
+  );
+
+const defaultExecute = (
+  focused: SugarElement<HTMLElement>
+): Optional<boolean> => {
+  focused.dom.click();
+  return Optional.some(true);
+
+};
+
+export const FlowTypeDemo: React.FC<Omit<FlowKeyingProps, 'containerRef'>> = ({
+  selector,
+  execute = defaultExecute,
+  escape = Fun.constant(Optional.none()),
+  allowVertical = true,
+  allowHorizontal = true,
+  cycles = true,
+  focusIn = false,
+  closest = true,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useFlowKeyNavigation({
+    containerRef,
+    selector,
+    allowHorizontal,
+    allowVertical,
+    closest,
+    cycles,
+    escape,
+    execute,
+    focusIn
+  });
+  return (
+    <div ref={containerRef as React.RefObject<HTMLDivElement>}
+      className='container'
+      style={{
+        background: 'white',
+        width: '200px',
+        height: '200px'
+      }}
+    >
+      <Item classes={[ 'stay', 'one' ]} />
+      <Item classes={[ 'stay', 'two' ]} />
+      <Item classes={[ 'skip', 'three' ]} />
+      <Item classes={[ 'skip', 'four' ]} />
+      <Item classes={[ 'stay', 'five' ]} />
+    </div>
+  );
+};

--- a/modules/oxide-components/src/test/ts/browser/keynav/KeynavFlowTypeTest.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/keynav/KeynavFlowTypeTest.spec.tsx
@@ -1,0 +1,246 @@
+import { Optional } from '@ephox/katamari';
+import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
+import { userEvent } from '@vitest/browser/context';
+import { useFlowKeyNavigation } from 'oxide-components/keynav/KeyboardNavigationHooks';
+import { forwardRef, useRef } from 'react';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+const styles = `.stay:focus {
+    background-color: #cadbee;
+  }
+  .skip:focus {
+    background-color: red;
+  }
+`;
+
+const store: string[] = [];
+
+const clearStore = (store: string[]) => {
+  store.splice(0, store.length);
+};
+
+interface ItemProps {
+  classes: string[];
+  name: string;
+  store: string[];
+}
+
+const Item = ({ classes, name, store }: ItemProps) =>
+  (
+    <span
+      className={classes.join(' ')}
+      style={{
+        display: 'inline-block',
+        width: '20px',
+        height: '20px',
+        margin: '2px',
+        border: '1px solid ' + (classes.includes('stay') ? 'blue' : 'yellow')
+      }}
+      tabIndex={-1}
+      onClick={() => store.push('item.execute: ' + name)}
+    />
+  );
+
+const Container = forwardRef<HTMLDivElement, { store: string[]; testId: string }>(({ store, testId }, ref) => (
+  <div
+    data-testid={testId}
+    ref={ref}
+    className="flow-keying-test"
+    style={{
+      background: 'white',
+      width: '200px',
+      height: '200px'
+    }}
+  >
+    <Item classes={[ 'stay', 'one' ]} name="one" store={store} />
+    <Item classes={[ 'stay', 'two' ]} name="two" store={store} />
+    <Item classes={[ 'skip', 'three' ]} name="three" store={store} />
+    <Item classes={[ 'skip', 'four' ]} name="four" store={store} />
+    <Item classes={[ 'stay', 'five' ]} name="five" store={store} />
+  </div>
+));
+
+const sequence = async (doc: Document, key: string, identifiers: Array<{ label: string; selector: string }>) => {
+  for (let i = 0; i < identifiers.length; i++) {
+    await userEvent.keyboard(`{${key}}`);
+    const element = doc.querySelector(identifiers[i].selector);
+    await expect.element(element, {
+      message: 'Focus should move from ' + (i > 0 ? identifiers[i - 1].label : '(start)') + ' to ' + identifiers[i].label
+    }).toHaveFocus();
+  }
+};
+
+const targets = {
+  one: { label: 'one', selector: '.one' },
+  two: { label: 'two', selector: '.two' },
+  five: { label: 'five', selector: '.five' }
+};
+
+describe('KeynavFowTypeTest', () => {
+
+  beforeEach(() => {
+    clearStore(store);
+  });
+
+  test('FlowKeying with cycles', async () => {
+
+    const FlowKeyingWithCycles = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useFlowKeyNavigation({
+        containerRef: ref,
+        selector: '.stay',
+        escape: () => {
+          store.push('flow.onEscape');
+          return Optional.some(true);
+        },
+        cycles: true,
+      });
+      return (
+        <Container ref={ref} store={store} testId='container' />
+      );
+    };
+
+    const { getByTestId, baseElement } = render(<FlowKeyingWithCycles />, {
+      wrapper: ({ children }) => (
+        <>
+          <style>
+            {styles}
+          </style>
+          <div className='tox'>
+            {children}
+          </div>
+        </>
+      )
+    });
+    const doc = baseElement.ownerDocument;
+    const container = getByTestId('container');
+    const firstChild = SelectorFind.descendant<HTMLElement>(SugarElement.fromDom(container.element()), '.one').getOrDie();
+    Focus.focus(firstChild);
+
+    await sequence(
+      doc,
+      'ArrowRight',
+      [
+        targets.two,
+        targets.five,
+        targets.one,
+        targets.two,
+        targets.five,
+        targets.one
+      ]
+    );
+
+    await sequence(
+      doc,
+      'ArrowLeft',
+      [
+        targets.five,
+        targets.two,
+        targets.one,
+        targets.five,
+        targets.two,
+        targets.one
+      ]
+    );
+    await sequence(
+      doc,
+      'ArrowUp',
+      [
+        targets.five,
+        targets.two,
+        targets.one,
+        targets.five,
+        targets.two,
+        targets.one
+      ]
+    );
+
+    await sequence(
+      doc,
+      'ArrowDown',
+      [
+        targets.two,
+        targets.five,
+        targets.one,
+        targets.two,
+        targets.five,
+        targets.one
+      ]
+    );
+
+    // Test execute
+    await userEvent.keyboard('{Enter}');
+    expect(store, 'Check that execute has fired on the right target').toEqual([ 'item.execute: one' ]);
+    clearStore(store);
+
+    await userEvent.keyboard('{Escape}');
+    expect(store, 'Check that escape handler has fired').toEqual([ 'flow.onEscape' ]);
+
+  });
+
+  test('TINY-9429: Flow with cycles false should stop on the first element when left is pressed and on the last when right is pressed', async () => {
+
+    const FlowKeyingWithoutCycles = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useFlowKeyNavigation({
+        containerRef: ref,
+        selector: '.stay',
+        escape: () => {
+          store.push('flow.onEscape');
+          return Optional.some(true);
+        },
+        cycles: false,
+      });
+      return (
+        <Container ref={ref} store={store} testId='container' />
+      );
+    };
+
+    const { getByTestId, baseElement } = render(<FlowKeyingWithoutCycles />, {
+      wrapper: ({ children }) => (
+        <>
+          <style>
+            {styles}
+          </style>
+          <div className='tox'>
+            {children}
+          </div>
+        </>
+      )
+    });
+    const doc = baseElement.ownerDocument;
+    const container = getByTestId('container');
+    const firstChild = SelectorFind.descendant<HTMLElement>(SugarElement.fromDom(container.element()), '.one').getOrDie();
+    Focus.focus(firstChild);
+
+    await sequence(
+      doc,
+      'ArrowRight',
+      [
+        targets.two,
+        targets.five,
+        targets.five,
+      ]
+    );
+
+    await sequence(
+      doc,
+      'ArrowLeft',
+      [
+        targets.two,
+        targets.one,
+        targets.one
+      ]
+    );
+
+    // Test execute
+    await userEvent.keyboard('{Enter}');
+    expect(store, 'Check that execute has fired on the right target').toEqual([ 'item.execute: one' ]);
+    clearStore(store);
+
+    await userEvent.keyboard('{Escape}');
+    expect(store, 'Check that escape handler has fired').toEqual([ 'flow.onEscape' ]);
+
+  });
+});

--- a/modules/oxide-components/src/test/ts/visual.spec.ts
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts
@@ -6,7 +6,7 @@ import storybook from '../../../storybook-static/index.json' with { type: 'json'
 
 // Only run tests on stories, not other documentation pages.
 const stories = Object.values(storybook.entries).filter(
-  (e) => e.type === 'story'
+  (e) => e.type === 'story' && !e.tags.includes('skip-visual-testing')
 );
 
 for (const story of stories) {

--- a/modules/oxide-components/tsconfig.demo.json
+++ b/modules/oxide-components/tsconfig.demo.json
@@ -30,5 +30,13 @@
   "include": [
     "src/demo/ts",
     "src/**/*.stories.*"
+  ],
+  "references": [
+    {
+      "path": "../katamari/tsconfig.json"
+    },
+    {
+      "path": "../sugar/tsconfig.json"
+    }
   ]
 }

--- a/modules/oxide-components/tsconfig.json
+++ b/modules/oxide-components/tsconfig.json
@@ -11,5 +11,8 @@
     {
       "path": "./tsconfig.demo.json"
     },
+    {
+      "path": "./tsconfig.test.json"
+    },
   ]
 }

--- a/modules/oxide-components/tsconfig.test.json
+++ b/modules/oxide-components/tsconfig.test.json
@@ -3,16 +3,18 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": [
-      "ES2022"
+      "ES2022",
+      "DOM"
     ],
     "types": [
       "node"
     ],
-    "module": "esnext",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "allowSyntheticDefaultImports": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
@@ -21,12 +23,17 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "oxide-components/*": ["src/main/ts/*"]
+    }
   },
   "include": [
-    "vite.config.ts",
-    "vitest.config.ts",
-    "playwright.config.ts",
+    "src/test/**/*.spec.ts",
+    "src/test/**/*.spec.tsx"
+  ],
+  "exclude": [
     "src/test/ts/visual.spec.ts"
   ]
 }

--- a/modules/oxide-components/vitest.config.ts
+++ b/modules/oxide-components/vitest.config.ts
@@ -14,7 +14,15 @@ export default defineConfig({
       {
         test: {
           name: 'browser',
-          include: [ 'src/test/ts/browser/**/*.spec.ts' ],
+          alias: [
+            {
+              find: 'oxide-components',
+              replacement: fileURLToPath(new URL('./src/main/ts/', import.meta.url))
+            }
+          ],
+          include: [
+            'src/test/ts/browser/**/*.spec.{ts,tsx}'
+          ],
           browser: {
             provider: 'playwright',
             enabled: true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "oxide-icons-build": "yarn -s --cwd modules/oxide-icons-default build",
     "oxide-icons-ci": "yarn -s --cwd modules/oxide-icons-default ci",
     "oxide-components-ci": "yarn -s --cwd modules/oxide-components ci",
-    "oxide-components-build": "yarn -s --cwd modules/oxide-components build",
+    "oxide-components-build": "yarn -s lerna run build --scope @tinymce/oxide-components --include-dependencies",
     "oxide-build": "yarn -s --cwd modules/oxide build",
     "oxide-start": "yarn -s --cwd modules/oxide start",
     "oxide-ci": "yarn -s --cwd modules/oxide ci",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13479,6 +13479,11 @@ vite@^6.3.5:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitest-browser-react@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vitest-browser-react/-/vitest-browser-react-1.0.1.tgz#e36f0a9ca46bf622841f0285defe0bebbb37e16d"
+  integrity sha512-LqiGFCdknrbMoSDWXTCTrPsED3SvdIXIgYOOZyYUNj2dkJusW2eF6NENOlBlxwq+FBQqzNK1X59b+b03pXFpAQ==
+
 vitest@^3.1.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"


### PR DESCRIPTION
# Add tests for flow type keyboard navigation 

Related Ticket: TINY-12468

Description of Changes:
* Added proper JSDoc comments to keyboard navigation hooks and components
* Created FlowType stories to demonstrate and test keyboard navigation functionality
* Updated KeyMatch and Keys to use modern keyboard event properties (code, key) alongside legacy 'which'
* Fixed click event handling in FlowType to use the standard click() method
* Enhanced Storybook configuration to better handle TypeScript documentation

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* ~[x] Milestone set~
* ~[x] Docs ticket created (if applicable)~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added interactive Storybook demos for flow keyboard navigation (with and without cycling).
  - Improved key handling to recognize key/code across browsers.
  - Default “execute” now triggers a native click for more consistent behavior.

- Documentation
  - Enhanced Storybook docs with TypeScript prop extraction, focused defaults, and canvas styling.

- Tests
  - Added browser-based keyboard navigation tests; visual tests now skip tagged stories.

- Chores
  - Updated build/test scripts and configurations to support browser testing and monorepo builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->