### PR TITLE
TINY-12601: introduce layers for better control over cascade

### DIFF
--- a/modules/oxide/src/less/theme/globals/global-custom-properties.less
+++ b/modules/oxide/src/less/theme/globals/global-custom-properties.less
@@ -1,89 +1,90 @@
-.tox when (@custom-properties-enabled = true) {
-  --tox-private-color-scheme: light dark;
-  // Root variables
-  // Begin customization by changing these variables as most other variables are derivatives of these.
-  --tox-private-background-color: light-dark(#fff, #222F3E);
-  --tox-private-base-value: 16px;
-  --tox-private-color-black: #222f3e;
-  --tox-private-color-tint: #006ce7;
-  --tox-private-color-white: #fff;
-  --tox-private-color-error: #c00;
-  --tox-private-color-error-element-focus-color: #f00;
-  --tox-private-color-success: #78AB46;
-  --tox-private-color-warning: #FFCC00;
-  --tox-private-color-active: light-dark(#ffcf30, #006ce7);
+@layer tox-globals {
+  .tox when (@custom-properties-enabled = true) {
+    --tox-private-color-scheme: light dark;
+    // Root variables
+    // Begin customization by changing these variables as most other variables are derivatives of these.
+    --tox-private-background-color: light-dark(#fff, #222F3E);
+    --tox-private-base-value: 16px;
+    --tox-private-color-black: #222f3e;
+    --tox-private-color-tint: #006ce7;
+    --tox-private-color-white: #fff;
+    --tox-private-color-error: #c00;
+    --tox-private-color-error-element-focus-color: #f00;
+    --tox-private-color-success: #78AB46;
+    --tox-private-color-warning: #FFCC00;
+    --tox-private-color-active: light-dark(#ffcf30, #006ce7);
 
-  --tox-private-font-stack: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+    --tox-private-font-stack: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 
-  // Content;
+    // Content;
 
-  --tox-private-content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
+    --tox-private-content-ui-darkmode: false; // Change this to true to get white icons in the content such as bookmarks.
 
-  // Colors
-  --tox-private-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 6.5));
-  --tox-private-separator-color: light-dark(
-    hsl( from var(--tox-private-border-color) h s calc(l - 4.5)),
-    hsla(0, 0%, 100%, 0.15);
-  );
-
-  // used only in toolbar-split-button -> should not be a global 
-  // --tox-private-border-color-light: light-dark(
-  //     hsl(from var(--tox-private-background-color) h s calc( l - 11)), 
-  //     hsl(from var(--tox-private-background-color) h s calc( l + 11))
-  //   );
-
-  --tox-private-text-color: light-dark(var(--tox-private-color-black), var(--tox-private-color-white));
-  --tox-private-text-color-muted: light-dark(
-      hsl(from var(--tox-private-color-black) h s l / 70%), 
-      hsl(from var(--tox-private-color-white) h s l / 50%)
+    // Colors
+    --tox-private-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 6.5));
+    --tox-private-separator-color: light-dark(
+      hsl( from var(--tox-private-border-color) h s calc(l - 4.5)),
+      hsla(0, 0%, 100%, 0.15);
     );
 
-  // Some useful generic variables
-  --tox-private-panel-border-radius: 6px; // Dialogs, menues etc.
-  --tox-private-control-border-radius: 6px; // Buttons, input fields etc.
-  --tox-private-control-height: 36px; // In many places there is fixed value or a referance to @textfield-height. That's why the global var is introduced. For inputs, checkbox etc.
+    // used only in toolbar-split-button -> should not be a global 
+    // --tox-private-border-color-light: light-dark(
+    //     hsl(from var(--tox-private-background-color) h s calc( l - 11)), 
+    //     hsl(from var(--tox-private-background-color) h s calc( l + 11))
+    //   );
 
-  // Focus outline
-  --tox-private-keyboard-focus-outline-width: 2px;
-  --tox-private-keyboard-focus-outline-color: light-dark(
-      var(--tox-private-color-tint),
-      var(--tox-private-color-white)
-    );
+    --tox-private-text-color: light-dark(var(--tox-private-color-black), var(--tox-private-color-white));
+    --tox-private-text-color-muted: light-dark(
+        hsl(from var(--tox-private-color-black) h s l / 70%), 
+        hsl(from var(--tox-private-color-white) h s l / 50%)
+      );
 
-  // Font
-  --tox-private-line-height: 1.3;
-  --tox-private-control-line-height: calc(var(--tox-private-font-size-md) * 1.5); // Use instead of @textfield-line-height. It can't be just 1.5 as it's used in calculations.
-  --tox-private-font-weight-normal: normal;
-  --tox-private-font-weight-bold: bold;
-  --tox-private-font-size-base: var(--tox-private-base-value);
-  --tox-private-font-size-xs: 12px; // Absolute value to not make it too small
-  --tox-private-font-size-sm: calc(var(--tox-private-font-size-base) * .875);
-  --tox-private-font-size-md: var(--tox-private-font-size-base);
-  --tox-private-font-size-lg: calc(var(--tox-private-font-size-base) * 1.25);
+    // Some useful generic variables
+    --tox-private-panel-border-radius: 6px; // Dialogs, menues etc.
+    --tox-private-control-border-radius: 6px; // Buttons, input fields etc.
+    --tox-private-control-height: 36px; // In many places there is fixed value or a referance to @textfield-height. That's why the global var is introduced. For inputs, checkbox etc.
 
-  // Spacings
-  --tox-private-pad-xs: calc(var(--tox-private-base-value) / 4);
-  --tox-private-pad-sm: calc(var(--tox-private-base-value) / 2);
-  --tox-private-pad-md: var(--tox-private-base-value);
-  --tox-private-pad-lg: calc(var(--tox-private-base-value) * 1.5);
-  --tox-private-pad-xl: calc(var(--tox-private-base-value) * 2);
+    // Focus outline
+    --tox-private-keyboard-focus-outline-width: 2px;
+    --tox-private-keyboard-focus-outline-color: light-dark(
+        var(--tox-private-color-tint),
+        var(--tox-private-color-white)
+      );
 
-  // z-index stack (reserved range 1000-10000)
-  --tox-private-z-index-fullscreen: 1200;
-  --tox-private-z-index-resize-handle: 1298;
-  --tox-private-z-index-throbber: 1299;
-  --tox-private-z-index-sink: 1300;
+    // Font
+    --tox-private-line-height: 1.3;
+    --tox-private-control-line-height: calc(var(--tox-private-font-size-md) * 1.5); // Use instead of @textfield-line-height. It can't be just 1.5 as it's used in calculations.
+    --tox-private-font-weight-normal: normal;
+    --tox-private-font-weight-bold: bold;
+    --tox-private-font-size-base: var(--tox-private-base-value);
+    --tox-private-font-size-xs: 12px; // Absolute value to not make it too small
+    --tox-private-font-size-sm: calc(var(--tox-private-font-size-base) * .875);
+    --tox-private-font-size-md: var(--tox-private-font-size-base);
+    --tox-private-font-size-lg: calc(var(--tox-private-font-size-base) * 1.25);
 
-  // sink z-index stack
-  // Note: these are rendered inside the sink so aren't affected by the other global z-index variables
-  --tox-private-z-index-loading: 1000;
-  --tox-private-z-index-dialogs: 1100;
-  --tox-private-z-index-menu: 1150;
+    // Spacings
+    --tox-private-pad-xs: calc(var(--tox-private-base-value) / 4);
+    --tox-private-pad-sm: calc(var(--tox-private-base-value) / 2);
+    --tox-private-pad-md: var(--tox-private-base-value);
+    --tox-private-pad-lg: calc(var(--tox-private-base-value) * 1.5);
+    --tox-private-pad-xl: calc(var(--tox-private-base-value) * 2);
 
-  // Responsive breakpoints -> do we need them as a global variables?
-  --tox-private-breakpoint-sm-value: 767px;
-  --tox-private-breakpoint-md: ~"only screen and (min-width:1000px)";
-  --tox-private-breakpoint-sm: ~"only screen and (max-width: var(--tox-private-breakpoint-sm-value))";
-  --tox-private-breakpoint-gt-sm: ~"only screen and (min-width: calc(var(--tox-private-breakpoint-sm-value) + 1px))";
+    // z-index stack (reserved range 1000-10000)
+    --tox-private-z-index-fullscreen: 1200;
+    --tox-private-z-index-resize-handle: 1298;
+    --tox-private-z-index-throbber: 1299;
+    --tox-private-z-index-sink: 1300;
 
+    // sink z-index stack
+    // Note: these are rendered inside the sink so aren't affected by the other global z-index variables
+    --tox-private-z-index-loading: 1000;
+    --tox-private-z-index-dialogs: 1100;
+    --tox-private-z-index-menu: 1150;
+
+    // Responsive breakpoints -> do we need them as a global variables?
+    --tox-private-breakpoint-sm-value: 767px;
+    --tox-private-breakpoint-md: ~"only screen and (min-width:1000px)";
+    --tox-private-breakpoint-sm: ~"only screen and (max-width: var(--tox-private-breakpoint-sm-value))";
+    --tox-private-breakpoint-gt-sm: ~"only screen and (min-width: calc(var(--tox-private-breakpoint-sm-value) + 1px))";
+  }
 }

--- a/modules/oxide/src/less/theme/globals/mixins.less
+++ b/modules/oxide/src/less/theme/globals/mixins.less
@@ -1,0 +1,14 @@
+.keyboard-focus-outline-mixin(@_inset: ~'') {
+  border-radius: @toolbar-button-border-radius;
+  bottom: 0;
+  box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color @_inset;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  @media (forced-colors: active) {
+    border: 2px solid highlight;
+  }
+}

--- a/modules/oxide/src/less/theme/globals/tinymce.less
+++ b/modules/oxide/src/less/theme/globals/tinymce.less
@@ -12,69 +12,55 @@
 
 @editor-header-inline-background-color: @background-color; 
 
-
-.tox {
-  color: var(--tox-private-color-black, @color-black);
-  font-family: var(--tox-private-font-stack, @font-stack);
-  font-size: var(--tox-private-font-size-base, @font-size-base);
-}
-
-.tox-tinymce {
-  border: @tinymce-border-width solid @tinymce-border-color;
-  border-radius: @tinymce-border-radius;
-  box-shadow: @tinymce-box-shadow;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  font-family: var(--tox-private-font-stack, @font-stack);
-  overflow: hidden;
-  position: relative;
-  visibility: inherit !important;
-}
-
-// Place the border/shadow on the header in inline mode instead of the root component
-.tox.tox-tinymce-inline {
-  border: none;
-  box-shadow: none;
-  overflow: initial;
-
-  .tox-editor-container {
-    overflow: initial;
+@layer tox-globals {
+  .tox {
+    color: var(--tox-private-color-black, @color-black);
+    font-family: var(--tox-private-font-stack, @font-stack);
+    font-size: var(--tox-private-font-size-base, @font-size-base);
   }
 
-  .tox-editor-header {
-    background-color: @editor-header-inline-background-color;
+  .tox-tinymce {
     border: @tinymce-border-width solid @tinymce-border-color;
     border-radius: @tinymce-border-radius;
     box-shadow: @tinymce-box-shadow;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--tox-private-font-stack, @font-stack);
     overflow: hidden;
+    position: relative;
+    visibility: inherit !important;
   }
-}
 
-.tox-tinymce-aux {
-  font-family: var(--tox-private-font-stack, @font-stack);
-  z-index: var(--tox-private-z-index-sink, @z-index-sink);
-}
+  // Place the border/shadow on the header in inline mode instead of the root component
+  .tox.tox-tinymce-inline {
+    border: none;
+    box-shadow: none;
+    overflow: initial;
 
-.keyboard-focus-outline-mixin(@_inset: ~'') {
-  border-radius: @toolbar-button-border-radius;
-  bottom: 0;
-  box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color @_inset;
-  content: '';
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
+    .tox-editor-container {
+      overflow: initial;
+    }
 
-  @media (forced-colors: active) {
-    border: 2px solid highlight;
+    .tox-editor-header {
+      background-color: @editor-header-inline-background-color;
+      border: @tinymce-border-width solid @tinymce-border-color;
+      border-radius: @tinymce-border-radius;
+      box-shadow: @tinymce-box-shadow;
+      overflow: hidden;
+    }
   }
-}
 
-// RTL
-.tox[dir=rtl] {
-  // Rotates configured icons 180 degrees when rendering in RTL
-  .tox-icon--flip svg {
-    transform: rotateY(180deg);
+  .tox-tinymce-aux {
+    font-family: var(--tox-private-font-stack, @font-stack);
+    z-index: var(--tox-private-z-index-sink, @z-index-sink);
+  }
+
+  // RTL
+  .tox[dir=rtl] {
+    // Rotates configured icons 180 degrees when rendering in RTL
+    .tox-icon--flip svg {
+      transform: rotateY(180deg);
+    }
   }
 }

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -1,6 +1,18 @@
 //
 // Oxide Theme
 //
+
+/* 
+Rules declared inside a layer cascade together. This gives us more control over the cascade. 
+Styles defined in the last layer will override styles declared in the previous layers no matter the specificity.
+Styles that are not defined in any layer always override styles declared in named and anonymous layers.
+  1. `tox-reset` - CSS reset to clear default browser formatting.
+  2. `tox-globals` - global styles and CSS Custom Properties. Overrides styles defined in `tox-reset`.
+  3. `tox-component` - bigger components that can conatin other components like dialog, menu bar etc. Overrides styles defined in `tox-reset` and `tox-globals`.
+  4. `tox-atomic-component` - atomic components like button, input, checkbox etc. Overrides styles defined in `tox-reset`, `tox-globals` and `tox-component`.
+*/
+@layer tox-reset, tox-globals, tox-component, tox-atomic-component;
+
 @import 'globals/feature-flags';
 
 @import 'globals/reset';
@@ -9,6 +21,7 @@
 @import 'globals/global-variables';
 @import 'globals/global-custom-properties';
 @import 'globals/animations';
+@import 'globals/mixins';
 
 @import 'globals/tinymce';
 @import 'components/editor/editor';


### PR DESCRIPTION
Related Ticket: TINY-12601

Description of Changes:
* Added CSS cascade layers to the Oxide theme to improve control over the cascade
* Created a layering system with `tox-reset`, `tox-globals`, `tox-component`, and `tox-atomic-component`
* Moved keyboard focus outline mixin to a separate file - mixins and less variables declarations need to be declared outside of the layer. 
* Wrapped existing global styles in appropriate layer declarations

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new keyboard focus outline style for improved accessibility.
  * Added CSS layer declarations to organize theme styles and control style precedence.

* **Refactor**
  * Grouped existing global and TinyMCE styles into a dedicated CSS layer for better style encapsulation and maintainability.

* **Documentation**
  * Added explanatory comments about CSS layering and cascade order in the theme styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->