### PR TITLE
TINY-12604: converting the naked button to the transitional stage

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button-naked.less
+++ b/modules/oxide/src/less/theme/components/button/button-naked.less
@@ -1,6 +1,6 @@
 //
 // Naked button - variant of the button
-// Variat class `tox-button--naked` should be added next to the base `tox-button` class.
+// Variant class `tox-button--naked` should be added next to the base `tox-button` class.
 // Note: naked button is mainly used for removing button chrome on button--icon
 // For base button styles see button.less
 //

--- a/modules/oxide/src/less/theme/components/button/button-naked.less
+++ b/modules/oxide/src/less/theme/components/button/button-naked.less
@@ -1,5 +1,5 @@
 //
-// Naked button - varinat of the button
+// Naked button - variant of the button
 // Variat class `tox-button--naked` should be added next to the base `tox-button` class.
 // Note: naked button is mainly used for removing button chrome on button--icon
 // For base button styles see button.less
@@ -29,7 +29,7 @@
 
 @layer tox-atomic-component {
   .tox-button--naked when (@custom-properties-enabled = true) {
-    // Naked button variant only styles the text color as the background and boreder are transparent by design
+    // Naked button variant only styles the text color as the background and border are transparent by design
     --tox-private-button-naked-text-color: var(--tox-private-text-color);
 
     /* 

--- a/modules/oxide/src/less/theme/components/button/button-naked.less
+++ b/modules/oxide/src/less/theme/components/button/button-naked.less
@@ -1,7 +1,8 @@
 //
-// Naked button
-// Extends button.less and button-icon-less
-// Note: button--naked is for removing button chrome on button--icon
+// Naked button - varinat of the button
+// Variat class `tox-button--naked` should be added next to the base `tox-button` class.
+// Note: naked button is mainly used for removing button chrome on button--icon
+// For base button styles see button.less
 //
 
 @button-naked-icon-color: @text-color;
@@ -26,49 +27,78 @@
 @button-naked-active-box-shadow: unset;
 @button-naked-active-icon-color: @button-naked-icon-color;
 
-.tox {
+@layer tox-atomic-component {
+  .tox-button--naked when (@custom-properties-enabled = true) {
+    // Naked button variant only styles the text color as the background and boreder are transparent by design
+    --tox-private-button-naked-text-color: var(--tox-private-text-color);
+
+    /* 
+      Button state variables - to be decided if we want them. 
+      If we do: 
+        1. They should inherit from button base variables (as they do now).
+        2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
+        3. In this case it is also possible to skin each state separately. 
+      If we don't: 
+        1. They should be removed. 
+        2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
+        3. In this case it is NOT possible to skin each state separately. 
+    */
+    --tox-private-button-naked-disabled-text-color: hsl(from var(--tox-private-button-naked-text-color) h s l / 50%);
+
+    --tox-private-button-naked-focus-background-color: light-dark(
+      hsl(from var(--tox-private-button-naked-text-color) h s l / 12%),
+      hsl(from var(--tox-private-button-naked-text-color) h s l / 20%)
+    );
+    --tox-private-button-naked-focus-border-color: var(--tox-private-button-naked-focus-background-color);
+    --tox-private-button-naked-focus-text-color: var(--tox-private-button-naked-text-color);
+    
+    --tox-private-button-naked-hover-background-color: light-dark(
+      hsl(from var(--tox-private-button-naked-text-color) h s l / 12%),
+      hsl(from var(--tox-private-button-naked-text-color) h s l / 20%)
+    );
+    --tox-private-button-naked-hover-border-color: var(--tox-private-button-naked-hover-background-color);
+    --tox-private-button-naked-hover-text-color: var(--tox-private-button-naked-text-color);
+    
+    --tox-private-button-naked-active-background-color: light-dark(
+      hsl(from var(--tox-private-button-naked-text-color) h s l / 18%),
+      hsl(from var(--tox-private-button-naked-text-color) h s l / 30%)
+    );
+    --tox-private-button-naked-active-border-color: var(--tox-private-button-naked-active-background-color);
+    --tox-private-button-naked-active-text-color: var(--tox-private-button-naked-text-color);
+  }
+
   .tox-button--naked {
     background-color: transparent;
     border-color: transparent;
     box-shadow: unset;
-    color: @button-naked-icon-color;
+    color: var(--tox-private-button-naked-text-color, @button-naked-icon-color);
 
     &[disabled] {
       background-color: @button-naked-disabled-background-color;
       border-color: @button-naked-disabled-border-color;
-      box-shadow: @button-naked-disabled-box-shadow;
-      color: @button-naked-disabled-icon-color;
+      color: var(--tox-private-button-naked-disabled-text-color, @button-naked-disabled-icon-color);
+      cursor: not-allowed;
     }
-
-    &:hover:not(:disabled) {
-      background-color: @button-naked-hover-background-color;
-      border-color: @button-naked-focus-border-color;
-      box-shadow: @button-naked-hover-box-shadow;
-      color: @button-naked-hover-icon-color;
-    }
-
+    
     &:focus:not(:disabled) {
-      background-color: @button-naked-focus-background-color;
-      border-color: @button-naked-focus-border-color;
+      background-color: var(--tox-private-button-naked-focus-background-color, @button-naked-focus-background-color);
+      border-color: var(--tox-private-button-naked-focus-border-color, @button-naked-focus-border-color);
+      color: var(--tox-private-button-naked-focus-text-color, @button-naked-focus-icon-color);
       box-shadow: @button-naked-focus-box-shadow;
-      color: @button-naked-focus-icon-color;
     }
-
-    &:active:not(:disabled) {
-      background-color: @button-naked-active-background-color;
-      border-color: @button-naked-active-border-color;
-      box-shadow: @button-naked-active-box-shadow;
-      color: @button-naked-active-icon-color;
-    }
-
-    .tox-icon svg {
-      fill: currentColor;
-    }
-  }
-
-  .tox-button--naked.tox-button--icon {
+    
     &:hover:not(:disabled) {
-      color: @button-naked-hover-icon-color;
+      background-color: var(--tox-private-button-naked-hover-background-color, @button-naked-hover-background-color);
+      border-color: var(--tox-private-button-naked-hover-background-color, @button-naked-hover-border-color);
+      color: var(--tox-private-button-naked-hover-text-color, @button-naked-hover-icon-color);
+      box-shadow: @button-naked-hover-box-shadow;
+    }
+    
+    &:active:not(:disabled) {
+      background-color: var(--tox-private-button-naked-active-background-color, @button-naked-active-background-color);
+      border-color: var(--tox-private-button-naked-active-border-color, @button-naked-active-border-color);
+      color: var(--tox-private-button-naked-active-text-color, @button-naked-active-icon-color);
+      box-shadow: @button-naked-active-box-shadow;
     }
   }
 }

--- a/modules/oxide/src/less/theme/components/button/button-naked.less
+++ b/modules/oxide/src/less/theme/components/button/button-naked.less
@@ -28,77 +28,79 @@
 @button-naked-active-icon-color: @button-naked-icon-color;
 
 @layer tox-atomic-component {
-  .tox-button--naked when (@custom-properties-enabled = true) {
-    // Naked button variant only styles the text color as the background and border are transparent by design
-    --tox-private-button-naked-text-color: var(--tox-private-text-color);
+  .tox {
+    .tox-button--naked when (@custom-properties-enabled = true) {
+      // Naked button variant only styles the text color as the background and border are transparent by design
+      --tox-private-button-naked-text-color: var(--tox-private-text-color);
 
-    /* 
-      Button state variables - to be decided if we want them. 
-      If we do: 
-        1. They should inherit from button base variables (as they do now).
-        2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
-        3. In this case it is also possible to skin each state separately. 
-      If we don't: 
-        1. They should be removed. 
-        2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
-        3. In this case it is NOT possible to skin each state separately. 
-    */
-    --tox-private-button-naked-disabled-text-color: hsl(from var(--tox-private-button-naked-text-color) h s l / 50%);
+      /* 
+        Button state variables - to be decided if we want them. 
+        If we do: 
+          1. They should inherit from button base variables (as they do now).
+          2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
+          3. In this case it is also possible to skin each state separately. 
+        If we don't: 
+          1. They should be removed. 
+          2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
+          3. In this case it is NOT possible to skin each state separately. 
+      */
+      --tox-private-button-naked-disabled-text-color: hsl(from var(--tox-private-button-naked-text-color) h s l / 50%);
 
-    --tox-private-button-naked-focus-background-color: light-dark(
-      hsl(from var(--tox-private-button-naked-text-color) h s l / 12%),
-      hsl(from var(--tox-private-button-naked-text-color) h s l / 20%)
-    );
-    --tox-private-button-naked-focus-border-color: var(--tox-private-button-naked-focus-background-color);
-    --tox-private-button-naked-focus-text-color: var(--tox-private-button-naked-text-color);
-    
-    --tox-private-button-naked-hover-background-color: light-dark(
-      hsl(from var(--tox-private-button-naked-text-color) h s l / 12%),
-      hsl(from var(--tox-private-button-naked-text-color) h s l / 20%)
-    );
-    --tox-private-button-naked-hover-border-color: var(--tox-private-button-naked-hover-background-color);
-    --tox-private-button-naked-hover-text-color: var(--tox-private-button-naked-text-color);
-    
-    --tox-private-button-naked-active-background-color: light-dark(
-      hsl(from var(--tox-private-button-naked-text-color) h s l / 18%),
-      hsl(from var(--tox-private-button-naked-text-color) h s l / 30%)
-    );
-    --tox-private-button-naked-active-border-color: var(--tox-private-button-naked-active-background-color);
-    --tox-private-button-naked-active-text-color: var(--tox-private-button-naked-text-color);
-  }
+      --tox-private-button-naked-focus-background-color: light-dark(
+        hsl(from var(--tox-private-button-naked-text-color) h s l / 12%),
+        hsl(from var(--tox-private-button-naked-text-color) h s l / 20%)
+      );
+      --tox-private-button-naked-focus-border-color: var(--tox-private-button-naked-focus-background-color);
+      --tox-private-button-naked-focus-text-color: var(--tox-private-button-naked-text-color);
 
-  .tox-button--naked {
-    background-color: transparent;
-    border-color: transparent;
-    box-shadow: unset;
-    color: var(--tox-private-button-naked-text-color, @button-naked-icon-color);
+      --tox-private-button-naked-hover-background-color: light-dark(
+        hsl(from var(--tox-private-button-naked-text-color) h s l / 12%),
+        hsl(from var(--tox-private-button-naked-text-color) h s l / 20%)
+      );
+      --tox-private-button-naked-hover-border-color: var(--tox-private-button-naked-hover-background-color);
+      --tox-private-button-naked-hover-text-color: var(--tox-private-button-naked-text-color);
 
-    &[disabled] {
-      background-color: @button-naked-disabled-background-color;
-      border-color: @button-naked-disabled-border-color;
-      color: var(--tox-private-button-naked-disabled-text-color, @button-naked-disabled-icon-color);
-      cursor: not-allowed;
+      --tox-private-button-naked-active-background-color: light-dark(
+        hsl(from var(--tox-private-button-naked-text-color) h s l / 18%),
+        hsl(from var(--tox-private-button-naked-text-color) h s l / 30%)
+      );
+      --tox-private-button-naked-active-border-color: var(--tox-private-button-naked-active-background-color);
+      --tox-private-button-naked-active-text-color: var(--tox-private-button-naked-text-color);
     }
-    
-    &:focus:not(:disabled) {
-      background-color: var(--tox-private-button-naked-focus-background-color, @button-naked-focus-background-color);
-      border-color: var(--tox-private-button-naked-focus-border-color, @button-naked-focus-border-color);
-      color: var(--tox-private-button-naked-focus-text-color, @button-naked-focus-icon-color);
-      box-shadow: @button-naked-focus-box-shadow;
-    }
-    
-    &:hover:not(:disabled) {
-      background-color: var(--tox-private-button-naked-hover-background-color, @button-naked-hover-background-color);
-      border-color: var(--tox-private-button-naked-hover-background-color, @button-naked-hover-border-color);
-      color: var(--tox-private-button-naked-hover-text-color, @button-naked-hover-icon-color);
-      box-shadow: @button-naked-hover-box-shadow;
-    }
-    
-    &:active:not(:disabled) {
-      background-color: var(--tox-private-button-naked-active-background-color, @button-naked-active-background-color);
-      border-color: var(--tox-private-button-naked-active-border-color, @button-naked-active-border-color);
-      color: var(--tox-private-button-naked-active-text-color, @button-naked-active-icon-color);
-      box-shadow: @button-naked-active-box-shadow;
+
+    .tox-button--naked {
+      background-color: transparent;
+      border-color: transparent;
+      box-shadow: unset;
+      color: var(--tox-private-button-naked-text-color, @button-naked-icon-color);
+
+      &[disabled] {
+        background-color: @button-naked-disabled-background-color;
+        border-color: @button-naked-disabled-border-color;
+        color: var(--tox-private-button-naked-disabled-text-color, @button-naked-disabled-icon-color);
+        cursor: not-allowed;
+      }
+
+      &:focus:not(:disabled) {
+        background-color: var(--tox-private-button-naked-focus-background-color, @button-naked-focus-background-color);
+        border-color: var(--tox-private-button-naked-focus-border-color, @button-naked-focus-border-color);
+        color: var(--tox-private-button-naked-focus-text-color, @button-naked-focus-icon-color);
+        box-shadow: @button-naked-focus-box-shadow;
+      }
+
+      &:hover:not(:disabled) {
+        background-color: var(--tox-private-button-naked-hover-background-color, @button-naked-hover-background-color);
+        border-color: var(--tox-private-button-naked-hover-background-color, @button-naked-hover-border-color);
+        color: var(--tox-private-button-naked-hover-text-color, @button-naked-hover-icon-color);
+        box-shadow: @button-naked-hover-box-shadow;
+      }
+
+      &:active:not(:disabled) {
+        background-color: var(--tox-private-button-naked-active-background-color, @button-naked-active-background-color);
+        border-color: var(--tox-private-button-naked-active-border-color, @button-naked-active-border-color);
+        color: var(--tox-private-button-naked-active-text-color, @button-naked-active-icon-color);
+        box-shadow: @button-naked-active-box-shadow;
+      }
     }
   }
 }

--- a/modules/oxide/src/less/theme/components/button/button-primary.less
+++ b/modules/oxide/src/less/theme/components/button/button-primary.less
@@ -151,7 +151,7 @@
 
       &:hover:not(:disabled) {
         background-color: var(--tox-private-button-primary-hover-background-color, @button-hover-background-color);
-        border-color: var(--tox-private-button-primary-hover-background-color, @button-hover-border-color);
+        border-color: var(--tox-private-button-primary-hover-border-color, @button-hover-border-color);
         color: var(--tox-private-button-primary-hover-text-color, @button-hover-text-color);
         background-image: @button-hover-background-image;
         box-shadow: @button-hover-box-shadow;

--- a/modules/oxide/src/less/theme/components/button/button-primary.less
+++ b/modules/oxide/src/less/theme/components/button/button-primary.less
@@ -1,5 +1,5 @@
 //
-// Primary button - varinat of the button
+// Primary button - variant of the button
 // For the primary variant we use base button class `tox-button`. We should later change it to `tox-button--primary` and use next to the base `tox-button` class.
 // For base button styles see button.less
 //

--- a/modules/oxide/src/less/theme/components/button/button-primary.less
+++ b/modules/oxide/src/less/theme/components/button/button-primary.less
@@ -61,144 +61,146 @@
 @button-enabled-active-text-color: @button-enabled-text-color;
 
 @layer tox-atomic-component {
-  /* TODO: Add `--primary` to class name. Currently, we treat primary as base in alloy */
-  .tox-button when (@custom-properties-enabled = true) {
-    /* Base variables */
-    --tox-private-button-primary-background-color: var(--tox-private-color-tint);
-    --tox-private-button-primary-text-color: var(--tox-private-color-white);
-    --tox-private-button-primary-border-color: var(--tox-private-button-primary-background-color);
-    
-    /* 
-      Button state variables - to be decided if we want them. 
-      If we do: 
-        1. They should inherit from button base variables (as they do now).
-        2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
-        3. In this case it is also possible to skin each state separately. 
-      If we don't: 
-        1. They should be removed. 
-        2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
-        3. In this case it is NOT possible to skin each state separately. 
-    */
-    /* Disabled state */
-    --tox-private-button-primary-disabled-background-color: var(--tox-private-button-primary-background-color);
-    --tox-private-button-primary-disabled-border-color: var(--tox-private-button-primary-border-color);
-    --tox-private-button-primary-disabled-text-color: hsl(from var(--tox-private-button-primary-text-color) h s l / 50%);
-    
-    /* Focus state */
-    --tox-private-button-primary-focus-background-color: hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 5));
-    --tox-private-button-primary-focus-border-color: var(--tox-private-button-primary-focus-background-color);
-    --tox-private-button-primary-focus-text-color: var(--tox-private-button-primary-text-color);
-    
-    /* Hover state */
-    --tox-private-button-primary-hover-background-color:  hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 5));
-    --tox-private-button-primary-hover-border-color: var(--tox-private-button-primary-hover-background-color);
-    --tox-private-button-primary-hover-text-color: var(--tox-private-button-primary-text-color);
-    
-    /* Active state */
-    --tox-private-button-primary-active-background-color:  hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 10));
-    --tox-private-button-primary-active-border-color: var(--tox-private-button-primary-active-background-color);
-    --tox-private-button-primary-active-text-color: var(--tox-private-button-primary-text-color);
-    
-    /* Enabled state 
-      Do we use this button as a toggle that can be enabled? 
-      If not - these variables and enabled state styles should be removed
-    */
-    --tox-private-button-primary-enabled-background-color:  hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 10));
-    --tox-private-button-primary-enabled-border-color: var(--tox-private-button-primary-enabled-background-color);
-    --tox-private-button-primary-enabled-text-color: var(--tox-private-button-primary-text-color);
-    
-    /* Enabled + focus state */
-    --tox-private-button-primary-enabled-focus-background-color: hsl(from var(--tox-private-button-primary-enabled-background-color) h s calc(l - 5));
-    --tox-private-button-primary-enabled-focus-border-color: var(--tox-private-button-primary-enabled-focus-background-color);
-    --tox-private-button-primary-enabled-focus-text-color: var(--tox-private-button-primary-enabled-text-color);
-    
-    /* Enabled + hover state */
-    --tox-private-button-primary-enabled-hover-background-color: hsl(from var(--tox-private-button-primary-enabled-background-color) h s calc(l - 5));
-    --tox-private-button-primary-enabled-hover-border-color: var(--tox-private-button-primary-enabled-hover-background-color);
-    --tox-private-button-primary-enabled-hover-text-color: var(--tox-private-button-primary-enabled-text-color);
-    
-    /* Enabled + active state */
-    --tox-private-button-primary-enabled-active-background-color: hsl(from var(--tox-private-button-primary-enabled-background-color) h s calc(l - 10));
-    --tox-private-button-primary-enabled-active-border-color: var(--tox-private-button-primary-enabled-active-background-color);
-    --tox-private-button-primary-enabled-active-text-color: var(--tox-private-button-primary-enabled-text-color);
-  }
+  .tox {
+    /* TODO: Add `--primary` to class name. Currently, we treat primary as base in alloy */
+    .tox-button when (@custom-properties-enabled = true) {
+      /* Base variables */
+      --tox-private-button-primary-background-color: var(--tox-private-color-tint);
+      --tox-private-button-primary-text-color: var(--tox-private-color-white);
+      --tox-private-button-primary-border-color: var(--tox-private-button-primary-background-color);
 
-  /* TODO: Add `--primary` to class name. Currently, we treat primary as base in alloy */
-  .tox-button {
-    background-color: var(--tox-private-button-primary-background-color, @button-background-color);
-    background-image: @button-background-image;
-    background-position: @button-background-position;
-    background-repeat: @button-background-repeat;
-    color: var(--tox-private-button-primary-text-color, @button-text-color);
-    border-color: var(--tox-private-button-primary-border-color, @button-border-color);
-    
-    &[disabled] {
-      background-color: var(--tox-private-button-primary-disabled-background-color, @button-disabled-background-color);
-      background-image: @button-disabled-background-image;
-      border-color: var(--tox-private-button-primary-disabled-border-color, @button-disabled-border-color);
-      color: var(--tox-private-button-primary-disabled-text-color, @button-disabled-text-color);
-      cursor: not-allowed;
+      /* 
+        Button state variables - to be decided if we want them. 
+        If we do: 
+          1. They should inherit from button base variables (as they do now).
+          2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
+          3. In this case it is also possible to skin each state separately. 
+        If we don't: 
+          1. They should be removed. 
+          2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
+          3. In this case it is NOT possible to skin each state separately. 
+      */
+      /* Disabled state */
+      --tox-private-button-primary-disabled-background-color: var(--tox-private-button-primary-background-color);
+      --tox-private-button-primary-disabled-border-color: var(--tox-private-button-primary-border-color);
+      --tox-private-button-primary-disabled-text-color: hsl(from var(--tox-private-button-primary-text-color) h s l / 50%);
+
+      /* Focus state */
+      --tox-private-button-primary-focus-background-color: hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 5));
+      --tox-private-button-primary-focus-border-color: var(--tox-private-button-primary-focus-background-color);
+      --tox-private-button-primary-focus-text-color: var(--tox-private-button-primary-text-color);
+
+      /* Hover state */
+      --tox-private-button-primary-hover-background-color:  hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 5));
+      --tox-private-button-primary-hover-border-color: var(--tox-private-button-primary-hover-background-color);
+      --tox-private-button-primary-hover-text-color: var(--tox-private-button-primary-text-color);
+
+      /* Active state */
+      --tox-private-button-primary-active-background-color:  hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 10));
+      --tox-private-button-primary-active-border-color: var(--tox-private-button-primary-active-background-color);
+      --tox-private-button-primary-active-text-color: var(--tox-private-button-primary-text-color);
+
+      /* Enabled state 
+        Do we use this button as a toggle that can be enabled? 
+        If not - these variables and enabled state styles should be removed
+      */
+      --tox-private-button-primary-enabled-background-color:  hsl(from var(--tox-private-button-primary-background-color) h s calc(l - 10));
+      --tox-private-button-primary-enabled-border-color: var(--tox-private-button-primary-enabled-background-color);
+      --tox-private-button-primary-enabled-text-color: var(--tox-private-button-primary-text-color);
+
+      /* Enabled + focus state */
+      --tox-private-button-primary-enabled-focus-background-color: hsl(from var(--tox-private-button-primary-enabled-background-color) h s calc(l - 5));
+      --tox-private-button-primary-enabled-focus-border-color: var(--tox-private-button-primary-enabled-focus-background-color);
+      --tox-private-button-primary-enabled-focus-text-color: var(--tox-private-button-primary-enabled-text-color);
+
+      /* Enabled + hover state */
+      --tox-private-button-primary-enabled-hover-background-color: hsl(from var(--tox-private-button-primary-enabled-background-color) h s calc(l - 5));
+      --tox-private-button-primary-enabled-hover-border-color: var(--tox-private-button-primary-enabled-hover-background-color);
+      --tox-private-button-primary-enabled-hover-text-color: var(--tox-private-button-primary-enabled-text-color);
+
+      /* Enabled + active state */
+      --tox-private-button-primary-enabled-active-background-color: hsl(from var(--tox-private-button-primary-enabled-background-color) h s calc(l - 10));
+      --tox-private-button-primary-enabled-active-border-color: var(--tox-private-button-primary-enabled-active-background-color);
+      --tox-private-button-primary-enabled-active-text-color: var(--tox-private-button-primary-enabled-text-color);
     }
-    
-    &:focus:not(:disabled) {
-      background-color: var(--tox-private-button-primary-focus-background-color, @button-focus-background-color);
-      border-color: var(--tox-private-button-primary-focus-border-color, @button-focus-border-color);
-      color: var(--tox-private-button-primary-focus-text-color, @button-focus-text-color);
-      background-image: @button-focus-background-image;
-      box-shadow: @button-focus-box-shadow;
-    }
-    
-    &:hover:not(:disabled) {
-      background-color: var(--tox-private-button-primary-hover-background-color, @button-hover-background-color);
-      border-color: var(--tox-private-button-primary-hover-background-color, @button-hover-border-color);
-      color: var(--tox-private-button-primary-hover-text-color, @button-hover-text-color);
-      background-image: @button-hover-background-image;
-      box-shadow: @button-hover-box-shadow;
-    }
-    
-    &:active:not(:disabled) {
-      background-color: var(--tox-private-button-primary-active-background-color, @button-active-background-color);
-      border-color: var(--tox-private-button-primary-active-border-color, @button-active-border-color);
-      color: var(--tox-private-button-primary-active-text-color, @button-active-text-color);
-      background-image: @button-active-background-image;
-      box-shadow: @button-active-box-shadow;
-    }
-    
-    /* Enabled state */
-    &.tox-button--enabled {
-      background-color: var(--tox-private-button-primary-enabled-background-color, @button-enabled-background-color);
-      border-color: var(--tox-private-button-primary-enabled-border-color, @button-enabled-border-color);
-      color: var(--tox-private-button-primary-enabled-text-color, @button-enabled-text-color);
-      background-image: @button-enabled-background-image;
-      box-shadow: @button-enabled-box-shadow;
-      
+
+    /* TODO: Add `--primary` to class name. Currently, we treat primary as base in alloy */
+    .tox-button {
+      background-color: var(--tox-private-button-primary-background-color, @button-background-color);
+      background-image: @button-background-image;
+      background-position: @button-background-position;
+      background-repeat: @button-background-repeat;
+      color: var(--tox-private-button-primary-text-color, @button-text-color);
+      border-color: var(--tox-private-button-primary-border-color, @button-border-color);
+
       &[disabled] {
+        background-color: var(--tox-private-button-primary-disabled-background-color, @button-disabled-background-color);
+        background-image: @button-disabled-background-image;
+        border-color: var(--tox-private-button-primary-disabled-border-color, @button-disabled-border-color);
         color: var(--tox-private-button-primary-disabled-text-color, @button-disabled-text-color);
         cursor: not-allowed;
       }
-      
+
       &:focus:not(:disabled) {
-        background-color: var(--tox-private-button-primary-enabled-focus-background-color, @button-enabled-focus-background-color);
-        border-color: var(--tox-private-button-primary-enabled-focus-border-color, @button-enabled-focus-border-color);
-        color: var(--tox-private-button-primary-enabled-focus-text-color, @button-enabled-focus-text-color);
-        background-image: @button-enabled-focus-background-image;
-        box-shadow: @button-enabled-focus-box-shadow;
+        background-color: var(--tox-private-button-primary-focus-background-color, @button-focus-background-color);
+        border-color: var(--tox-private-button-primary-focus-border-color, @button-focus-border-color);
+        color: var(--tox-private-button-primary-focus-text-color, @button-focus-text-color);
+        background-image: @button-focus-background-image;
+        box-shadow: @button-focus-box-shadow;
       }
-      
+
       &:hover:not(:disabled) {
-        background-color: var(--tox-private-button-primary-enabled-hover-background-color, @button-enabled-hover-background-color);
-        border-color: var(--tox-private-button-primary-enabled-hover-border-color, @button-enabled-hover-border-color);
-        color: var(--tox-private-button-primary-enabled-hover-text-color, @button-enabled-hover-text-color);
-        background-image: @button-enabled-hover-background-image;
-        box-shadow: @button-enabled-hover-box-shadow;
+        background-color: var(--tox-private-button-primary-hover-background-color, @button-hover-background-color);
+        border-color: var(--tox-private-button-primary-hover-background-color, @button-hover-border-color);
+        color: var(--tox-private-button-primary-hover-text-color, @button-hover-text-color);
+        background-image: @button-hover-background-image;
+        box-shadow: @button-hover-box-shadow;
       }
-      
+
       &:active:not(:disabled) {
-        background-color: var(--tox-private-button-primary-enabled-active-background-color, @button-enabled-active-background-color);
-        border-color: var(--tox-private-button-primary-enabled-active-border-color, @button-enabled-active-border-color);
-        color: var(--tox-private-button-primary-enabled-active-text-color, @button-enabled-active-text-color);
-        background-image: @button-enabled-active-background-image;
-        box-shadow: @button-enabled-active-box-shadow;
+        background-color: var(--tox-private-button-primary-active-background-color, @button-active-background-color);
+        border-color: var(--tox-private-button-primary-active-border-color, @button-active-border-color);
+        color: var(--tox-private-button-primary-active-text-color, @button-active-text-color);
+        background-image: @button-active-background-image;
+        box-shadow: @button-active-box-shadow;
+      }
+
+      /* Enabled state */
+      &.tox-button--enabled {
+        background-color: var(--tox-private-button-primary-enabled-background-color, @button-enabled-background-color);
+        border-color: var(--tox-private-button-primary-enabled-border-color, @button-enabled-border-color);
+        color: var(--tox-private-button-primary-enabled-text-color, @button-enabled-text-color);
+        background-image: @button-enabled-background-image;
+        box-shadow: @button-enabled-box-shadow;
+
+        &[disabled] {
+          color: var(--tox-private-button-primary-disabled-text-color, @button-disabled-text-color);
+          cursor: not-allowed;
+        }
+
+        &:focus:not(:disabled) {
+          background-color: var(--tox-private-button-primary-enabled-focus-background-color, @button-enabled-focus-background-color);
+          border-color: var(--tox-private-button-primary-enabled-focus-border-color, @button-enabled-focus-border-color);
+          color: var(--tox-private-button-primary-enabled-focus-text-color, @button-enabled-focus-text-color);
+          background-image: @button-enabled-focus-background-image;
+          box-shadow: @button-enabled-focus-box-shadow;
+        }
+
+        &:hover:not(:disabled) {
+          background-color: var(--tox-private-button-primary-enabled-hover-background-color, @button-enabled-hover-background-color);
+          border-color: var(--tox-private-button-primary-enabled-hover-border-color, @button-enabled-hover-border-color);
+          color: var(--tox-private-button-primary-enabled-hover-text-color, @button-enabled-hover-text-color);
+          background-image: @button-enabled-hover-background-image;
+          box-shadow: @button-enabled-hover-box-shadow;
+        }
+
+        &:active:not(:disabled) {
+          background-color: var(--tox-private-button-primary-enabled-active-background-color, @button-enabled-active-background-color);
+          border-color: var(--tox-private-button-primary-enabled-active-border-color, @button-enabled-active-border-color);
+          color: var(--tox-private-button-primary-enabled-active-text-color, @button-enabled-active-text-color);
+          background-image: @button-enabled-active-background-image;
+          box-shadow: @button-enabled-active-box-shadow;
+        }
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
@@ -5,72 +5,74 @@
 //
 
 @layer tox-atomic-component {
-  .tox-button--secondary--outline when (@custom-properties-enabled = true) {
-    // Secondary outlined button variant only styles the text and border color as the background is transparent by design
-    --tox-private-button-secondary-outline-text-color: var(--tox-private-text-color);
-    --tox-private-button-secondary-outline-border-color: light-dark(
-      hsl(from var(--tox-private-background-color) h s calc(l - 6)), 
-      hsl(from var(--tox-private-background-color) h s calc(l - -15))); // calc(l + 15) is valid css but less compiler perserve new line characters when + is used here. This behavior breaks our minification. 
-    
-    /* 
-      Button state variables - to be decided if we want them. 
-      If we do: 
-        1. They should inherit from button base variables (as they do now).
-        2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
-        3. In this case it is also possible to skin each state separately. 
-      If we don't: 
-        1. They should be removed. 
-        2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
-        3. In this case it is NOT possible to skin each state separately. 
-    */
-    /* Disabled state */
-    --tox-private-button-secondary-outline-disabled-background-color: transparent;
-    --tox-private-button-secondary-outline-disabled-border-color: var(--tox-private-button-secondary-outline-border-color);
-    --tox-private-button-secondary-outline-disabled-text-color: hsl(from var(--tox-private-button-secondary-outline-text-color) h s l / 50%);
-    
-    /* Focus state */
-    --tox-private-button-secondary-outline-focus-background-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
-    --tox-private-button-secondary-outline-focus-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
-    --tox-private-button-secondary-outline-focus-text-color: var(--tox-private-button-secondary-outline-text-color);
-    
-    /* Hover state */
-    --tox-private-button-secondary-outline-hover-background-color: var(--tox-private-button-secondary-outline-border-color);
-    --tox-private-button-secondary-outline-hover-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
-    --tox-private-button-secondary-outline-hover-text-color: var(--tox-private-button-secondary-outline-text-color);
-    
-    /* Active state */
-    --tox-private-button-secondary-outline-active-background-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
-    --tox-private-button-secondary-outline-active-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
-    --tox-private-button-secondary-outline-active-text-color: var(--tox-private-button-secondary-outline-text-color);
-  } 
+  .tox {
+    .tox-button--secondary--outline when (@custom-properties-enabled = true) {
+      // Secondary outlined button variant only styles the text and border color as the background is transparent by design
+      --tox-private-button-secondary-outline-text-color: var(--tox-private-text-color);
+      --tox-private-button-secondary-outline-border-color: light-dark(
+        hsl(from var(--tox-private-background-color) h s calc(l - 6)), 
+        hsl(from var(--tox-private-background-color) h s calc(l - -15))); // calc(l + 15) is valid css but less compiler perserve new line characters when + is used here. This behavior breaks our minification. 
 
-  .tox-button--secondary--outline {
-    background-color: transparent;
-    border-color: var(--tox-private-button-secondary-outline-border-color, @button-secondary-background-color);
-    color: var(--tox-private-button-secondary-outline-text-color, @text-color);
+      /* 
+        Button state variables - to be decided if we want them. 
+        If we do: 
+          1. They should inherit from button base variables (as they do now).
+          2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
+          3. In this case it is also possible to skin each state separately. 
+        If we don't: 
+          1. They should be removed. 
+          2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
+          3. In this case it is NOT possible to skin each state separately. 
+      */
+      /* Disabled state */
+      --tox-private-button-secondary-outline-disabled-background-color: transparent;
+      --tox-private-button-secondary-outline-disabled-border-color: var(--tox-private-button-secondary-outline-border-color);
+      --tox-private-button-secondary-outline-disabled-text-color: hsl(from var(--tox-private-button-secondary-outline-text-color) h s l / 50%);
 
-    &:focus:not(:disabled) {
-      background-color: var(--tox-private-button-secondary-outline-focus-background-color, @button-secondary-hover-background-color);
-      border-color: var(--tox-private-button-secondary-outline-focus-border-color, @button-secondary-hover-background-color);
-      color: var(--tox-private-button-secondary-outline-focus-text-color, @text-color);
-    }
-    
-    &:hover:not(:disabled) {
-      background-color: var(--tox-private-button-secondary-outline-hover-background-color, @button-secondary-background-color);
-      border-color: var(--tox-private-button-secondary-outline-hover-border-color, @button-secondary-hover-background-color);
-      color: var(--tox-private-button-secondary-outline-hover-text-color, @text-color);
-    }
+      /* Focus state */
+      --tox-private-button-secondary-outline-focus-background-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
+      --tox-private-button-secondary-outline-focus-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
+      --tox-private-button-secondary-outline-focus-text-color: var(--tox-private-button-secondary-outline-text-color);
 
-    &:active:not(:disabled) {
-      background-color: var(--tox-private-button-secondary-outline-active-background-color, @button-secondary-hover-background-color);
-      border-color: var(--tox-private-button-secondary-outline-active-border-color, @button-secondary-hover-background-color);
-      color: var(--tox-private-button-secondary-outline-active-text-color, @text-color);
-    }
+      /* Hover state */
+      --tox-private-button-secondary-outline-hover-background-color: var(--tox-private-button-secondary-outline-border-color);
+      --tox-private-button-secondary-outline-hover-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
+      --tox-private-button-secondary-outline-hover-text-color: var(--tox-private-button-secondary-outline-text-color);
 
-    &[disabled] {
-      background-color: var(--tox-private-button-secondary-outline-disabled-background-color, transparent);
-      border-color: var(--tox-private-button-secondary-outline-disabled-border-color, @button-secondary-background-color);
-      color: var(--tox-private-button-secondary-outline-disabled-text-color, @button-secondary-disabled-text-color);
+      /* Active state */
+      --tox-private-button-secondary-outline-active-background-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
+      --tox-private-button-secondary-outline-active-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
+      --tox-private-button-secondary-outline-active-text-color: var(--tox-private-button-secondary-outline-text-color);
+    } 
+
+    .tox-button--secondary--outline {
+      background-color: transparent;
+      border-color: var(--tox-private-button-secondary-outline-border-color, @button-secondary-background-color);
+      color: var(--tox-private-button-secondary-outline-text-color, @text-color);
+
+      &:focus:not(:disabled) {
+        background-color: var(--tox-private-button-secondary-outline-focus-background-color, @button-secondary-hover-background-color);
+        border-color: var(--tox-private-button-secondary-outline-focus-border-color, @button-secondary-hover-background-color);
+        color: var(--tox-private-button-secondary-outline-focus-text-color, @text-color);
+      }
+
+      &:hover:not(:disabled) {
+        background-color: var(--tox-private-button-secondary-outline-hover-background-color, @button-secondary-background-color);
+        border-color: var(--tox-private-button-secondary-outline-hover-border-color, @button-secondary-hover-background-color);
+        color: var(--tox-private-button-secondary-outline-hover-text-color, @text-color);
+      }
+
+      &:active:not(:disabled) {
+        background-color: var(--tox-private-button-secondary-outline-active-background-color, @button-secondary-hover-background-color);
+        border-color: var(--tox-private-button-secondary-outline-active-border-color, @button-secondary-hover-background-color);
+        color: var(--tox-private-button-secondary-outline-active-text-color, @text-color);
+      }
+
+      &[disabled] {
+        background-color: var(--tox-private-button-secondary-outline-disabled-background-color, transparent);
+        border-color: var(--tox-private-button-secondary-outline-disabled-border-color, @button-secondary-background-color);
+        color: var(--tox-private-button-secondary-outline-disabled-text-color, @button-secondary-disabled-text-color);
+      }
     }
   }
 }

--- a/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
@@ -1,5 +1,5 @@
 //
-// Secondary outlined button - varinat of the button
+// Secondary outlined button - variant of the button
 // Variat class `tox-button--secondary--outline` should be added next to the base `tox-button` class.
 // For base button styles see button.less
 //

--- a/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
@@ -1,6 +1,6 @@
 //
 // Secondary outlined button - variant of the button
-// Variat class `tox-button--secondary--outline` should be added next to the base `tox-button` class.
+// Variant class `tox-button--secondary--outline` should be added next to the base `tox-button` class.
 // For base button styles see button.less
 //
 

--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -1,5 +1,5 @@
 //
-// Secondary button - varinat of the button
+// Secondary button - variant of the button
 // Variat class `tox-button--secondary` should be added next to the base `tox-button` class.
 // For base button styles see button.less
 //

--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -72,165 +72,167 @@
 @button-secondary-enabled-active-text-color: @button-secondary-enabled-text-color;
 
 @layer tox-atomic-component {
-  .tox-button--secondary when (@custom-properties-enabled = true) {
-    // Base variables
-    --tox-private-button-secondary-background-color: light-dark(
-      hsl(from var(--tox-private-background-color) h s calc(l - 6)), 
-      hsl(from var(--tox-private-background-color) h s calc(l - -15))); // calc(l + 15) is valid css but less compiler perserve new line characters when + is used here. This behavior breaks our minification. 
+  .tox {
+    .tox-button--secondary when (@custom-properties-enabled = true) {
+      // Base variables
+      --tox-private-button-secondary-background-color: light-dark(
+        hsl(from var(--tox-private-background-color) h s calc(l - 6)), 
+        hsl(from var(--tox-private-background-color) h s calc(l - -15))); // calc(l + 15) is valid css but less compiler perserve new line characters when + is used here. This behavior breaks our minification. 
 
-    --tox-private-button-secondary-text-color: var(--tox-private-text-color);
-    --tox-private-button-secondary-border-color: var(--tox-private-button-secondary-background-color);
-    
-    /* 
-      Button state variables - to be decided if we want them. 
-      If we do: 
-        1. They should inherit from button base variables (as they do now).
-        2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
-        3. In this case it is also possible to skin each state separately. 
-      If we don't: 
-        1. They should be removed. 
-        2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
-        3. In this case it is NOT possible to skin each state separately. 
-    */
-    /* Disabled state */
-    --tox-private-button-secondary-disabled-background-color: var(--tox-private-button-secondary-background-color);
-    --tox-private-button-secondary-disabled-border-color: var(--tox-private-button-secondary-border-color);
-    --tox-private-button-secondary-disabled-text-color: hsl(from var(--tox-private-button-secondary-text-color) h s l / 50%);
-    
-    /* Focus state */
-    --tox-private-button-secondary-focus-background-color: hsl(from var(--tox-private-button-secondary-background-color) h s calc(l - 5));
-    --tox-private-button-secondary-focus-border-color: var(--tox-private-button-secondary-focus-background-color);
-    --tox-private-button-secondary-focus-text-color: var(--tox-private-button-secondary-text-color);
-    
-    /* Hover state */
-    --tox-private-button-secondary-hover-background-color:  hsl(from var(--tox-private-button-secondary-background-color) h s calc(l - 5));
-    --tox-private-button-secondary-hover-border-color: var(--tox-private-button-secondary-hover-background-color);
-    --tox-private-button-secondary-hover-text-color: var(--tox-private-button-secondary-text-color);
-    
-    /* Active state */
-    --tox-private-button-secondary-active-background-color:  hsl(from var(--tox-private-button-secondary-background-color) h s calc(l - 10));
-    --tox-private-button-secondary-active-border-color: var(--tox-private-button-secondary-active-background-color);
-    --tox-private-button-secondary-active-text-color: var(--tox-private-button-secondary-text-color);
-    
-    /* Enabled state 
-      Do we use this button as a toggle that can be enabled? 
-      If not - these variables and enabled state styles should be removed
-    */
-    --tox-private-button-secondary-enabled-background-color: light-dark(
-      mix(darken(@background-color, 6%), @color-tint, 70%),
-      mix(lighten(@background-color, 15%), @color-tint, 70%)
-    );
+      --tox-private-button-secondary-text-color: var(--tox-private-text-color);
+      --tox-private-button-secondary-border-color: var(--tox-private-button-secondary-background-color);
 
-    --tox-private-button-secondary-enabled-border-color: var(--tox-private-button-secondary-enabled-background-color);
-    --tox-private-button-secondary-enabled-text-color: var(--tox-private-button-secondary-text-color);
-    
-    /* Enabled + focus state */
-    --tox-private-button-secondary-enabled-focus-background-color: hsl(from var(--tox-private-button-secondary-enabled-background-color) h s calc(l - 5));
-    --tox-private-button-secondary-enabled-focus-border-color: var(--tox-private-button-secondary-enabled-focus-background-color);
-    --tox-private-button-secondary-enabled-focus-text-color: var(--tox-private-button-secondary-enabled-text-color);
-    
-    /* Enabled + hover state */
-    --tox-private-button-secondary-enabled-hover-background-color: hsl(from var(--tox-private-button-secondary-enabled-background-color) h s calc(l - 5));
-    --tox-private-button-secondary-enabled-hover-border-color: var(--tox-private-button-secondary-enabled-hover-background-color);
-    --tox-private-button-secondary-enabled-hover-text-color: var(--tox-private-button-secondary-enabled-text-color);
-    
-    /* Enabled + active state */
-    --tox-private-button-secondary-enabled-active-background-color: hsl(from var(--tox-private-button-secondary-enabled-background-color) h s calc(l - 10));
-    --tox-private-button-secondary-enabled-active-border-color: var(--tox-private-button-secondary-enabled-active-background-color);
-    --tox-private-button-secondary-enabled-active-text-color: var(--tox-private-button-secondary-enabled-text-color);
-  } 
+      /* 
+        Button state variables - to be decided if we want them. 
+        If we do: 
+          1. They should inherit from button base variables (as they do now).
+          2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
+          3. In this case it is also possible to skin each state separately. 
+        If we don't: 
+          1. They should be removed. 
+          2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
+          3. In this case it is NOT possible to skin each state separately. 
+      */
+      /* Disabled state */
+      --tox-private-button-secondary-disabled-background-color: var(--tox-private-button-secondary-background-color);
+      --tox-private-button-secondary-disabled-border-color: var(--tox-private-button-secondary-border-color);
+      --tox-private-button-secondary-disabled-text-color: hsl(from var(--tox-private-button-secondary-text-color) h s l / 50%);
 
-  .tox-button--secondary {
-    background-color: var(--tox-private-button-secondary-background-color, @button-secondary-background-color);
-    border-color: var(--tox-private-button-secondary-border-color, @button-secondary-border-color);
-    color: var(--tox-private-button-secondary-text-color, @button-secondary-text-color);
-    
-    // TODO: remove this styles as this should be covered by button.less. 
-    // Secondary variant should only change colors (background, text and border)
-    // Currently these variables inherit from base button variables (in button.less)
-    border-style: @button-secondary-border-style;
-    border-width: @button-secondary-border-width;
-    background-image: @button-secondary-background-image;
-    background-position: @button-secondary-background-position;
-    background-repeat: @button-secondary-background-repeat;
-    border-radius: @button-secondary-border-radius;
-    box-shadow: @button-secondary-box-shadow;
-    font-size: @button-secondary-font-size;
-    font-style: @button-secondary-font-style;
-    font-weight: @button-secondary-font-weight;
-    letter-spacing: @button-secondary-letter-spacing;
-    outline: @button-secondary-outline;
-    padding: @button-padding-y @button-padding-x;
-    text-decoration: @button-secondary-text-decoration;
-    text-transform: @button-secondary-text-transform;
+      /* Focus state */
+      --tox-private-button-secondary-focus-background-color: hsl(from var(--tox-private-button-secondary-background-color) h s calc(l - 5));
+      --tox-private-button-secondary-focus-border-color: var(--tox-private-button-secondary-focus-background-color);
+      --tox-private-button-secondary-focus-text-color: var(--tox-private-button-secondary-text-color);
 
-    &[disabled] {
-      background-color: var(--tox-private-button-secondary-disabled-background-color, @button-secondary-disabled-background-color);
-      background-image: @button-secondary-disabled-background-image;
-      border-color: var(--tox-private-button-secondary-disabled-border-color, @button-secondary-disabled-border-color);
-      color: var(--tox-private-button-secondary-disabled-text-color, @button-secondary-disabled-text-color);
-      cursor: not-allowed;
-    }
-    
-    &:focus:not(:disabled) {
-      background-color: var(--tox-private-button-secondary-focus-background-color, @button-secondary-focus-background-color);
-      border-color: var(--tox-private-button-secondary-focus-border-color, @button-secondary-focus-border-color);
-      color: var(--tox-private-button-secondary-focus-text-color, @button-secondary-focus-text-color);
-      background-image: @button-secondary-focus-background-image;
-      box-shadow: @button-secondary-focus-box-shadow;
-    }
-    
-    &:hover:not(:disabled) {
-      background-color: var(--tox-private-button-secondary-hover-background-color, @button-secondary-hover-background-color);
-      border-color: var(--tox-private-button-secondary-hover-border-color, @button-secondary-hover-border-color);
-      color: var(--tox-private-button-secondary-hover-text-color, @button-secondary-hover-text-color);
-      background-image: @button-secondary-hover-background-image;
-      box-shadow: @button-secondary-hover-box-shadow;
-    }
-    
-    &:active:not(:disabled) {
-      background-color: var(--tox-private-button-secondary-active-background-color, @button-secondary-active-background-color);
-      border-color: var(--tox-private-button-secondary-active-border-color, @button-secondary-active-border-color);
-      color: var(--tox-private-button-secondary-active-text-color, @button-secondary-active-text-color);
-      background-image: @button-secondary-active-background-image;
-      box-shadow: @button-secondary-active-box-shadow;
-    }
-    
-    /* Enabled state */
-    &.tox-button--enabled {
-      background-color: var(--tox-private-button-secondary-enabled-background-color, @button-secondary-enabled-background-color);
-      border-color: var(--tox-private-button-secondary-enabled-border-color, @button-secondary-enabled-border-color);
-      color: var(--tox-private-button-secondary-enabled-text-color, @button-secondary-enabled-text-color);
-      background-image: @button-secondary-enabled-background-image;
-      box-shadow: @button-secondary-enabled-box-shadow;
-      
+      /* Hover state */
+      --tox-private-button-secondary-hover-background-color:  hsl(from var(--tox-private-button-secondary-background-color) h s calc(l - 5));
+      --tox-private-button-secondary-hover-border-color: var(--tox-private-button-secondary-hover-background-color);
+      --tox-private-button-secondary-hover-text-color: var(--tox-private-button-secondary-text-color);
+
+      /* Active state */
+      --tox-private-button-secondary-active-background-color:  hsl(from var(--tox-private-button-secondary-background-color) h s calc(l - 10));
+      --tox-private-button-secondary-active-border-color: var(--tox-private-button-secondary-active-background-color);
+      --tox-private-button-secondary-active-text-color: var(--tox-private-button-secondary-text-color);
+
+      /* Enabled state 
+        Do we use this button as a toggle that can be enabled? 
+        If not - these variables and enabled state styles should be removed
+      */
+      --tox-private-button-secondary-enabled-background-color: light-dark(
+        mix(darken(@background-color, 6%), @color-tint, 70%),
+        mix(lighten(@background-color, 15%), @color-tint, 70%)
+      );
+
+      --tox-private-button-secondary-enabled-border-color: var(--tox-private-button-secondary-enabled-background-color);
+      --tox-private-button-secondary-enabled-text-color: var(--tox-private-button-secondary-text-color);
+
+      /* Enabled + focus state */
+      --tox-private-button-secondary-enabled-focus-background-color: hsl(from var(--tox-private-button-secondary-enabled-background-color) h s calc(l - 5));
+      --tox-private-button-secondary-enabled-focus-border-color: var(--tox-private-button-secondary-enabled-focus-background-color);
+      --tox-private-button-secondary-enabled-focus-text-color: var(--tox-private-button-secondary-enabled-text-color);
+
+      /* Enabled + hover state */
+      --tox-private-button-secondary-enabled-hover-background-color: hsl(from var(--tox-private-button-secondary-enabled-background-color) h s calc(l - 5));
+      --tox-private-button-secondary-enabled-hover-border-color: var(--tox-private-button-secondary-enabled-hover-background-color);
+      --tox-private-button-secondary-enabled-hover-text-color: var(--tox-private-button-secondary-enabled-text-color);
+
+      /* Enabled + active state */
+      --tox-private-button-secondary-enabled-active-background-color: hsl(from var(--tox-private-button-secondary-enabled-background-color) h s calc(l - 10));
+      --tox-private-button-secondary-enabled-active-border-color: var(--tox-private-button-secondary-enabled-active-background-color);
+      --tox-private-button-secondary-enabled-active-text-color: var(--tox-private-button-secondary-enabled-text-color);
+    } 
+
+    .tox-button--secondary {
+      background-color: var(--tox-private-button-secondary-background-color, @button-secondary-background-color);
+      border-color: var(--tox-private-button-secondary-border-color, @button-secondary-border-color);
+      color: var(--tox-private-button-secondary-text-color, @button-secondary-text-color);
+
+      // TODO: remove this styles as this should be covered by button.less. 
+      // Secondary variant should only change colors (background, text and border)
+      // Currently these variables inherit from base button variables (in button.less)
+      border-style: @button-secondary-border-style;
+      border-width: @button-secondary-border-width;
+      background-image: @button-secondary-background-image;
+      background-position: @button-secondary-background-position;
+      background-repeat: @button-secondary-background-repeat;
+      border-radius: @button-secondary-border-radius;
+      box-shadow: @button-secondary-box-shadow;
+      font-size: @button-secondary-font-size;
+      font-style: @button-secondary-font-style;
+      font-weight: @button-secondary-font-weight;
+      letter-spacing: @button-secondary-letter-spacing;
+      outline: @button-secondary-outline;
+      padding: @button-padding-y @button-padding-x;
+      text-decoration: @button-secondary-text-decoration;
+      text-transform: @button-secondary-text-transform;
+
       &[disabled] {
+        background-color: var(--tox-private-button-secondary-disabled-background-color, @button-secondary-disabled-background-color);
+        background-image: @button-secondary-disabled-background-image;
+        border-color: var(--tox-private-button-secondary-disabled-border-color, @button-secondary-disabled-border-color);
         color: var(--tox-private-button-secondary-disabled-text-color, @button-secondary-disabled-text-color);
         cursor: not-allowed;
       }
-      
+
       &:focus:not(:disabled) {
-        background-color: var(--tox-private-button-secondary-enabled-focus-background-color, @button-secondary-enabled-focus-background-color);
-        border-color: var(--tox-private-button-secondary-enabled-focus-border-color, @button-secondary-enabled-focus-border-color);
-        color: var(--tox-private-button-secondary-enabled-focus-text-color, @button-secondary-enabled-focus-text-color);
-        background-image: @button-secondary-enabled-focus-background-image;
-        box-shadow: @button-secondary-enabled-focus-box-shadow;
+        background-color: var(--tox-private-button-secondary-focus-background-color, @button-secondary-focus-background-color);
+        border-color: var(--tox-private-button-secondary-focus-border-color, @button-secondary-focus-border-color);
+        color: var(--tox-private-button-secondary-focus-text-color, @button-secondary-focus-text-color);
+        background-image: @button-secondary-focus-background-image;
+        box-shadow: @button-secondary-focus-box-shadow;
       }
-      
+
       &:hover:not(:disabled) {
-        background-color: var(--tox-private-button-secondary-enabled-hover-background-color, @button-secondary-enabled-hover-background-color);
-        border-color: var(--tox-private-button-secondary-enabled-hover-border-color, @button-secondary-enabled-hover-border-color);
-        color: var(--tox-private-button-secondary-enabled-hover-text-color, @button-secondary-enabled-hover-text-color);
-        background-image: @button-secondary-enabled-hover-background-image;
-        box-shadow: @button-secondary-enabled-hover-box-shadow;
+        background-color: var(--tox-private-button-secondary-hover-background-color, @button-secondary-hover-background-color);
+        border-color: var(--tox-private-button-secondary-hover-border-color, @button-secondary-hover-border-color);
+        color: var(--tox-private-button-secondary-hover-text-color, @button-secondary-hover-text-color);
+        background-image: @button-secondary-hover-background-image;
+        box-shadow: @button-secondary-hover-box-shadow;
       }
-      
+
       &:active:not(:disabled) {
-        background-color: var(--tox-private-button-secondary-enabled-active-background-color, @button-secondary-enabled-active-background-color);
-        border-color: var(--tox-private-button-secondary-enabled-active-border-color, @button-secondary-enabled-active-border-color);
-        color: var(--tox-private-button-secondary-enabled-active-text-color, @button-secondary-enabled-active-text-color);
-        background-image: @button-secondary-enabled-active-background-image;
-        box-shadow: @button-secondary-enabled-active-box-shadow;
+        background-color: var(--tox-private-button-secondary-active-background-color, @button-secondary-active-background-color);
+        border-color: var(--tox-private-button-secondary-active-border-color, @button-secondary-active-border-color);
+        color: var(--tox-private-button-secondary-active-text-color, @button-secondary-active-text-color);
+        background-image: @button-secondary-active-background-image;
+        box-shadow: @button-secondary-active-box-shadow;
+      }
+
+      /* Enabled state */
+      &.tox-button--enabled {
+        background-color: var(--tox-private-button-secondary-enabled-background-color, @button-secondary-enabled-background-color);
+        border-color: var(--tox-private-button-secondary-enabled-border-color, @button-secondary-enabled-border-color);
+        color: var(--tox-private-button-secondary-enabled-text-color, @button-secondary-enabled-text-color);
+        background-image: @button-secondary-enabled-background-image;
+        box-shadow: @button-secondary-enabled-box-shadow;
+
+        &[disabled] {
+          color: var(--tox-private-button-secondary-disabled-text-color, @button-secondary-disabled-text-color);
+          cursor: not-allowed;
+        }
+
+        &:focus:not(:disabled) {
+          background-color: var(--tox-private-button-secondary-enabled-focus-background-color, @button-secondary-enabled-focus-background-color);
+          border-color: var(--tox-private-button-secondary-enabled-focus-border-color, @button-secondary-enabled-focus-border-color);
+          color: var(--tox-private-button-secondary-enabled-focus-text-color, @button-secondary-enabled-focus-text-color);
+          background-image: @button-secondary-enabled-focus-background-image;
+          box-shadow: @button-secondary-enabled-focus-box-shadow;
+        }
+
+        &:hover:not(:disabled) {
+          background-color: var(--tox-private-button-secondary-enabled-hover-background-color, @button-secondary-enabled-hover-background-color);
+          border-color: var(--tox-private-button-secondary-enabled-hover-border-color, @button-secondary-enabled-hover-border-color);
+          color: var(--tox-private-button-secondary-enabled-hover-text-color, @button-secondary-enabled-hover-text-color);
+          background-image: @button-secondary-enabled-hover-background-image;
+          box-shadow: @button-secondary-enabled-hover-box-shadow;
+        }
+
+        &:active:not(:disabled) {
+          background-color: var(--tox-private-button-secondary-enabled-active-background-color, @button-secondary-enabled-active-background-color);
+          border-color: var(--tox-private-button-secondary-enabled-active-border-color, @button-secondary-enabled-active-border-color);
+          color: var(--tox-private-button-secondary-enabled-active-text-color, @button-secondary-enabled-active-text-color);
+          background-image: @button-secondary-enabled-active-background-image;
+          box-shadow: @button-secondary-enabled-active-box-shadow;
+        }
       }
     }
   }

--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -1,6 +1,6 @@
 //
 // Secondary button - variant of the button
-// Variat class `tox-button--secondary` should be added next to the base `tox-button` class.
+// Variant class `tox-button--secondary` should be added next to the base `tox-button` class.
 // For base button styles see button.less
 //
 

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -27,95 +27,97 @@
 @button-icon-error-color: @color-error;
 
 @layer tox-atomic-component {
-  .tox-button when (@custom-properties-enabled = true) {
-    --tox-private-button-border-width: 1px;
-    --tox-private-button-border-style: solid;
-
-    --tox-private-button-padding-x: var(--tox-private-pad-md);
-    --tox-private-button-padding-y: var(--tox-private-pad-xs);
+  .tox {
+    .tox-button when (@custom-properties-enabled = true) {
+      --tox-private-button-border-width: 1px;
+      --tox-private-button-border-style: solid;
     
-    --tox-private-button-font-size: var(--tox-private-font-size-sm);
-    --tox-private-button-font-style: normal;
-    --tox-private-button-font-weight: var(--tox-private-font-weight-bold); 
-    --tox-private-button-focus-outline: inset 0 0 0 1px var(--tox-private-color-white), 0 0 0 2px var(--tox-private-color-tint);
-  }
-  
-  .tox-button {  
-    border-width: var(--tox-private-button-border-width, @button-border-width);
-    border-style: var(--tox-private-button-border-style, @button-border-style);
-    border-radius: var(--tox-private-control-border-radius, @button-border-radius);
-    font-family: var(--tox-private-font-stack, @button-font-family);
-    font-size: var(--tox-private-button-font-size, @button-font-size);
-    font-style: var(--tox-private-button-font-style, @button-font-style);
-    font-weight: var(--tox-private-button-font-weight, @button-font-weight);
-    line-height: var(--tox-private-control-line-height, @button-line-height);
-    padding: var(--tox-private-button-padding-y, @button-padding-y) var(--tox-private-button-padding-x, @button-padding-x);
-    text-align: @button-text-align;
-    text-decoration: @button-text-decoration;
-    text-transform: @button-text-transform;
-    letter-spacing: @button-letter-spacing;
-    box-shadow: @button-box-shadow;
-    box-sizing: border-box;
-    cursor: pointer;
-    outline: none;
-    position: relative;
-    white-space: nowrap;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    gap: 2px;
-
-    // The before element is used for visible focus outline. 
-    // The same result can be achieved with box-shadow on the button element.
-    // Using the button element instead of before would mean removing following variables (currently all equal to box-shadow: none)  
-    //  1. @button-box-shadow
-    //  2. All of the box-shadow raletad variables for different states (for example: @button-disabled-box-shadow, @button-hover-box-shadow) 
-    // The before element can be removed if we decide to use box-shadow on button element.
-    &::before {
-      border-radius: var(--tox-private-control-border-radius, @button-border-radius);
-      bottom: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
-      box-shadow: var(--tox-private-button-focus-outline, @button-focus-outline);
-      content: '';
-      left: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
-      opacity: 0;
-      pointer-events: none;
-      position: absolute;
-      right: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
-      top: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
+      --tox-private-button-padding-x: var(--tox-private-pad-md);
+      --tox-private-button-padding-y: var(--tox-private-pad-xs);
+      
+      --tox-private-button-font-size: var(--tox-private-font-size-sm);
+      --tox-private-button-font-style: normal;
+      --tox-private-button-font-weight: var(--tox-private-font-weight-bold); 
+      --tox-private-button-focus-outline: inset 0 0 0 1px var(--tox-private-color-white), 0 0 0 2px var(--tox-private-color-tint);
     }
     
-    &:focus:not(:disabled) {
-      background-color: var(--tox-private-button-focus-background-color, @button-focus-background-color);
-      background-image: @button-focus-background-image;
-      border-color: var(--tox-private-button-focus-border-color, @button-focus-border-color);
-      box-shadow: var(--tox-private-button-focus-box-shadow, @button-focus-box-shadow);
-      color: var(--tox-private-button-focus-text-color, @button-focus-text-color);
-      
+    .tox-button {  
+      border-width: var(--tox-private-button-border-width, @button-border-width);
+      border-style: var(--tox-private-button-border-style, @button-border-style);
+      border-radius: var(--tox-private-control-border-radius, @button-border-radius);
+      font-family: var(--tox-private-font-stack, @button-font-family);
+      font-size: var(--tox-private-button-font-size, @button-font-size);
+      font-style: var(--tox-private-button-font-style, @button-font-style);
+      font-weight: var(--tox-private-button-font-weight, @button-font-weight);
+      line-height: var(--tox-private-control-line-height, @button-line-height);
+      padding: var(--tox-private-button-padding-y, @button-padding-y) var(--tox-private-button-padding-x, @button-padding-x);
+      text-align: @button-text-align;
+      text-decoration: @button-text-decoration;
+      text-transform: @button-text-transform;
+      letter-spacing: @button-letter-spacing;
+      box-shadow: @button-box-shadow;
+      box-sizing: border-box;
+      cursor: pointer;
+      outline: none;
+      position: relative;
+      white-space: nowrap;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      gap: 2px;
+    
+      // The before element is used for visible focus outline. 
+      // The same result can be achieved with box-shadow on the button element.
+      // Using the button element instead of before would mean removing following variables (currently all equal to box-shadow: none)  
+      //  1. @button-box-shadow
+      //  2. All of the box-shadow raletad variables for different states (for example: @button-disabled-box-shadow, @button-hover-box-shadow) 
+      // The before element can be removed if we decide to use box-shadow on button element.
       &::before {
-        opacity: 1;
+        border-radius: var(--tox-private-control-border-radius, @button-border-radius);
+        bottom: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
+        box-shadow: var(--tox-private-button-focus-outline, @button-focus-outline);
+        content: '';
+        left: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
+        opacity: 0;
+        pointer-events: none;
+        position: absolute;
+        right: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
+        top: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
+      }
+      
+      &:focus:not(:disabled) {
+        background-color: var(--tox-private-button-focus-background-color, @button-focus-background-color);
+        background-image: @button-focus-background-image;
+        border-color: var(--tox-private-button-focus-border-color, @button-focus-border-color);
+        box-shadow: var(--tox-private-button-focus-box-shadow, @button-focus-box-shadow);
+        color: var(--tox-private-button-focus-text-color, @button-focus-text-color);
+        
+        &::before {
+          opacity: 1;
+        }
+      }
+    
+      &.tox-button--icon, &:has(.tox-icon:only-child) {    
+        padding: @button-padding-y; // Use padding-y as horizontal padding to make icon button square-ish
+      }
+    
+      .tox-icon svg {
+        display: block;
+        fill: currentColor;
+      }
+    
+      .tox-icon.tox-icon--success svg {
+        fill: var(--tox-private-color-success, @button-icon-success-color);
+      }
+    
+      .tox-icon.tox-icon--error svg {
+        fill: var(--tox-private-color-error, @button-icon-error-color)
       }
     }
-
-    &.tox-button--icon, &:has(.tox-icon:only-child) {    
-      padding: @button-padding-y; // Use padding-y as horizontal padding to make icon button square-ish
+    
+    .tox-button--stretch {
+      width: 100%;
     }
-
-    .tox-icon svg {
-      display: block;
-      fill: currentColor;
-    }
-
-    .tox-icon.tox-icon--success svg {
-      fill: var(--tox-private-color-success, @button-icon-success-color);
-    }
-
-    .tox-icon.tox-icon--error svg {
-      fill: var(--tox-private-color-error, @button-icon-error-color)
-    }
-  }
-  
-  .tox-button--stretch {
-    width: 100%;
   }
 }
 

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -1,7 +1,7 @@
 /*
   Button - base button styles and variables. 
   These affect each button variant - primary, secondary, secondary-outlined and naked. 
-  Variat classes should be added next to the base `tox-button` class.
+  Variant classes should be added next to the base `tox-button` class.
 */
 
 
@@ -31,16 +31,16 @@
     .tox-button when (@custom-properties-enabled = true) {
       --tox-private-button-border-width: 1px;
       --tox-private-button-border-style: solid;
-    
+
       --tox-private-button-padding-x: var(--tox-private-pad-md);
       --tox-private-button-padding-y: var(--tox-private-pad-xs);
-      
+
       --tox-private-button-font-size: var(--tox-private-font-size-sm);
       --tox-private-button-font-style: normal;
       --tox-private-button-font-weight: var(--tox-private-font-weight-bold); 
       --tox-private-button-focus-outline: inset 0 0 0 1px var(--tox-private-color-white), 0 0 0 2px var(--tox-private-color-tint);
     }
-    
+
     .tox-button {  
       border-width: var(--tox-private-button-border-width, @button-border-width);
       border-style: var(--tox-private-button-border-style, @button-border-style);
@@ -65,7 +65,7 @@
       justify-content: center;
       align-items: center;
       gap: 2px;
-    
+
       // The before element is used for visible focus outline. 
       // The same result can be achieved with box-shadow on the button element.
       // Using the button element instead of before would mean removing following variables (currently all equal to box-shadow: none)  
@@ -84,37 +84,37 @@
         right: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
         top: calc(-1 * var(--tox-private-button-border-width, @button-border-width));
       }
-      
+
       &:focus:not(:disabled) {
         background-color: var(--tox-private-button-focus-background-color, @button-focus-background-color);
         background-image: @button-focus-background-image;
         border-color: var(--tox-private-button-focus-border-color, @button-focus-border-color);
         box-shadow: var(--tox-private-button-focus-box-shadow, @button-focus-box-shadow);
         color: var(--tox-private-button-focus-text-color, @button-focus-text-color);
-        
+
         &::before {
           opacity: 1;
         }
       }
-    
+
       &.tox-button--icon, &:has(.tox-icon:only-child) {    
         padding: @button-padding-y; // Use padding-y as horizontal padding to make icon button square-ish
       }
-    
+
       .tox-icon svg {
         display: block;
         fill: currentColor;
       }
-    
+
       .tox-icon.tox-icon--success svg {
         fill: var(--tox-private-color-success, @button-icon-success-color);
       }
-    
+
       .tox-icon.tox-icon--error svg {
         fill: var(--tox-private-color-error, @button-icon-error-color)
       }
     }
-    
+
     .tox-button--stretch {
       width: 100%;
     }

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -57,7 +57,6 @@
     box-shadow: @button-box-shadow;
     box-sizing: border-box;
     cursor: pointer;
-    margin: 0;
     outline: none;
     position: relative;
     white-space: nowrap;

--- a/modules/oxide/src/less/theme/components/button/button.less
+++ b/modules/oxide/src/less/theme/components/button/button.less
@@ -111,7 +111,7 @@
       }
 
       .tox-icon.tox-icon--error svg {
-        fill: var(--tox-private-color-error, @button-icon-error-color)
+        fill: var(--tox-private-color-error, @button-icon-error-color);
       }
     }
 


### PR DESCRIPTION
Related Ticket: TINY-12604

Description of Changes:
* Added CSS custom properties for naked button styling when custom properties are enabled
* Updated comments to clarify the purpose and usage of naked buttons
* Refactored styles to use CSS custom properties with fallbacks
* Implemented light/dark mode support through the light-dark() function
* Organized code into a `tox-atomic-component` layer for better CSS organization

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a "naked" button variant and full-width "stretch" button; improved icon-only button spacing.

- Style
  - Unified colors and state behaviors (hover, focus, active, disabled) using CSS custom properties for consistent theming.

- Refactor
  - Scoped button styles to a dedicated namespace/layer and reorganized variant/state structure for clearer inheritance.

- Documentation
  - Corrected typos and clarified the Naked button as a variant adjacent to the base button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->