### PR TITLE
TINY-12535: Remove Custom Toolbar and Title Styles for Suggested Edits Plugin

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -53,10 +53,6 @@
     width: 100%;
   }
 
-  .tox-revisionhistory--align-right {
-    margin-left: auto;
-  }
-
   .tox-revisionhistory__iframe {
     flex: 1;
   }

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -58,42 +58,18 @@
     display: flex;
     flex-direction: column;
 
-    .tox-suggestededits__toolbar {
-      display: flex;
-      align-content: center;
-      align-self: stretch;
-      flex-direction: row;
-      gap: 8px;
-      justify-content: space-between;
-      overflow-x: auto;
-      padding: @view-header-padding;
-      width: 100%;
+    .tox-suggestededits__align-right {
+      margin-left: auto;
+    }
 
-      .tox-suggestededits__toolbar--start {
-        display: flex;
-        align-items: start;
-        flex: 0;
-        gap: 8px;
-        width: 100%;
-      }
-
-      .tox-suggestededits__toolbar--end {
-        display: flex;
-        align-items: end;
-        flex: 0;
-        gap: 8px;
-        width: 100%;
-      }
-
-      .tox-suggestededits__title {
-        color: @suggestededits-text-color;
-        font-size: 20px;
-        font-weight: 700;
-        line-height: 24px;
-        padding: 4px 16px;
-        text-align: center;
-        white-space: nowrap;
-      }
+    .tox-suggestededits__title {
+      color: @suggestededits-text-color;
+      font-size: 20px;
+      font-weight: 700;
+      line-height: 24px;
+      padding: 4px 16px;
+      text-align: center;
+      white-space: nowrap;
     }
 
     .tox-suggestededits {

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -62,16 +62,6 @@
       margin-left: auto;
     }
 
-    .tox-suggestededits__title {
-      color: @suggestededits-text-color;
-      font-size: 20px;
-      font-weight: 700;
-      line-height: 24px;
-      padding: 4px 16px;
-      text-align: center;
-      white-space: nowrap;
-    }
-
     .tox-suggestededits {
       background-color: @suggestededits-background-color;
       border-top: 1px solid @suggestededits-border-color;

--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -58,10 +58,6 @@
     display: flex;
     flex-direction: column;
 
-    .tox-suggestededits__align-right {
-      margin-left: auto;
-    }
-
     .tox-suggestededits {
       background-color: @suggestededits-background-color;
       border-top: 1px solid @suggestededits-border-color;

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -60,6 +60,10 @@
     overflow-x: auto;
   }
 
+  .tox-view__align-right {
+    margin-left: auto;
+  }
+
   .tox-view__toolbar {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Related Ticket: [TINY-12535](https://ephocks.atlassian.net/browse/TINY-12535)

Description of Changes:
* The custom styles that we added to the toolbar and title in the Suggested Edits plugin can be substituted for styles that we already have defined in our core view toolbar styles. 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12535]: https://ephocks.atlassian.net/browse/TINY-12535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified toolbar styling for suggested edits by removing complex layout and typography rules.
  * Updated alignment styles by removing right alignment from revision history and adding a new right alignment helper for view components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->