### PR TITLE
TINY-12257:  Improve contrast of <hr> in review edits view for better visibility 

### DIFF
--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -100,3 +100,15 @@ iframe {
     padding: 0em;
   }
 }
+
+div.tox-suggestededits__annotation:has(> hr) {
+  padding: 0.25em;
+}
+
+div.tox-suggestededits__annotation--removed__highlight > hr {
+  border-color: darken(@removed-background-color, 50%);
+}
+
+div.tox-suggestededits__annotation--added__highlight > hr {
+  border-color: darken(@added-background-color, 50%);
+}


### PR DESCRIPTION
Related Ticket: TINY-12257

Description of Changes:
* Improve contrast of `<hr>` in review edits view for better visibility 

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
