### PR TITLE
TINY-12589: Added more abilities to the parser.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added parser option `useDocumentNotBody` to allow parser to include header and other elements outside of the body.
+time: 2025-07-04T07:22:38.998267+02:00
+custom:
+    Issue: TINY-12589

--- a/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Added
-body: Added parser option `useDocumentNotBody` to allow parser to include header and other elements outside of the body.
+body: Added option to set `root_body` to `#document` to allow parser to include header and other elements outside of the body element.
 time: 2025-07-04T07:22:38.998267+02:00
 custom:
     Issue: TINY-12589

--- a/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: The editor `DomParser` API can now parse full documents when the API's `root_name` option is set to `#document`.
+body: "The editor `DomParser` API can now parse full documents when the API's `root_name` option is set to `#document`."
 time: 2025-07-04T07:22:38.998267+02:00
 custom:
     Issue: TINY-12589

--- a/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-12589-2025-07-04.yaml
@@ -1,6 +1,6 @@
 project: tinymce
-kind: Added
-body: Added option to set `root_body` to `#document` to allow parser to include header and other elements outside of the body element.
+kind: Improved
+body: The editor `DomParser` API can now parse full documents when the API's `root_name` option is set to `#document`.
 time: 2025-07-04T07:22:38.998267+02:00
 custom:
     Issue: TINY-12589

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -312,13 +312,13 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
   const sanitizer = getSanitizer(defaultedSettings, schema);
 
   const parseAndSanitizeWithContext = (html: string, rootName: string, format: string = 'html', useDocumentNotBody: boolean = false): Element => {
-    const mimeType = format === 'xhtml' ? 'application/xhtml+xml' : 'text/html';
+    const isxhtml = format === 'xhtml';
+    const mimeType = isxhtml ? 'application/xhtml+xml' : 'text/html';
     // Determine the root element to wrap the HTML in when parsing. If we're dealing with a
     // special element then we need to wrap it so the internal content is handled appropriately.
     const isSpecialRoot = Obj.has(schema.getSpecialElements(), rootName.toLowerCase());
     const content = isSpecialRoot ? `<${rootName}>${html}</${rootName}>` : html;
     const makeWrap = () => {
-      const isxhtml = format === 'xhtml';
       if (/^[\s]*<head/i.test(html) || /^[\s]*<html/i.test(html) || /^[\s]*<!DOCTYPE/i.test(html)) {
         return `<html${isxhtml ? xhtmlAttribte : ''}>${content}</html>`;
       } else {

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -44,7 +44,6 @@ export interface ParserArgs {
   format?: string;
   invalid?: boolean;
   no_events?: boolean;
-  useDocumentNotBody?: boolean;
 
   // TODO finish typing the parser args
   [key: string]: any;
@@ -81,7 +80,6 @@ export interface DomParserSettings {
   sandbox_iframes_exclusions?: string[];
   sanitize?: boolean;
   validate?: boolean;
-  useDocumentNotBody?: boolean;
 }
 
 interface DomParser {
@@ -481,10 +479,11 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    */
   const parse = (html: string, args: ParserArgs = {}): AstNode => {
     const validate = defaultedSettings.validate;
-    const rootName = args.context ?? (defaultedSettings.useDocumentNotBody ? 'html' : defaultedSettings.root_name);
+    const preferFullDocument = defaultedSettings.root_name === '#document';
+    const rootName = args.context ?? (preferFullDocument ? 'html' : defaultedSettings.root_name);
 
     // Parse and sanitize the content
-    const element = parseAndSanitizeWithContext(html, rootName, args.format, defaultedSettings.useDocumentNotBody);
+    const element = parseAndSanitizeWithContext(html, rootName, args.format, preferFullDocument);
 
     TransparentElements.updateChildren(schema, element);
 

--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -293,6 +293,8 @@ const getRootBlockName = (settings: DomParserSettings, args: ParserArgs) => {
   }
 };
 
+const xhtmlAttribte = ' xmlns="http://www.w3.org/1999/xhtml"';
+
 const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomParser => {
   const nodeFilterRegistry = FilterRegistry.create<ParserFilterCallback>();
   const attributeFilterRegistry = FilterRegistry.create<ParserFilterCallback>();
@@ -316,17 +318,15 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
     const isSpecialRoot = Obj.has(schema.getSpecialElements(), rootName.toLowerCase());
     const content = isSpecialRoot ? `<${rootName}>${html}</${rootName}>` : html;
     const makeWrap = () => {
-      if (format === 'xhtml') {
-        // If parsing XHTML then the content must contain the xmlns declaration, see https://www.w3.org/TR/xhtml1/normative.html#strict
-        if (useDocumentNotBody) {
-          return `<html xmlns="http://www.w3.org/1999/xhtml">${content}</html>`;
-        } else {
-          return `<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>${content}</body></html>`;
-        }
-      } else if (/^[\s]*<head/i.test(html) || /^[\s]*<html/i.test(html) || /^[\s]*<!DOCTYPE/i.test(html)) {
-        return `<html>${content}</html>`;
+      const isxhtml = format === 'xhtml';
+      if (/^[\s]*<head/i.test(html) || /^[\s]*<html/i.test(html) || /^[\s]*<!DOCTYPE/i.test(html)) {
+        return `<html${isxhtml ? xhtmlAttribte : ''}>${content}</html>`;
       } else {
-        return `<body>${content}</body>`;
+        if (isxhtml) {
+          return `<html${xhtmlAttribte}><head></head><body>${content}</body></html>`;
+        } else {
+          return `<body>${content}</body>`;
+        }
       }
     };
 

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -192,7 +192,7 @@ const getPurifyConfig = (settings: DomParserSettings, mimeType: MimeType): Confi
     // Deliberately ban all tags and attributes by default, and then un-ban them on demand in hooks
     // #comment and #cdata-section are always allowed as they aren't controlled via the schema
     // body is also allowed due to the DOMPurify checking the root node before sanitizing
-    ALLOWED_TAGS: [ '#comment', '#cdata-section', 'body' ],
+    ALLOWED_TAGS: [ '#comment', '#cdata-section', 'body', 'html' ],
     ALLOWED_ATTR: []
   };
   const config = { ...basePurifyConfig };

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -63,8 +63,8 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         assert.deepEqual(countNodes(root), { 'body': 1, 'b': 1, '#text': 1 }, 'Element attributes (count)');
       });
 
-      it('TINY-12589: Parse full document, with useDocumentNotBody = true', () => {
-        const parser = DomParser({ ...scenario.settings, useDocumentNotBody: true }, schema);
+      it('TINY-12589: Parse full document, with root_name = "#document"', () => {
+        const parser = DomParser({ ...scenario.settings, root_name: '#document' }, schema);
         const root = parser.parse(fullDocumentParseHtml);
         assert.equal(serializer.serialize(root), '<head><style></style><!--header Some Text 1--></head><body data-test="Test">Some Text 2</body><!--footer Some Text 3-->', 'Document context remains');
         assert.equal(root.firstChild?.type, 1, 'Element type');
@@ -72,7 +72,7 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         assert.deepEqual(countNodes(root), { 'html': 1, 'head': 1, 'style': 1, 'body': 1, '#text': 1, '#comment': 2 }, 'Element attributes (count)');
       });
 
-      it('TINY-12589: Parse full document, without useDocumentNotBody = false', () => {
+      it('TINY-12589: Parse full document, without root_name = "#document"', () => {
         const parser = DomParser(scenario.settings, schema);
         const root = parser.parse(fullDocumentParseHtml);
         assert.equal(serializer.serialize(root), 'Some Text 2', 'Content should have been stripped of its document context');


### PR DESCRIPTION
Related Ticket: TINY-12589

Description of Changes:
As the new fullpage plugin will allow the user to change certain values within the header we may need to use the domparser to prevent anything funny happening.
At the moment the parser deliberately only parses the body and discarding everything else, including the very header that the fullpage plugin wants to check. This PR adds a flag to make it parse and return the entirety of the html.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional parser mode to preserve full documents (keeps head and elements outside body when enabled).
* **Bug Fixes**
  * Sanitization updated to allow the html element, improving handling of full HTML documents.
* **Tests**
  * Added tests validating full-document parsing with and without the new parser mode.
* **Chores**
  * Added an unreleased changelog entry for this improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->