### PR TITLE
TINY-11789: change revision card to match the designs

### DIFF
--- a/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
+++ b/modules/oxide/src/less/theme/components/revisionhistory/revisionhistory.less
@@ -171,7 +171,7 @@
       .tox-revisionhistory__card-author-name {
         .overflow-text();
 
-        font-size: 12px;
+        font-size: @font-size-xs;
         font-weight: @font-weight-normal;
       }
 


### PR DESCRIPTION
Related Ticket: TINY-11789

Description of Changes:
* Updated the dark mode active card background color from `#62430b` to `#1b3b60` in the revision history component
* Restructured the card layout to match the designs
* Updated font sizes and weights to use variables instead of hardcoded values

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of the revision history for improved clarity and hierarchy.
  * Refined card label and date presentation for better readability and alignment.
  * Enhanced color adaptation in dark mode, switching the active card accent to a cooler blue tone.
  * Adjusted spacing, typography, and icon sizing for a cleaner, more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->