### PR TITLE
Add modules/oxide/tasks/ to dev archive in 7.x

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -495,6 +495,7 @@ module.exports = function (grunt) {
               'modules/*/webpack.config.js',
               'modules/*/.stylelintignore',
               'modules/*/.stylelintrc',
+              'modules/oxide/tasks',
               'modules/tinymce/tools',
               'bin',
               'patches',


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Including the files in modules/oxide/tasks in tinymce_7.*_dev.zip for it to build cleanly.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable): #10531
