### PR TITLE
TINY-12257: Fix `pagebreak` image styles in Review Edits view

### DIFF
--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -112,3 +112,19 @@ div.tox-suggestededits__annotation--removed__highlight > hr {
 div.tox-suggestededits__annotation--added__highlight > hr {
   border-color: darken(@added-background-color, 50%);
 }
+
+.mce-pagebreak {
+  &.tox-suggestededits__annotation--added__selected,
+  &.tox-suggestededits__annotation--removed__selected,
+  &.tox-suggestededits__annotation--modified__selected {
+    // Taken from the content pagebreak styles
+    border: 1px dashed #aaa;
+    box-shadow: none;
+  }
+
+  &.tox-suggestededits__annotation--added__highlight,
+  &.tox-suggestededits__annotation--modified__highlight,
+  &.tox-suggestededits__annotation--removed__highlight {
+    padding: 0;
+  }
+}


### PR DESCRIPTION
Related Ticket: TINY-12257

Description of Changes:
* Fix styling issues of `mce-pagebreak` in Review Edits view 
<details>
<summary>Screenshot</summary>
Not selected: 
<img width="1788" height="747" alt="image" src="https://github.com/user-attachments/assets/526d25fc-b3af-4eb9-960a-e7778e150b33" />

Selected:
<img width="1765" height="852" alt="image" src="https://github.com/user-attachments/assets/e1a6496b-baea-4405-9346-58a37f90b289" />
</details>

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
