### PR TITLE
TINY-12653: add shared sidebar styles for comments and AI chat

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -1,0 +1,51 @@
+.tox-ai when (@custom-properties-enabled = true) {
+  --tox-private-ai-user-prompt-background: hsl( from var(--tox-private-background-color) h s calc(l - 6));
+  --tox-private-ai-footer-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 11));
+}
+
+.tox-ai {
+  .tox-ai__user-prompt {
+    background-color: var(--tox-private-ai-user-prompt-background, darken(@background-color, 6%));
+    padding: var(--tox-private-pad-sm, @pad-sm) 12px;
+    border-radius: var(--tox-private-control-border-radius, @control-border-radius);
+    max-width: 80%;
+    align-self: flex-end;
+    color: var(--tox-private-text-color, @text-color);
+  }
+  
+  .tox-ai__scroll {
+    overflow: auto;
+    background-color: var(--tox-private-background-color, @background-color);
+    display: flex;
+    padding: 12px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    flex: 1 0 0;
+    align-self: stretch;
+  }
+  
+  .tox-ai-response__content {
+    padding: var(--tox-private-pad-sm, @pad-sm) 0;
+    color: var(--tox-private-text-color, @text-color);
+    font-feature-settings: 'liga' off, 'clig' off;
+    font-size: var(--tox-private-font-size-sm, @font-size-sm);
+    font-style: normal;
+    font-weight: var(--tox-private-font-weight-normal, @font-weight-normal);
+    line-height: var(--tox-private-line-height, 18px);
+  }
+  
+  .tox-ai__footer {
+    border-top: 1px solid var(--tox-private-ai-footer-border-color, darken(@background-color, 11%));
+    padding: 12px;
+    gap: var(--tox-private-pad-sm, @pad-sm);
+    background-color: var(--tox-private-background-color, @background-color);
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .tox-ai__footer-actions {
+    display: flex;
+    gap: var(--tox-private-pad-sm, @pad-sm);
+  }
+}

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -10,7 +10,7 @@
 @comment-border-radius: @panel-border-radius;
 @comment-border-width: 1px;
 @comment-border: @comment-border-width solid @comment-border-color;
-@comment-box-shadow: 0 4px 8px 0 fade(@color-black, 10%);
+@comment-box-shadow: @sidebar-header-box-shadow;
 //TODO: Same as menu. Make a common helper variable?
 @comment-font-size: @font-size-md;
 @comment-font-style: normal;
@@ -28,37 +28,6 @@
 
 @single-comment-margin-bottom: 12px;
 .tox {
-
-  .tox-conversations {
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    height: 100%;
-
-    /* This is to give the sidebar a consistent width. Need a solution for this */
-    min-width: 300px;
-    max-width: 300px;
-    width: 300px;
-  }
-
-  .tox-conversations__header {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-    box-shadow: @comment-box-shadow;
-    padding: @pad-sm 12px;
-    background: @background-color;
-    z-index: 1;
-  }
-
-  .tox-conversations__title {
-    font-size: @font-size-lg;
-    font-weight: 400;
-    padding: @pad-sm 0 @pad-sm 0;
-    color: @comment-text-color;
-    line-height: 28px;
-  }
-
   .tox-comment {
     background: @comment-background-color;
     border: @comment-border;

--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
@@ -2,6 +2,13 @@
 // Sidebar
 //
 
+.tox-sidebar when (@custom-properties-enabled = true) {
+  --tox-private-sidebar-background-color: light-dark(
+    hsl( from var(--tox-private-background-color) h s calc(l - 6)),
+    hsl( from var(--tox-private-background-color) h s calc(l + 10))
+  );
+}
+
 @sidebar-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 10%));
 
 .tox {
@@ -17,7 +24,7 @@
   }
 
   .tox-sidebar {
-    background-color: @sidebar-background-color;
+    background-color: var(--tox-private-sidebar-background-color, @sidebar-background-color);
     display: flex;
     flex-direction: row;
     justify-content: flex-end;

--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-content.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-content.less
@@ -1,0 +1,40 @@
+
+.tox-sidebar when (@custom-properties-enabled = true) {
+  --tox-private-sidebar-header-box-shadow: 0 4px 8px 0 hsl( from var(--tox-private-color-black) h s l / 10%);
+  --tox-private-sidebar-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 11));
+}
+
+@sidebar-header-box-shadow: 0 4px 8px 0 fade(@color-black, 10%);
+
+.tox-sidebar-content {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  height: 100%;
+  min-width: 300px;
+  max-width: 300px;
+  width: 300px;
+  border-left: 1px solid var(--tox-private-sidebar-border-color, darken(@background-color, 11%));
+}
+
+.tox-sidebar-content__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  box-shadow: var(--tox-private-sidebar-header-box-shadow, @sidebar-header-box-shadow);
+  padding: var(--tox-private-pad-sm, @pad-sm) 12px;
+  background: var(--tox-private-background-color, @background-color);
+  z-index: 1;
+  .tox-sidebar-content__header-close-button {
+    margin-left: auto;
+  }
+}
+
+.tox-sidebar-content__title {
+  font-size: var(--tox-private-font-size-lg, @font-size-lg);
+  font-weight: var(--tox-private-font-weight-normal, @font-weight-normal);
+  padding: var(--tox-private-pad-sm, @pad-sm) 0 var(--tox-private-pad-sm, @pad-sm) 0;
+  color: var(--tox-private-text-color, @text-color);
+  line-height: 28px;
+}
+

--- a/modules/oxide/src/less/theme/globals/global-custom-properties.less
+++ b/modules/oxide/src/less/theme/globals/global-custom-properties.less
@@ -53,7 +53,7 @@
 
     // Font
     --tox-private-line-height: 1.3;
-    --tox-private-control-line-height: calc(var(--tox-private-font-size-md) * 1.5); // Use instead of @textfield-line-height. It can't be just 1.5 as it's used in calculations.
+    --tox-private-control-line-height: calc(var(--tox-private-font-size-base) * 1.5); // Use instead of @textfield-line-height. It can't be just 1.5 as it's used in calculations.
     --tox-private-font-weight-normal: normal;
     --tox-private-font-weight-bold: bold;
     --tox-private-font-size-base: var(--tox-private-base-value);

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -73,7 +73,9 @@ Styles that are not defined in any layer always override styles declared in name
 @import 'components/notification/notification';
 @import 'components/onboarding/onboarding';
 @import 'components/pop/pop';
-@import 'components/sidebar/sidebar';
+@import 'components/sidebar/sidebar-container';
+@import 'components/sidebar/sidebar-content';
+@import 'components/ai-chat/ai-chat';
 @import 'components/selector/selector';
 @import 'components/skeleton/skeleton.less';
 @import 'components/slider/slider';


### PR DESCRIPTION
Related Ticket: TINY-12653

Description of Changes:

- Added new AI chat component styling with custom properties for user prompts, responses, and footer
- Refactored sidebar structure by splitting into separate files (sidebar-container.less and sidebar-content.less)
- Added custom properties for sidebar styling including background color and header box-shadow
- Moved conversations styling from comments to sidebar-content
- Fixed line-height variable reference in global custom properties

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Added AI chat UI styles: themed message bubbles, scrollable conversation area, and structured footer actions.
- Style
    - Refined sidebar visuals with theme-aware background, border, and header shadow for improved contrast and consistency.
    - Unified comment shadow to match sidebar header styling for visual harmony.
    - Adjusted control typography line-height to align with base font sizing.
- Refactor
    - Split sidebar theming into container and content modules and included AI chat styles.
- Bug Fixes
    - Removed legacy conversations sidebar UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->