### PR TITLE
TINY-12529: Added a LESS variable mapping for secondary button hover text color customization

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary-outlined.less
@@ -4,7 +4,7 @@
 // For base button styles see button.less
 //
 
-@button-secondary-outline-hover-text-color-mapping: var(--tox-private-button-secondary-outline-hover-text-color, @text-color);
+@button-secondary-outline-hover-text-color: @text-color;
 
 @layer tox-atomic-component {
   .tox {
@@ -12,19 +12,19 @@
       // Secondary outlined button variant only styles the text and border color as the background is transparent by design
       --tox-private-button-secondary-outline-text-color: var(--tox-private-text-color);
       --tox-private-button-secondary-outline-border-color: light-dark(
-        hsl(from var(--tox-private-background-color) h s calc(l - 6)), 
-        hsl(from var(--tox-private-background-color) h s calc(l - -15))); // calc(l + 15) is valid css but less compiler perserve new line characters when + is used here. This behavior breaks our minification. 
+        hsl(from var(--tox-private-background-color) h s calc(l - 6)),
+        hsl(from var(--tox-private-background-color) h s calc(l - -15))); // calc(l + 15) is valid css but less compiler perserve new line characters when + is used here. This behavior breaks our minification.
 
-      /* 
-        Button state variables - to be decided if we want them. 
-        If we do: 
+      /*
+        Button state variables - to be decided if we want them.
+        If we do:
           1. They should inherit from button base variables (as they do now).
-          2. While skinning the change of the base variable will result with others being calculated/inherited from it. 
-          3. In this case it is also possible to skin each state separately. 
-        If we don't: 
-          1. They should be removed. 
-          2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables. 
-          3. In this case it is NOT possible to skin each state separately. 
+          2. While skinning the change of the base variable will result with others being calculated/inherited from it.
+          3. In this case it is also possible to skin each state separately.
+        If we don't:
+          1. They should be removed.
+          2. Different states of the button should use base button variables and calculate from them if neccessary, but not create new variables.
+          3. In this case it is NOT possible to skin each state separately.
       */
       /* Disabled state */
       --tox-private-button-secondary-outline-disabled-background-color: transparent;
@@ -45,7 +45,7 @@
       --tox-private-button-secondary-outline-active-background-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
       --tox-private-button-secondary-outline-active-border-color: hsl(from var(--tox-private-button-secondary-outline-border-color) h s calc(l - 5));
       --tox-private-button-secondary-outline-active-text-color: var(--tox-private-button-secondary-outline-text-color);
-    } 
+    }
 
     .tox-button--secondary--outline {
       background-color: transparent;
@@ -61,7 +61,7 @@
       &:hover:not(:disabled) {
         background-color: var(--tox-private-button-secondary-outline-hover-background-color, @button-secondary-background-color);
         border-color: var(--tox-private-button-secondary-outline-hover-border-color, @button-secondary-hover-background-color);
-        color: @button-secondary-outline-hover-text-color-mapping;
+        color: var(--tox-private-button-secondary-outline-hover-text-color, @button-secondary-outline-hover-text-color);
       }
 
       &:active:not(:disabled) {


### PR DESCRIPTION
Related Ticket: [TINY-12529](https://ephocks.atlassian.net/browse/TINY-12529)

Description of Changes:
* Added a mapping variable to make it easier to customize hover text colors in secondary buttons. 
* Before this, we had to either change all text colors or break the pattern in our skins where we only use variables. 
* Now, skins can just override one variable to change the hover text color for secondary buttons.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12529]: https://ephocks.atlassian.net/browse/TINY-12529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Improved internal theming for the secondary outlined button’s hover text color by introducing an intermediate mapping, making overrides and customization across themes easier.
  - Maintains current visuals and behavior; this change enhances maintainability and consistency of design tokens with no impact on end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->