### PR TITLE
TINY-12690: add skin with modern css enabled

### DIFF
--- a/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/content.inline.less
+++ b/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/content.inline.less
@@ -1,0 +1,1 @@
+@import 'src/less/theme/content-ui';

--- a/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/content.less
+++ b/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/content.less
@@ -1,0 +1,9 @@
+@import 'src/less/theme/content-ui';
+
+body {
+  font-family: sans-serif;
+}
+
+table {
+  border-collapse: collapse;
+}

--- a/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/skin.less
+++ b/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/skin.less
@@ -1,0 +1,7 @@
+@import 'src/less/theme/theme';
+
+//
+// Place your variables here
+//
+
+@custom-properties-enabled: true;

--- a/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/skin.shadowdom.less
+++ b/modules/oxide/src/less/skins/ui/experimental-css-custom-props-enabled/skin.shadowdom.less
@@ -1,0 +1,1 @@
+@import 'src/less/theme/shadowdom';

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -31,7 +31,8 @@ let oxideUiSkinMap = {
   'dark': 'oxide-dark',
   'default': 'oxide',
   'tinymce-5': 'tinymce-5',
-  'tinymce-5-dark': 'tinymce-5-dark'
+  'tinymce-5-dark': 'tinymce-5-dark',
+  'experimental-css-custom-props-enabled': 'experimental-css-custom-props-enabled'
 };
 
 const stripSourceMaps = function (data) {


### PR DESCRIPTION
# Add experimental CSS custom properties skin

Related Ticket:

Description of Changes:

- Added a new skin that enables CSS custom properties
- Updated the oxideUiSkinMap in Gruntfile.js to include the new skin

Pre-checks:

- [ ] ~~Changelog entry added~~
- [ ] ~~Tests have been added (if applicable)~~
- [ ] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [ ] Milestone set
- [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):