### PR TITLE
TINY-12578: deprecate option 'content_css_cors'

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12578-2025-08-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-12578-2025-08-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Deprecated
+body: Deprecated 'content_css_cors' config option.
+time: 2025-08-19T15:55:11.97751+02:00
+custom:
+  Issue: TINY-12578

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -18,7 +18,6 @@ const removedOptions = (
   'template_cdate_classes,template_mdate_classes,template_selected_content_classes,template_preview_replace_values,template_replace_values,templates,template_cdate_format,template_mdate_format'
 ).split(',');
 
-// const deprecatedOptions: string[] = ('').split(',');
 const deprecatedOptions: string[] = [ 'content_css_cors' ];
 
 const removedPlugins = 'bbcode,colorpicker,contextmenu,fullpage,legacyoutput,spellchecker,template,textcolor,rtc'.split(',');

--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -19,7 +19,7 @@ const removedOptions = (
 ).split(',');
 
 // const deprecatedOptions: string[] = ('').split(',');
-const deprecatedOptions: string[] = [];
+const deprecatedOptions: string[] = [ 'content_css_cors' ];
 
 const removedPlugins = 'bbcode,colorpicker,contextmenu,fullpage,legacyoutput,spellchecker,template,textcolor,rtc'.split(',');
 


### PR DESCRIPTION
Related Ticket: TINY-12578

Description of Changes:
* Deprecated `content_css_cors` config option.

Pre-checks:
* [x] Changelog entry added
~~* [ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated the “content_css_cors” configuration option; using it will now trigger deprecation warnings.
  * Added an unreleased changelog entry to track this deprecation.

* **Documentation**
  * Updated release notes to reflect the deprecation of “content_css_cors.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->