### PR TITLE
TINY-12744: Update TypeScript and Terser to target ES2022 

### DIFF
--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -199,7 +199,7 @@ module.exports = function (grunt) {
     terser: Object.assign(
       {
         options: {
-          ecma: 2018,
+          ecma: 2022,
           output: {
             ascii_only: true
           },

--- a/modules/tinymce/Gruntfile.js
+++ b/modules/tinymce/Gruntfile.js
@@ -880,16 +880,6 @@ module.exports = function (grunt) {
         retries: 3,
         customRoutes: 'src/core/test/json/routes.json',
         name: grunt.option('bedrock-browser') !== undefined ? grunt.option('bedrock-browser') : 'chrome-headless'
-      },
-      silver: {
-        browser: 'phantomjs',
-        config: 'tsconfig.json',
-        testfiles: ['src/themes/silver/test/ts/phantom/**/*Test.ts', 'src/themes/silver/test/ts/browser/**/*Test.ts', 'src/themes/silver/test/ts/webdriver/*/*Test.ts'],
-        stopOnFailure: true,
-        overallTimeout: 600000,
-        singleTimeout: 300000,
-        customRoutes: 'src/core/test/json/routes.json',
-        name: 'silver-tests'
       }
     }
   });

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es2018",
-    "module": "es2015",
+    "target": "es2022",
+    "module": "es2022",
     "lib": ["es2022", "dom"],
     "importHelpers": true,
     "declaration": true,


### PR DESCRIPTION
Related Ticket: [TINY-12744](https://ephocks.atlassian.net/browse/TINY-12744)

Description of Changes:
* TypeScript will now output modern JavaScript syntax (or at least from `es2022`) in the compiled code instead of transforming it down to older syntax, so we are maintaining broad browser support while taking advantage of ES2022 features.
* This keeps our configuration consistent since we were already using ES2022 features during development via `lib`, now our output matches that capability.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12744]: https://ephocks.atlassian.net/browse/TINY-12744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated JavaScript compilation and minification targets to ES2022 across the app, aligning build outputs.
  - Impact: Smaller, more efficient bundles and improved performance on modern browsers; older browser support may be reduced.

- Tests
  - Removed the silver (phantomjs/browser/webdriver) test configuration from automated test settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->