### PR TITLE
[CARE-77544] fix: format_empty_lines feature and forced attributes for block fixes

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Settings.ts
+++ b/modules/tinymce/src/core/main/ts/api/Settings.ts
@@ -173,6 +173,8 @@ const getInlineBoundarySelector = (editor: Editor): string => {
   return editor.getParam('inline_boundaries_selector', 'a[href],code,.mce-annotation', 'string');
 };
 
+const canFormatEmptyLines = (editor: Editor) => editor.getParam('format_empty_lines', false, 'boolean');
+
 export default {
   getIframeAttrs,
   getDocType,
@@ -206,5 +208,6 @@ export default {
   getIndentation,
   getContentCss,
   getDirectionality,
-  getInlineBoundarySelector
+  getInlineBoundarySelector,
+  canFormatEmptyLines,
 };

--- a/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
+++ b/modules/tinymce/src/core/main/ts/delete/MergeBlocks.ts
@@ -30,7 +30,7 @@ const extractChildren = (block: Element) => {
 
 const removeEmptyRoot = (rootNode: Element, block: Element) => {
   const parents = Parents.parentsAndSelf(block, rootNode);
-  return Arr.find(parents.reverse(), Empty.isEmpty).each(Remove.remove);
+  return Arr.find(parents.reverse(), (el) => Empty.isEmpty(el)).each(Remove.remove);
 };
 
 const isEmptyBefore = (el: Element) => Arr.filter(Traverse.prevSiblings(el), (el) => !Empty.isEmpty(el)).length === 0;

--- a/modules/tinymce/src/core/main/ts/dom/Empty.ts
+++ b/modules/tinymce/src/core/main/ts/dom/Empty.ts
@@ -33,7 +33,7 @@ const isBookmark = NodeType.hasAttribute('data-mce-bookmark');
 const isBogus = NodeType.hasAttribute('data-mce-bogus');
 const isBogusAll = NodeType.hasAttributeValue('data-mce-bogus', 'all');
 
-const isEmptyNode = function (targetNode) {
+const isEmptyNode = function (targetNode, skipBogus) {
   let node, brCount = 0;
 
   if (isContent(targetNode, targetNode)) {
@@ -46,14 +46,15 @@ const isEmptyNode = function (targetNode) {
 
     const walker = new TreeWalker(node, targetNode);
     do {
-      if (isBogusAll(node)) {
-        node = walker.next(true);
-        continue;
-      }
-
-      if (isBogus(node)) {
-        node = walker.next();
-        continue;
+      if (skipBogus) {
+        if (isBogusAll(node)) {
+          node = walker.next(true);
+          continue;
+        }
+        if (isBogus(node)) {
+          node = walker.next();
+          continue;
+        }
       }
 
       if (NodeType.isBr(node)) {
@@ -73,7 +74,7 @@ const isEmptyNode = function (targetNode) {
   }
 };
 
-const isEmpty = (elm) => isEmptyNode(elm.dom());
+const isEmpty = (elm, skipBogus = true) => isEmptyNode(elm.dom(), skipBogus);
 
 export default {
   isEmpty

--- a/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
+++ b/modules/tinymce/src/core/main/ts/newline/InsertBlock.ts
@@ -6,8 +6,8 @@
  */
 
 import { Element as DomElement, DocumentFragment, KeyboardEvent } from '@ephox/dom-globals';
-import { Arr } from '@ephox/katamari';
-import { PredicateFilter, Element, Node } from '@ephox/sugar';
+import { Arr, Option, Obj } from '@ephox/katamari';
+import { PredicateFilter, Element, Css, Node } from '@ephox/sugar';
 import Settings from '../api/Settings';
 import * as CaretContainer from '../caret/CaretContainer';
 import NodeType from '../dom/NodeType';
@@ -133,11 +133,58 @@ const getEditableRoot = function (dom, node) {
   return parent !== root ? editableRoot : root;
 };
 
+const objAcc = (r) => (x, i) => {
+  r[i] = x;
+};
+
+const internalFilter = function (obj, pred, onTrue, onFalse) {
+  const r = {};
+  Obj.each(obj, function (x, i) {
+    (pred(x, i) ? onTrue : onFalse)(x, i);
+  });
+  return r;
+};
+
+const filter = function (obj, pred) {
+  const t = {};
+  internalFilter(obj, pred, objAcc(t), () => {});
+  return t;
+};
+
+export const lift2 = (oa, ob, f) =>
+  oa.isSome() && ob.isSome() ? Option.some(f(oa.getOrDie(), ob.getOrDie())) : Option.none();
+
+const applyAttributes = (editor: Editor, node: DomElement, forcedRootBlockAttrs: Record<string, string>) => {
+  // Merge and apply style attribute
+  Option.from(forcedRootBlockAttrs.style)
+    .map(editor.dom.parseStyle)
+    .each((attrStyles) => {
+      const currentStyles = Css.getAllRaw(Element.fromDom(node));
+      const newStyles = { ...currentStyles, ...attrStyles };
+      editor.dom.setStyles(node, newStyles);
+    });
+
+  // Merge and apply class attribute
+  const attrClassesOpt = Option.from(forcedRootBlockAttrs.class).map((attrClasses) => attrClasses.split(/\s+/));
+  const currentClassesOpt = Option.from(node.className).map((currentClasses) => Arr.filter(currentClasses.split(/\s+/), (clazz) => clazz !== ''));
+  lift2(attrClassesOpt, currentClassesOpt, (attrClasses, currentClasses) => {
+    const filteredClasses = Arr.filter(currentClasses, (clazz) => !Arr.contains(attrClasses, clazz));
+    const newClasses = [...attrClasses, ...filteredClasses];
+    editor.dom.setAttrib(node, 'class', newClasses.join(' '));
+  });
+
+  // Apply any remaining forced root block attributes
+  const appliedAttrs = ['style', 'class'];
+  const remainingAttrs = filter(forcedRootBlockAttrs, (_, attrs) => !Arr.contains(appliedAttrs, attrs));
+  editor.dom.setAttribs(node, remainingAttrs);
+};
+
 const setForcedBlockAttrs = function (editor: Editor, node) {
   const forcedRootBlockName = Settings.getForcedRootBlock(editor);
 
   if (forcedRootBlockName && forcedRootBlockName.toLowerCase() === node.tagName.toLowerCase()) {
-    editor.dom.setAttribs(node, Settings.getForcedRootBlockAttrs(editor));
+    const forcedRootBlockAttrs = Settings.getForcedRootBlockAttrs(editor);
+    applyAttributes(editor, node, forcedRootBlockAttrs);
   }
 };
 
@@ -231,7 +278,6 @@ const insert = function (editor: Editor, evt?: EditorEvent<KeyboardEvent>) {
 
     if (name || parentBlockName === 'TABLE' || parentBlockName === 'HR') {
       block = dom.create(name || newBlockName);
-      setForcedBlockAttrs(editor, block);
     } else {
       block = parentBlock.cloneNode(false);
     }
@@ -263,6 +309,8 @@ const insert = function (editor: Editor, evt?: EditorEvent<KeyboardEvent>) {
         }
       } while ((node = node.parentNode) && node !== editableRoot);
     }
+
+    setForcedBlockAttrs(editor, block);
 
     emptyBlock(caretNode);
 
@@ -427,6 +475,7 @@ const insert = function (editor: Editor, evt?: EditorEvent<KeyboardEvent>) {
     if (dom.isEmpty(parentBlock)) {
       emptyBlock(parentBlock);
     }
+    setForcedBlockAttrs(editor, newBlock);
     NewLineUtils.moveToCaretPosition(editor, newBlock);
   } else if (isCaretAtStartOrEndOfBlock()) {
     insertNewBlockAfter();
@@ -457,6 +506,7 @@ const insert = function (editor: Editor, evt?: EditorEvent<KeyboardEvent>) {
       dom.remove(newBlock);
       insertNewBlockAfter();
     } else {
+      setForcedBlockAttrs(editor, newBlock);
       NewLineUtils.moveToCaretPosition(editor, newBlock);
     }
   }


### PR DESCRIPTION
Related Ticket: [https://sprinklr.atlassian.net/browse/CARE-77544](url)

Description of Changes:
1. format_empty_lines feature integration - [MR](https://github.com/tinymce/tinymce/pull/7835/files)
2. forced_root_block_attrs config's some fixes related to creating new blocks - [MR](https://github.com/tinymce/tinymce/pull/5412)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to allow formatting empty lines, enabling richer formatting on empty paragraphs/line breaks.
  - Improved handling of line breaks during formatting to better respect context.

- Bug Fixes
  - Forced root block attributes now merge with existing styles and classes instead of overwriting them, preserving current formatting.
  - Improved empty-content detection with an option to include/exclude bogus nodes, reducing unintended skips.

- Refactor
  - Streamlined internal formatting flow and wrapper management for greater stability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->