### PR TITLE
TINY-12597: fix suggested edits annotation colors

### DIFF
--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -2,9 +2,9 @@
 // Suggested Edits
 //
 
-@added-background-color: saturate(lighten(@color-success, 34%), 25%);
-@modified-background-color: desaturate(lighten(@color-tint, 44%), 12%);
-@removed-background-color: desaturate(lighten(@color-error, 40%), 25%);
+@added-background-color: fade(@color-success, 20%);
+@modified-background-color: fade(@color-tint, 20%);
+@removed-background-color: fade(@color-error, 20%);
 
 @selected-outline-color: @color-tint;
 @selected-box-shadow: 0 -2px 0 0 @selected-outline-color inset, 0 -2px 0 0 @selected-outline-color;


### PR DESCRIPTION
Related Ticket: TINY-12597

Description of Changes:
* Changed colors for added, modified, and removed annotations to match the designs

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized Suggested Edits highlighting (Added/Modified/Removed) to use translucent base colors for a cleaner, more consistent look.
  * Reduces overly intense tints, improving readability and keeping focus on content.
  * Enhances visual consistency across themes and alignment with the brand palette.
  * No functional changes; this is a purely visual refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->