### PR TITLE
TINY-12787: Improve handling of failing visual regression tests to not exit with code 1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -319,8 +319,14 @@ timestamps { alertWorseResult(
   processes['playwright'] = runPlaywrightPod(cacheName, 'playwright-tests') {
     exec('yarn -s --cwd modules/oxide-components test-ci')
     junit allowEmptyResults: true, testResults: 'modules/oxide-components/scratch/test-results.xml'
-    exec('yarn -s --cwd modules/oxide-components test-visual-ci')
+    def visualTestStatus = exec(script: 'yarn -s --cwd modules/oxide-components test-visual-ci', returnStatus: true)
+    if (visualTestStatus == 4) {
+      unstable("Visual tests failed")
+    } else if (visualTestStatus != 0) {
+      error("Unexpected error running visual tests")
+    }
     junit allowEmptyResults: true, testResults: 'modules/oxide-components/scratch/test-results-visual.xml'
+    exec('find modules/oxide-components -name "*.png" -type f || echo "No PNG files found"')
     archiveArtifacts artifacts: 'modules/oxide-components/test-results/**/*.png', allowEmptyArchive: true, fingerprint: true
   }
 


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Improved error handling in visual regression test CI script
- Added differentiation between test failures and actual script errors
- Allows CI to continue when tests fail (exit code 1) but stops for other errors
- Enhanced error messages to better identify the source of failures

Pre-checks:

- [x] ~Changelog entry added~
- [x] ~Tests have been added (if applicable)~
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] Milestone set
- [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
    - Visual regression test failures are now reported as an unstable outcome (distinct exit status) so they don't fail the CI; script/runtime startup errors still fail the build.
- **Chores**
    - Improved error messaging for script-level startup/runtime issues.
    - CI now checks for PNG artifacts and prints a notice if none are found.
    - Minor formatting cleanup (no functional change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->