### PR TITLE
TINY-12796: Fix Outdated Lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,7 +2803,7 @@
     "@smithy/util-buffer-from" "^4.0.0"
     tslib "^2.6.2"
 
-"@storybook/addon-a11y@^9.0.10":
+"@storybook/addon-a11y@9.0.17":
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-9.0.17.tgz#a23b2babb812190919d54e5015cc55d86895ab72"
   integrity sha512-9cXNK3q/atx3hwJAt9HkJbd9vUxCXfKKiNNuSACbf8h9/j6u3jktulKOf6Xjc3B8lwn6ZpdK/x1HHZN2kTqsvg==
@@ -2811,7 +2811,7 @@
     "@storybook/global" "^5.0.0"
     axe-core "^4.2.0"
 
-"@storybook/addon-docs@^9.0.11":
+"@storybook/addon-docs@9.0.17":
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-9.0.17.tgz#4b139b80f824fb2a0f36df2499522d8b074d679d"
   integrity sha512-LOX/kKgQGnyulrqZHsvf77+ZoH/nSUaplGr5hvZglW/U6ak6fO9seJyXAzVKEnC6p+F8n02kFBZbi3s+znQhSg==
@@ -2824,12 +2824,12 @@
     react-dom "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-onboarding@^9.0.10":
+"@storybook/addon-onboarding@9.0.17":
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-onboarding/-/addon-onboarding-9.0.17.tgz#97c8dc4249f30a1afed2a1a05b4d9c3dde10f59c"
   integrity sha512-WoZZ8d58gP6uBu6OJ2K1GjBSM4+Kcr0I9lo0z3convzYqxrhfUm9pNEwVm57KCbVVyBbIKmevddCsSFoPC5u6Q==
 
-"@storybook/addon-vitest@^9.0.10":
+"@storybook/addon-vitest@9.0.17":
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-vitest/-/addon-vitest-9.0.17.tgz#7407095dff881618e50a9dc03b9cb514d3a70bcf"
   integrity sha512-eogqcGbACR1sTedBSE2SP/4QV1ruicHYEhYjBtoPIjvYgymN1g5KSuQNysLx4f0SvAzczrcNjX2WVVLX2DVyzA==
@@ -2859,7 +2859,7 @@
   resolved "https://registry.yarnpkg.com/@storybook/global/-/global-5.0.0.tgz#b793d34b94f572c1d7d9e0f44fac4e0dbc9572ed"
   integrity sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==
 
-"@storybook/icons@^1.2.10", "@storybook/icons@^1.2.12", "@storybook/icons@^1.4.0":
+"@storybook/icons@^1.2.12", "@storybook/icons@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@storybook/icons/-/icons-1.4.0.tgz#7cf7ab3dfb41943930954c4ef493a73798d8b31d"
   integrity sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==
@@ -2869,7 +2869,7 @@
   resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-9.0.17.tgz#fe0e6431ff6002269b18e9bb32cbe3fc01b13b10"
   integrity sha512-ak/x/m6MDDxdE6rCDymTltaiQF3oiKrPHSwfM+YPgQR6MVmzTTs4+qaPfeev7FZEHq23IkfDMTmSTTJtX7Vs9A==
 
-"@storybook/react-vite@^9.0.10":
+"@storybook/react-vite@9.0.17":
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/@storybook/react-vite/-/react-vite-9.0.17.tgz#49e3858612b21697ede54253ad7f33ad3c214af1"
   integrity sha512-wx1yKScni4ifOC/ccqpnnpceQbyF2xto+jHGsyua+M4UUCQdS2NYPDR8JFWp1YvBhVt2cQiD6SAltVGM9QLGnQ==
@@ -6363,7 +6363,7 @@ eslint-plugin-security-node@^1.1.4:
   resolved "https://registry.yarnpkg.com/eslint-plugin-security-node/-/eslint-plugin-security-node-1.1.4.tgz#e78dbfa9d4852076d51ca512a28d6b4ead069792"
   integrity sha512-8+agTMb2glNbP1zFhqo/Ixwtz16Hn0TvJW5KgpoHkAzGjDUhQf9iT+D6OgbhvZCMWRKMjc+5FbJ2Lh0UEUz7fQ==
 
-eslint-plugin-storybook@^9.0.10:
+eslint-plugin-storybook@9.0.17:
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/eslint-plugin-storybook/-/eslint-plugin-storybook-9.0.17.tgz#4a7d6d51882d52a5f946e74cf910a425ead4a7de"
   integrity sha512-IuTdlwCEwoDNobdygRCxNhlKXHmsDfPtPvHGcsY35x2Bx8KItrjfekO19gJrjc1VT2CMfcZMYF8OBKaxHELupw==
@@ -12342,14 +12342,12 @@ std-env@^3.9.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
   integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
-storybook-addon-pseudo-states@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-4.0.4.tgz#d2327427960dce236be2714a3af2ab9f34d7ce2a"
-  integrity sha512-hF3nLFpRPjqNxa7eqp+j1bd+DvyUCns1iesUZqMZz9ZuIijosOTQgJO5G0drbdxlHvXehu/BgcqbyxBb2eJR5w==
-  dependencies:
-    "@storybook/icons" "^1.2.10"
+storybook-addon-pseudo-states@9.0.17:
+  version "9.0.17"
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-9.0.17.tgz#77cdaace4cd44aaf5937385567b59aaa0a94577c"
+  integrity sha512-sf+UEKT0fOuQ9G1Usnn1hDnhyJqkRgsMtx0m2f3SvRY5DbammcKDpyrunrUdGtOiOYNhc0pkU8VD167BLMbDkg==
 
-storybook@^9.0.10:
+storybook@9.0.17:
   version "9.0.17"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-9.0.17.tgz#d17628db97314a441d0e4ad5c5f71956d0436a90"
   integrity sha512-O+9jgJ+Trlq9VGD1uY4OBLKQWHHDKM/A/pA8vMW6PVehhGHNvpzcIC1bngr6mL5gGHZP2nBv+9XG8pTMcggMmg==


### PR DESCRIPTION
Related Ticket: [TINY-12796](https://ephocks.atlassian.net/browse/TINY-12796)

Description of Changes:
* We have been unable to run `yarn upgrade-interactive` due to an outdated lockfile introduced in [this commit](https://github.com/tinymce/tinymce/pull/10536/files). It appears that there might still be some ambiguity in how Storybook handles managing dependencies.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12796]: https://ephocks.atlassian.net/browse/TINY-12796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ