### PR TITLE
TINY-12582: Notify status change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,11 +206,12 @@ def cacheName = "cache_${BUILD_TAG}"
 
 def testPrefix = "tinymce_${cleanBuildName(env.BRANCH_NAME)}-build${env.BUILD_NUMBER}"
 
-timestamps { alertWorseResult(
+timestamps { notifyStatusChange(
   cleanupStep: { devPods.cleanUpPod(build: cacheName) },
   branches: ['main', 'release/7', 'release/8'],
   channel: '#tinymce-build-status',
-  name: 'TinyMCE'
+  name: 'TinyMCE',
+  mention: true
   ) {
   devPods.nodeProducer(
     nodeOpts: [


### PR DESCRIPTION
Related Ticket: TINY-12582

Description of Changes:
* Change alertWorseResult to notifyStatusChange to track when builds go back to green.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline status notifications to use a newer notifier.
  * Introduced an optional “mention” parameter in notifications; existing fields and behavior remain the same.
  * Made minor formatting adjustments to accommodate the new parameter.
  * No changes to product functionality; only build notifications may appear slightly different to recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->