### PR TITLE
TINY-12807: Enforce consistent type imports and exports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -16,6 +16,10 @@ export default defineConfig(
         onlyWarn,
       },
       rules: {
+        "@typescript-eslint/no-import-type-side-effects": "error",
+        "@typescript-eslint/consistent-type-exports": "error",
+        "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: 'inline-type-imports' }],
+
         "@typescript-eslint/camelcase": "off", // leave off
         "@typescript-eslint/member-ordering": "off",
         "@typescript-eslint/no-empty-function": "off",

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -16,6 +16,7 @@
     "noImplicitReturns": true,
     "strict": true,
     "noEmitOnError": true,
-    "types": []
+    "types": [],
+    "verbatimModuleSyntax": true,
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-12807

Description of Changes:

- Added new TypeScript ESLint rules to enforce consistent type imports/exports:
    - `@typescript-eslint/no-import-type-side-effects`: Prevents side effects from type imports
    - `@typescript-eslint/consistent-type-exports`: Ensures consistent type exports
    - `@typescript-eslint/consistent-type-imports`: Enforces inline type imports
- Enabled `verbatimModuleSyntax: true` in tsconfig.shared.json to improve type-only import/export handling

NOTE: The PRs are too big to properly review. The eslint auto-fixer largely did most of the work so should be safe.

`yarn build`​ works witout issues with a `tinymce.d.ts`​ still correctly generated

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Enforced stricter TypeScript linting around type imports/exports.
  - Enabled automatic fixes for inline type-import formatting during linting.
  - Updated TypeScript compiler settings to opt into verbatim module syntax for clearer ESM semantics.
  - No runtime or user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->