### PR TITLE
TINY-12807: Enforce consistent import and export types (Modules #2)

### DIFF
--- a/modules/boss/src/main/ts/ephox/boss/api/DomUniverse.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/DomUniverse.ts
@@ -6,7 +6,7 @@ import {
 
 import TagBoundaries from '../common/TagBoundaries';
 
-import { Universe } from './Universe';
+import type { Universe } from './Universe';
 
 export default (): Universe<SugarElement, Document> => {
   const clone = (element: SugarElement<Node>) => {

--- a/modules/boss/src/main/ts/ephox/boss/api/Main.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/Main.ts
@@ -5,7 +5,7 @@ import { Gene } from './Gene';
 import { SpecialGene } from './SpecialGene';
 import { TestUniverse } from './TestUniverse';
 import { TextGene } from './TextGene';
-import { Universe } from './Universe';
+import type { Universe } from './Universe';
 
 /* eslint-disable import-x/order */
 // NON API USAGE
@@ -15,15 +15,5 @@ import * as Logger from '../mutant/Logger';
 import * as Locator from '../mutant/Locator';
 /* eslint-enable import-x/order */
 
-export {
-  BasicPage,
-  CommentGene,
-  DomUniverse,
-  Gene,
-  SpecialGene,
-  TestUniverse,
-  TextGene,
-  Logger,
-  Locator,
-  Universe
-};
+export type { Universe };
+export { BasicPage, CommentGene, DomUniverse, Gene, SpecialGene, TestUniverse, TextGene, Logger, Locator };

--- a/modules/boss/src/main/ts/ephox/boss/api/TestUniverse.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/TestUniverse.ts
@@ -14,8 +14,8 @@ import * as Styling from '../mutant/Styling';
 import * as Tracks from '../mutant/Tracks';
 import * as Up from '../mutant/Up';
 
-import { Gene } from './Gene';
-import { Universe } from './Universe';
+import type { Gene } from './Gene';
+import type { Universe } from './Universe';
 
 export interface TestUniverseUp extends ReturnType<Universe<Gene, undefined>['up']> {
   top: (element: Gene) => Gene;

--- a/modules/boss/src/main/ts/ephox/boss/api/Universe.ts
+++ b/modules/boss/src/main/ts/ephox/boss/api/Universe.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 export interface Universe<E, D> {
   up: () => {

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Attribution.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Attribution.ts
@@ -1,4 +1,4 @@
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 const set = (item: Gene, property: string, value: string | number | boolean): void => {
   item.attrs = {

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Comparator.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Comparator.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Attribution from './Attribution';
 

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Detach.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Detach.ts
@@ -1,6 +1,6 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, type Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Comparator from './Comparator';
 import * as Locator from './Locator';

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Down.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Down.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Comparator from './Comparator';
 

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Insertion.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Insertion.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Detach from './Detach';
 import * as Locator from './Locator';

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Locator.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Locator.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Comparator from './Comparator';
 import * as Creator from './Creator';

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Logger.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Logger.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 const basic = (item: Gene): string => {
   return custom(item, (i: Gene) => {

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Properties.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Properties.ts
@@ -1,6 +1,6 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 import TagBoundaries from '../common/TagBoundaries';
 
 // Warning: not exhaustive

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Query.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Query.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Properties from './Properties';
 import * as Up from './Up';

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Removal.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Removal.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Comparator from './Comparator';
 import * as Detach from './Detach';

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Styling.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Styling.ts
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 const set = (item: Gene, property: string, value: string): void => {
   item.css = {

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Tracks.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Tracks.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 const track = (current: Gene, parent: Optional<Gene>): Gene => {
   const r: Gene = { ...current, parent };

--- a/modules/boss/src/main/ts/ephox/boss/mutant/Up.ts
+++ b/modules/boss/src/main/ts/ephox/boss/mutant/Up.ts
@@ -1,6 +1,6 @@
 import { Fun, Optional } from '@ephox/katamari';
 
-import { Gene } from '../api/Gene';
+import type { Gene } from '../api/Gene';
 
 import * as Comparator from './Comparator';
 

--- a/modules/boulder/src/main/ts/ephox/boulder/api/FieldSchema.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/api/FieldSchema.ts
@@ -2,8 +2,8 @@ import { Arr, Result } from '@ephox/katamari';
 
 import { SimpleResult } from '../alien/SimpleResult';
 import * as FieldProcessor from '../core/FieldProcessor';
-import { type FieldProcessor as FieldProcessorType } from '../core/FieldProcessor';
-import { arrOf, arrOfObj, objOf, objOfOnly, StructureProcessor } from '../core/StructureProcessor';
+import type { FieldProcessor as FieldProcessorType } from '../core/FieldProcessor';
+import { arrOf, arrOfObj, objOf, objOfOnly, type StructureProcessor } from '../core/StructureProcessor';
 import * as FieldTypes from '../core/ValueType';
 
 import * as FieldPresence from './FieldPresence';

--- a/modules/boulder/src/main/ts/ephox/boulder/api/Main.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/api/Main.ts
@@ -1,5 +1,5 @@
-import { FieldProcessor } from '../core/FieldProcessor';
-import { StructureProcessor } from '../core/StructureProcessor';
+import type { FieldProcessor } from '../core/FieldProcessor';
+import type { StructureProcessor } from '../core/StructureProcessor';
 import * as ValueType from '../core/ValueType';
 
 import * as FieldPresence from './FieldPresence';
@@ -7,14 +7,5 @@ import * as FieldSchema from './FieldSchema';
 import * as Objects from './Objects';
 import * as StructureSchema from './StructureSchema';
 
-export {
-  FieldPresence,
-  FieldSchema,
-  ValueType,
-  Objects,
-  StructureSchema,
-
-  // Types
-  StructureProcessor,
-  FieldProcessor
-};
+export type { StructureProcessor, FieldProcessor };
+export { FieldPresence, FieldSchema, ValueType, Objects, StructureSchema };

--- a/modules/boulder/src/main/ts/ephox/boulder/api/StructureSchema.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/api/StructureSchema.ts
@@ -1,10 +1,10 @@
-import { Fun, Obj, Result } from '@ephox/katamari';
+import { Fun, Obj, type Result } from '@ephox/katamari';
 
 import { SimpleResult } from '../alien/SimpleResult';
 import { choose as chooseProcessor } from '../core/ChoiceProcessor';
-import { FieldProcessor } from '../core/FieldProcessor';
+import type { FieldProcessor } from '../core/FieldProcessor';
 import {
-  arrOf, arrOfObj, func, objOf, objOfOnly, oneOf, setOf as doSetOf, StructureProcessor, thunk, valueThunk as valueThunkOf
+  arrOf, arrOfObj, func, objOf, objOfOnly, oneOf, setOf as doSetOf, type StructureProcessor, thunk, valueThunk as valueThunkOf
 } from '../core/StructureProcessor';
 import { value, anyValue as _anyValue } from '../core/Utils';
 import { formatErrors, formatObj } from '../format/PrettyPrinter';

--- a/modules/boulder/src/main/ts/ephox/boulder/core/ChoiceProcessor.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/ChoiceProcessor.ts
@@ -1,7 +1,7 @@
 import { Obj } from '@ephox/katamari';
 
 import { missingBranch, missingKey } from './SchemaError';
-import { StructureProcessor } from './StructureProcessor';
+import type { StructureProcessor } from './StructureProcessor';
 
 const chooseFrom = (path: string[], input: Record<string, any>, branches: Record<string, StructureProcessor>, ch: string) => {
   const fields = Obj.get(branches, ch);

--- a/modules/boulder/src/main/ts/ephox/boulder/core/FieldProcessor.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/FieldProcessor.ts
@@ -1,6 +1,6 @@
-import { FieldPresence } from '../api/FieldPresence';
+import type { FieldPresence } from '../api/FieldPresence';
 
-import { StructureProcessor } from './StructureProcessor';
+import type { StructureProcessor } from './StructureProcessor';
 
 export const enum FieldTag {
   Field = 'field',

--- a/modules/boulder/src/main/ts/ephox/boulder/core/StructureProcessor.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/StructureProcessor.ts
@@ -1,13 +1,13 @@
 import { Arr, Fun, Merger, Obj, Optional, Thunk, Type } from '@ephox/katamari';
 
 import { SimpleResult, SimpleResultType } from '../alien/SimpleResult';
-import { FieldPresence, FieldPresenceTag, required } from '../api/FieldPresence';
+import { type FieldPresence, FieldPresenceTag, required } from '../api/FieldPresence';
 import { ResultCombine } from '../combine/ResultCombine';
 
 import * as FieldProcessor from './FieldProcessor';
-import { type FieldProcessor as FieldProcessorType } from './FieldProcessor';
+import type { FieldProcessor as FieldProcessorType } from './FieldProcessor';
 import * as SchemaError from './SchemaError';
-import { type SchemaError as SchemaErrorType } from './SchemaError';
+import type { SchemaError as SchemaErrorType } from './SchemaError';
 import { value } from './Utils';
 
 export type ValueValidator = (a) => SimpleResult<string, any>;

--- a/modules/boulder/src/main/ts/ephox/boulder/core/Utils.ts
+++ b/modules/boulder/src/main/ts/ephox/boulder/core/Utils.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import { SimpleResult } from '../alien/SimpleResult';
 
 import * as SchemaError from './SchemaError';
-import { StructureProcessor, ValueValidator } from './StructureProcessor';
+import type { StructureProcessor, ValueValidator } from './StructureProcessor';
 
 const value = (validator: ValueValidator): StructureProcessor => {
   const extract = (path, val) => {

--- a/modules/boulder/src/test/ts/atomic/api/FieldSchemaTest.ts
+++ b/modules/boulder/src/test/ts/atomic/api/FieldSchemaTest.ts
@@ -4,7 +4,7 @@ import { KAssert } from '@ephox/katamari-assertions';
 
 import * as FieldSchema from 'ephox/boulder/api/FieldSchema';
 import * as StructureSchema from 'ephox/boulder/api/StructureSchema';
-import { FieldProcessor } from 'ephox/boulder/core/FieldProcessor';
+import type { FieldProcessor } from 'ephox/boulder/core/FieldProcessor';
 import * as ValueType from 'ephox/boulder/core/ValueType';
 
 UnitTest.test('Atomic Test: api.FieldSchemaTest', () => {

--- a/modules/boulder/src/test/ts/atomic/api/StructureSchemaRawTest.ts
+++ b/modules/boulder/src/test/ts/atomic/api/StructureSchemaRawTest.ts
@@ -7,7 +7,7 @@ import * as FieldPresence from 'ephox/boulder/api/FieldPresence';
 import * as FieldSchema from 'ephox/boulder/api/FieldSchema';
 import * as Objects from 'ephox/boulder/api/Objects';
 import * as StructureSchema from 'ephox/boulder/api/StructureSchema';
-import { StructureProcessor } from 'ephox/boulder/core/StructureProcessor';
+import type { StructureProcessor } from 'ephox/boulder/core/StructureProcessor';
 import * as ValueType from 'ephox/boulder/core/ValueType';
 
 UnitTest.test('StructureSchemaRawTest', () => {

--- a/modules/darwin/src/demo/ts/ephox/darwin/demo/DarwinTableDemo.ts
+++ b/modules/darwin/src/demo/ts/ephox/darwin/demo/DarwinTableDemo.ts
@@ -1,6 +1,6 @@
 import { Fun, Optional } from '@ephox/katamari';
 import {
-  Attribute, Compare, Direction, DomEvent, EventArgs, Insert, Replication, SelectorFind, SimSelection, SugarBody, SugarElement, SugarNode, Traverse,
+  Attribute, Compare, Direction, DomEvent, type EventArgs, Insert, Replication, SelectorFind, SimSelection, SugarBody, SugarElement, SugarNode, Traverse,
   WindowSelection
 } from '@ephox/sugar';
 
@@ -8,7 +8,7 @@ import { Ephemera } from 'ephox/darwin/api/Ephemera';
 import * as InputHandlers from 'ephox/darwin/api/InputHandlers';
 import { SelectionAnnotation } from 'ephox/darwin/api/SelectionAnnotation';
 import * as SelectionKeys from 'ephox/darwin/api/SelectionKeys';
-import { Response } from 'ephox/darwin/selection/Response';
+import type { Response } from 'ephox/darwin/selection/Response';
 import * as Util from 'ephox/darwin/selection/Util';
 
 const ephoxUi = SelectorFind.first('#ephox-ui').getOrDie();

--- a/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/InputHandlers.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { ContentEditable, EventArgs, PredicateFind, Situ, SugarElement, SugarNode } from '@ephox/sugar';
+import { ContentEditable, type EventArgs, PredicateFind, Situ, type SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as KeySelection from '../keyboard/KeySelection';
 import * as VerticalMovement from '../keyboard/VerticalMovement';
@@ -8,7 +8,7 @@ import * as KeyDirection from '../navigation/KeyDirection';
 import * as CellSelection from '../selection/CellSelection';
 import { Response } from '../selection/Response';
 
-import { SelectionAnnotation } from './SelectionAnnotation';
+import type { SelectionAnnotation } from './SelectionAnnotation';
 import * as SelectionKeys from './SelectionKeys';
 import { WindowBridge } from './WindowBridge';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/SelectionAnnotation.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
-import { Attribute, Class, OnNode, SelectorFilter, SugarElement } from '@ephox/sugar';
+import { Attribute, Class, OnNode, SelectorFilter, type SugarElement } from '@ephox/sugar';
 
-import { Ephemera } from './Ephemera';
+import type { Ephemera } from './Ephemera';
 
 export interface SelectionAnnotation {
   clearBeforeUpdate: (container: SugarElement<Node>) => void;

--- a/modules/darwin/src/main/ts/ephox/darwin/api/SelectionTypes.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/SelectionTypes.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 export const enum SelectionTypeTag {
   None = 'none',

--- a/modules/darwin/src/main/ts/ephox/darwin/api/TableSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/TableSelection.ts
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
-import { Structs, TablePositions } from '@ephox/snooker';
-import { Compare, SelectorFind, SugarElement } from '@ephox/sugar';
+import { type Structs, TablePositions } from '@ephox/snooker';
+import { Compare, SelectorFind, type SugarElement } from '@ephox/sugar';
 
 import * as CellSelection from '../selection/CellSelection';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/api/WindowBridge.ts
@@ -1,5 +1,5 @@
-import { Optional } from '@ephox/katamari';
-import { RawRect, Scroll, SimRange, SimSelection, Situ, SugarElement, WindowSelection } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import { type RawRect, Scroll, type SimRange, SimSelection, type Situ, SugarElement, WindowSelection } from '@ephox/sugar';
 
 import { Situs } from '../selection/Situs';
 import * as Util from '../selection/Util';

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/KeySelection.ts
@@ -1,9 +1,9 @@
 import { Optional } from '@ephox/katamari';
-import { Awareness, Compare, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Awareness, Compare, SelectorFind, type SugarElement } from '@ephox/sugar';
 
-import { SelectionAnnotation } from '../api/SelectionAnnotation';
+import type { SelectionAnnotation } from '../api/SelectionAnnotation';
 import * as CellSelection from '../selection/CellSelection';
-import { IdentifiedExt } from '../selection/Identified';
+import type { IdentifiedExt } from '../selection/Identified';
 import { Response } from '../selection/Response';
 import * as Util from '../selection/Util';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Rectangles.ts
@@ -1,9 +1,9 @@
 import { Optional } from '@ephox/katamari';
-import { Awareness, RawRect, SugarElement, SugarNode } from '@ephox/sugar';
+import { Awareness, type RawRect, type SugarElement, SugarNode } from '@ephox/sugar';
 
-import { WindowBridge } from '../api/WindowBridge';
+import type { WindowBridge } from '../api/WindowBridge';
 
-import * as Carets from './Carets';
+import type * as Carets from './Carets';
 
 type Carets = Carets.Carets;
 

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/Retries.ts
@@ -1,10 +1,10 @@
 import { Adt, Fun, Optional } from '@ephox/katamari';
 import { DomGather } from '@ephox/phoenix';
 import { DomStructure } from '@ephox/robin';
-import { PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
+import { PredicateFind, type SugarElement, SugarNode } from '@ephox/sugar';
 
-import { WindowBridge } from '../api/WindowBridge';
-import { Situs } from '../selection/Situs';
+import type { WindowBridge } from '../api/WindowBridge';
+import type { Situs } from '../selection/Situs';
 
 import * as Carets from './Carets';
 import * as Rectangles from './Rectangles';

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/TableKeys.ts
@@ -1,13 +1,13 @@
 import { Optional } from '@ephox/katamari';
-import { Spot, SpotPoint } from '@ephox/phoenix';
+import { Spot, type SpotPoint } from '@ephox/phoenix';
 import { PlatformDetection } from '@ephox/sand';
-import { Awareness, Compare, SimRange, SugarElement } from '@ephox/sugar';
+import { Awareness, Compare, type SimRange, type SugarElement } from '@ephox/sugar';
 
-import { WindowBridge } from '../api/WindowBridge';
+import type { WindowBridge } from '../api/WindowBridge';
 import { BeforeAfter } from '../navigation/BeforeAfter';
 import * as BrTags from '../navigation/BrTags';
-import { KeyDirection } from '../navigation/KeyDirection';
-import { Situs } from '../selection/Situs';
+import type { KeyDirection } from '../navigation/KeyDirection';
+import type { Situs } from '../selection/Situs';
 
 import * as Carets from './Carets';
 import * as Rectangles from './Rectangles';

--- a/modules/darwin/src/main/ts/ephox/darwin/keyboard/VerticalMovement.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/keyboard/VerticalMovement.ts
@@ -1,9 +1,9 @@
 import { Optional } from '@ephox/katamari';
 import { DomGather } from '@ephox/phoenix';
-import { Awareness, Compare, CursorPosition, PredicateExists, SelectorFilter, SelectorFind, SimRange, SugarElement, Traverse } from '@ephox/sugar';
+import { Awareness, Compare, CursorPosition, PredicateExists, SelectorFilter, SelectorFind, type SimRange, type SugarElement, Traverse } from '@ephox/sugar';
 
-import { WindowBridge } from '../api/WindowBridge';
-import { KeyDirection } from '../navigation/KeyDirection';
+import type { WindowBridge } from '../api/WindowBridge';
+import type { KeyDirection } from '../navigation/KeyDirection';
 import { Response } from '../selection/Response';
 import * as Util from '../selection/Util';
 

--- a/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/mouse/MouseSelection.ts
@@ -1,8 +1,8 @@
-import { Optional, Optionals, Singleton } from '@ephox/katamari';
-import { Compare, ContentEditable, EventArgs, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
+import { type Optional, Optionals, Singleton } from '@ephox/katamari';
+import { Compare, ContentEditable, type EventArgs, SelectorFind, type SugarElement, Traverse } from '@ephox/sugar';
 
-import { SelectionAnnotation } from '../api/SelectionAnnotation';
-import { WindowBridge } from '../api/WindowBridge';
+import type { SelectionAnnotation } from '../api/SelectionAnnotation';
+import type { WindowBridge } from '../api/WindowBridge';
 import * as CellSelection from '../selection/CellSelection';
 
 export interface MouseSelection {

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/BeforeAfter.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/BeforeAfter.ts
@@ -1,8 +1,8 @@
-import { Adt, Optional } from '@ephox/katamari';
+import { Adt, type Optional } from '@ephox/katamari';
 import { DomParent } from '@ephox/robin';
-import { Awareness, Compare, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Awareness, Compare, SelectorFind, type SugarElement } from '@ephox/sugar';
 
-import { WindowBridge } from '../api/WindowBridge';
+import type { WindowBridge } from '../api/WindowBridge';
 
 type NoneHandler<T> = (message: string) => T;
 type SuccessHandler<T> = () => T;

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/BrTags.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/BrTags.ts
@@ -1,11 +1,11 @@
 import { Optional } from '@ephox/katamari';
-import { Spot, SpotPoint } from '@ephox/phoenix';
-import { Awareness, ElementAddress, Situ, SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
+import { Spot, type SpotPoint } from '@ephox/phoenix';
+import { Awareness, ElementAddress, Situ, type SugarElement, SugarNode, SugarText, Traverse } from '@ephox/sugar';
 
-import { Situs } from '../selection/Situs';
+import type { Situs } from '../selection/Situs';
 
 import { BeforeAfter } from './BeforeAfter';
-import { KeyDirection } from './KeyDirection';
+import type { KeyDirection } from './KeyDirection';
 
 const isBr = SugarNode.isTag('br');
 

--- a/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/navigation/KeyDirection.ts
@@ -1,13 +1,13 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 import { DomGather } from '@ephox/phoenix';
-import { Situ, SugarElement, Traverse } from '@ephox/sugar';
+import { Situ, type SugarElement, Traverse } from '@ephox/sugar';
 
-import { WindowBridge } from '../api/WindowBridge';
-import { Carets } from '../keyboard/Carets';
+import type { WindowBridge } from '../api/WindowBridge';
+import type { Carets } from '../keyboard/Carets';
 import { Retries } from '../keyboard/Retries';
-import { Situs } from '../selection/Situs';
+import type { Situs } from '../selection/Situs';
 
-import { BeforeAfter, BeforeAfterFailureConstructor } from './BeforeAfter';
+import { BeforeAfter, type BeforeAfterFailureConstructor } from './BeforeAfter';
 
 export interface KeyDirection {
   traverse: (element: SugarElement<Node>) => Optional<SugarElement<Node & ChildNode>>;

--- a/modules/darwin/src/main/ts/ephox/darwin/queries/CellOpSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/queries/CellOpSelection.ts
@@ -1,8 +1,8 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { RunOperation } from '@ephox/snooker';
-import { Attribute, SugarElement } from '@ephox/sugar';
+import type { RunOperation } from '@ephox/snooker';
+import { Attribute, type SugarElement } from '@ephox/sugar';
 
-import { Ephemera } from '../api/Ephemera';
+import type { Ephemera } from '../api/Ephemera';
 import * as TableSelection from '../api/TableSelection';
 
 const selection: (selectedCells: SugarElement<HTMLTableCellElement>[]) => SugarElement<HTMLTableCellElement>[] = Fun.identity;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/CellSelection.ts
@@ -1,9 +1,9 @@
 import { Arr, Optional } from '@ephox/katamari';
 import { DomParent } from '@ephox/robin';
 import { TablePositions } from '@ephox/snooker';
-import { Compare, SelectorFilter, SelectorFind, Selectors, SugarElement } from '@ephox/sugar';
+import { Compare, SelectorFilter, SelectorFind, Selectors, type SugarElement } from '@ephox/sugar';
 
-import { Identified, IdentifiedExt } from './Identified';
+import type { Identified, IdentifiedExt } from './Identified';
 
 interface Edges {
   readonly first: SugarElement<HTMLTableCellElement>;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Identified.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Identified.ts
@@ -1,5 +1,5 @@
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 export interface Identified {
   readonly boxes: Optional<SugarElement<HTMLTableCellElement>[]>;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Response.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Response.ts
@@ -1,6 +1,6 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
-import { Situs } from './Situs';
+import type { Situs } from './Situs';
 
 export interface Response {
   readonly selection: Optional<Situs>;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Selections.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Selections.ts
@@ -1,5 +1,5 @@
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as SelectionTypes from '../api/SelectionTypes';
 import * as TableSelection from '../api/TableSelection';

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Situs.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Situs.ts
@@ -1,4 +1,4 @@
-import { Situ, SugarElement } from '@ephox/sugar';
+import { Situ, type SugarElement } from '@ephox/sugar';
 
 export interface Situs {
   readonly start: Situ;

--- a/modules/darwin/src/main/ts/ephox/darwin/selection/Util.ts
+++ b/modules/darwin/src/main/ts/ephox/darwin/selection/Util.ts
@@ -1,4 +1,4 @@
-import { SelectionDirection, SimRange, SimSelection, SugarElement } from '@ephox/sugar';
+import { SelectionDirection, SimRange, type SimSelection, SugarElement } from '@ephox/sugar';
 
 import { Situs } from './Situs';
 

--- a/modules/dragster/src/main/ts/ephox/dragster/api/DragApis.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/DragApis.ts
@@ -1,7 +1,7 @@
-import { Contracts, Optional } from '@ephox/katamari';
-import { EventArgs, SugarElement, SugarPosition } from '@ephox/sugar';
+import { Contracts, type Optional } from '@ephox/katamari';
+import type { EventArgs, SugarElement, SugarPosition } from '@ephox/sugar';
 
-import { BlockerOptions } from '../detect/Blocker';
+import type { BlockerOptions } from '../detect/Blocker';
 
 export interface DragMutation {
   mutate: (x: number, y: number) => void;

--- a/modules/dragster/src/main/ts/ephox/dragster/api/Dragger.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/Dragger.ts
@@ -1,7 +1,7 @@
 import * as Dragging from '../core/Dragging';
-import { BlockerOptions } from '../detect/Blocker';
+import type { BlockerOptions } from '../detect/Blocker';
 
-import { DragMode, DragMutation } from './DragApis';
+import type { DragMode, DragMutation } from './DragApis';
 import MouseDrag from './MouseDrag';
 
 export interface DraggerOptions extends BlockerOptions {

--- a/modules/dragster/src/main/ts/ephox/dragster/api/Main.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/Main.ts
@@ -1,4 +1,4 @@
-import { DragImageData } from '../datatransfer/DragImage';
+import type { DragImageData } from '../datatransfer/DragImage';
 
 import * as DataTransfer from './DataTransfer';
 import * as DataTransferContent from './DataTransferContent';
@@ -8,13 +8,5 @@ import * as DragApis from './DragApis';
 import * as Dragger from './Dragger';
 import MouseDrag from './MouseDrag';
 
-export {
-  DataTransfer,
-  DataTransferMode,
-  DataTransferContent,
-  DataTransferEvent,
-  DragApis,
-  Dragger,
-  MouseDrag,
-  DragImageData
-};
+export type { DragImageData };
+export { DataTransfer, DataTransferMode, DataTransferContent, DataTransferEvent, DragApis, Dragger, MouseDrag };

--- a/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/api/MouseDrag.ts
@@ -1,9 +1,9 @@
 import { Optional } from '@ephox/katamari';
-import { DomEvent, EventArgs, Insert, Remove, SugarElement, SugarPosition } from '@ephox/sugar';
+import { DomEvent, type EventArgs, Insert, Remove, type SugarElement, SugarPosition } from '@ephox/sugar';
 
-import { Blocker, BlockerOptions } from '../detect/Blocker';
+import { Blocker, type BlockerOptions } from '../detect/Blocker';
 
-import { DragApi, DragMode, DragMutation, DragSink } from './DragApis';
+import { type DragApi, DragMode, type DragMutation, DragSink } from './DragApis';
 
 const compare = (old: SugarPosition, nu: SugarPosition) => {
   return SugarPosition(nu.left - old.left, nu.top - old.top);

--- a/modules/dragster/src/main/ts/ephox/dragster/core/Dragging.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/core/Dragging.ts
@@ -1,9 +1,9 @@
 import { Throttler } from '@ephox/katamari';
-import { Bindable, Event, Events } from '@ephox/porkbun';
-import { EventArgs, SugarElement } from '@ephox/sugar';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
+import type { EventArgs, SugarElement } from '@ephox/sugar';
 
-import { DragApi, DragMode, DragMutation } from '../api/DragApis';
-import { BlockerOptions } from '../detect/Blocker';
+import { DragApi, type DragMode, type DragMutation } from '../api/DragApis';
+import type { BlockerOptions } from '../detect/Blocker';
 import { Movement } from '../detect/Movement';
 
 interface DragActionEvents {

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/DragTypes.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/DragTypes.ts
@@ -1,7 +1,7 @@
-import { Bindable } from '@ephox/porkbun';
-import { EventArgs, SugarPosition } from '@ephox/sugar';
+import type { Bindable } from '@ephox/porkbun';
+import type { EventArgs, SugarPosition } from '@ephox/sugar';
 
-import { DragMode } from '../api/DragApis';
+import type { DragMode } from '../api/DragApis';
 
 export interface DragEvent {
   readonly info: SugarPosition;

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/InDrag.ts
@@ -1,10 +1,10 @@
 import { Optional } from '@ephox/katamari';
 import { Event, Events } from '@ephox/porkbun';
-import { EventArgs, SugarPosition } from '@ephox/sugar';
+import type { EventArgs, SugarPosition } from '@ephox/sugar';
 
-import { DragMode } from '../api/DragApis';
+import type { DragMode } from '../api/DragApis';
 
-import { DragEvents, DragState } from './DragTypes';
+import type { DragEvents, DragState } from './DragTypes';
 
 export const InDrag = (): DragState => {
 

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/Movement.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/Movement.ts
@@ -1,8 +1,8 @@
-import { EventArgs } from '@ephox/sugar';
+import type { EventArgs } from '@ephox/sugar';
 
-import { DragMode } from '../api/DragApis';
+import type { DragMode } from '../api/DragApis';
 
-import { DragEvents, DragState } from './DragTypes';
+import type { DragEvents, DragState } from './DragTypes';
 import { InDrag } from './InDrag';
 import { NoDrag } from './NoDrag';
 

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/NoDrag.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/NoDrag.ts
@@ -1,7 +1,7 @@
 import { Fun } from '@ephox/katamari';
 import { Event, Events } from '@ephox/porkbun';
 
-import { DragEvents, DragState } from './DragTypes';
+import type { DragEvents, DragState } from './DragTypes';
 
 export const NoDrag = (): DragState => {
   const events: DragEvents = Events.create({

--- a/modules/dragster/src/main/ts/ephox/dragster/transform/Grow.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/transform/Grow.ts
@@ -1,5 +1,5 @@
-import { Bindable, Event, Events } from '@ephox/porkbun';
-import { Height, SugarElement, Width } from '@ephox/sugar';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
+import { Height, type SugarElement, Width } from '@ephox/sugar';
 
 export interface GrowEvent {
   readonly x: number;

--- a/modules/dragster/src/main/ts/ephox/dragster/transform/Relocate.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/transform/Relocate.ts
@@ -1,5 +1,5 @@
-import { Bindable, Event, Events } from '@ephox/porkbun';
-import { Css, SugarElement, SugarLocation } from '@ephox/sugar';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
+import { Css, type SugarElement, SugarLocation } from '@ephox/sugar';
 
 export interface RelocateEvent {
   readonly x: number;

--- a/modules/dragster/src/test/ts/atomic/DraggerTest.ts
+++ b/modules/dragster/src/test/ts/atomic/DraggerTest.ts
@@ -1,8 +1,8 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
-import { SugarElement, SugarPosition } from '@ephox/sugar';
+import type { SugarElement, SugarPosition } from '@ephox/sugar';
 
-import { DragApi, DragMode, DragSink } from 'ephox/dragster/api/DragApis';
+import { type DragApi, DragMode, DragSink } from 'ephox/dragster/api/DragApis';
 import * as Dragging from 'ephox/dragster/core/Dragging';
 
 UnitTest.test('DraggerTest', () => {

--- a/modules/dragster/src/test/ts/browser/datatransfer/DataTransferCloneTest.ts
+++ b/modules/dragster/src/test/ts/browser/datatransfer/DataTransferCloneTest.ts
@@ -4,7 +4,7 @@ import { PlatformDetection } from '@ephox/sand';
 import { assert } from 'chai';
 
 import { cloneDataTransfer, createDataTransfer, getDragImage } from 'ephox/dragster/datatransfer/DataTransfer';
-import { DragImageData } from 'ephox/dragster/datatransfer/DragImage';
+import type { DragImageData } from 'ephox/dragster/datatransfer/DragImage';
 import { Event, getEvent, setDragstartEvent } from 'ephox/dragster/datatransfer/Event';
 import { getMode, Mode, setMode, setReadOnlyMode, setReadWriteMode } from 'ephox/dragster/datatransfer/Mode';
 

--- a/modules/jax/src/main/ts/ephox/jax/core/Http.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/Http.ts
@@ -1,8 +1,8 @@
 import { FutureResult, Global, Obj, Optional, Result, Strings, Type } from '@ephox/katamari';
 
 import { DataType } from './DataType';
-import { RequestBody, ResponseBodyDataTypes, ResponseType, ResponseTypeMap, textData } from './HttpData';
-import { HttpError, HttpErrorCode } from './HttpError';
+import { type RequestBody, type ResponseBodyDataTypes, type ResponseType, type ResponseTypeMap, textData } from './HttpData';
+import { type HttpError, HttpErrorCode } from './HttpError';
 import * as HttpTypes from './HttpTypes';
 import * as ResponseError from './ResponseError';
 import * as ResponseSuccess from './ResponseSuccess';

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpError.ts
@@ -1,6 +1,6 @@
 import { Result } from '@ephox/katamari';
 
-import { ResponseType, ResponseTypeMap } from './HttpData';
+import type { ResponseType, ResponseTypeMap } from './HttpData';
 
 export const enum HttpErrorCode {
   Created = 201,

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpJwt.ts
@@ -1,9 +1,9 @@
 import { FutureResult } from '@ephox/katamari';
 
 import * as Http from './Http';
-import { ResponseBodyDataTypes, ResponseType, ResponseTypeMap } from './HttpData';
-import { HttpError, HttpErrorCode } from './HttpError';
-import { GetDelInit, HttpRequest, JwtToken, JwtTokenFactory, PostPutInit } from './HttpTypes';
+import type { ResponseBodyDataTypes, ResponseType, ResponseTypeMap } from './HttpData';
+import { type HttpError, HttpErrorCode } from './HttpError';
+import type { GetDelInit, HttpRequest, JwtToken, JwtTokenFactory, PostPutInit } from './HttpTypes';
 
 const headers = (headersInput: HttpRequest<ResponseBodyDataTypes>['headers'], token: string) => {
   const authHeader = { Authorization: 'Bearer ' + token };

--- a/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/HttpTypes.ts
@@ -1,7 +1,7 @@
-import { FutureResult } from '@ephox/katamari';
+import type { FutureResult } from '@ephox/katamari';
 
-import { RequestBody, ResponseBody, ResponseBodyDataTypes, ResponseType } from './HttpData';
-import { HttpError } from './HttpError';
+import type { RequestBody, ResponseBody, ResponseBodyDataTypes, ResponseType } from './HttpData';
+import type { HttpError } from './HttpError';
 
 export const enum HttpMethod {
   Get = 'get',

--- a/modules/jax/src/main/ts/ephox/jax/core/ResponseError.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/ResponseError.ts
@@ -2,8 +2,8 @@ import { Future, Optional } from '@ephox/katamari';
 
 import { readBlobAsText } from './BlobReader';
 import { DataType } from './DataType';
-import { ResponseBodyDataTypes, ResponseType } from './HttpData';
-import { HttpError } from './HttpError';
+import type { ResponseBodyDataTypes, ResponseType } from './HttpData';
+import type { HttpError } from './HttpError';
 import * as JsonResponse from './JsonResponse';
 
 // can't get responseText of a blob, throws a DomException. Need to use FileReader.

--- a/modules/jax/src/main/ts/ephox/jax/core/ResponseSuccess.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/ResponseSuccess.ts
@@ -1,8 +1,8 @@
 import { FutureResult } from '@ephox/katamari';
 
 import { DataType } from './DataType';
-import { ResponseBodyDataTypes, ResponseType, ResponseTypeMap } from './HttpData';
-import { HttpError } from './HttpError';
+import type { ResponseBodyDataTypes, ResponseType, ResponseTypeMap } from './HttpData';
+import type { HttpError } from './HttpError';
 import * as JsonResponse from './JsonResponse';
 
 export const validate = <T extends ResponseType>(responseType: ResponseBodyDataTypes, request: XMLHttpRequest): FutureResult<ResponseTypeMap[T], HttpError<T>> => {

--- a/modules/jax/src/main/ts/ephox/jax/core/UrlBuilder.ts
+++ b/modules/jax/src/main/ts/ephox/jax/core/UrlBuilder.ts
@@ -1,4 +1,4 @@
-import { Obj, Optional, Strings } from '@ephox/katamari';
+import { Obj, type Optional, Strings } from '@ephox/katamari';
 
 export const buildUrl = (url: string, queryParams: Optional<Record<string, string>>): string => queryParams.map((query) => {
   const parts = Obj.mapToArray(query, (v, k) => encodeURIComponent(k) + '=' + encodeURIComponent(v));

--- a/modules/jax/src/test/ts/browser/AjaxTest.ts
+++ b/modules/jax/src/test/ts/browser/AjaxTest.ts
@@ -4,7 +4,7 @@ import { Arr, FutureResult, Result } from '@ephox/katamari';
 import { readBlobAsText } from 'ephox/jax/core/BlobReader';
 import { DataType } from 'ephox/jax/core/DataType';
 import * as Http from 'ephox/jax/core/Http';
-import { HttpError } from 'ephox/jax/core/HttpError';
+import type { HttpError } from 'ephox/jax/core/HttpError';
 
 /* eslint-disable no-console */
 

--- a/modules/jax/src/test/ts/browser/HttpJwtTest.ts
+++ b/modules/jax/src/test/ts/browser/HttpJwtTest.ts
@@ -2,9 +2,9 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, FutureResult, Result } from '@ephox/katamari';
 
 import { DataType } from 'ephox/jax/core/DataType';
-import { HttpError } from 'ephox/jax/core/HttpError';
+import type { HttpError } from 'ephox/jax/core/HttpError';
 import * as HttpJwt from 'ephox/jax/core/HttpJwt';
-import { JwtTokenFactory } from 'ephox/jax/core/HttpTypes';
+import type { JwtTokenFactory } from 'ephox/jax/core/HttpTypes';
 
 /* eslint-disable no-console */
 

--- a/modules/katamari-assertions/src/main/ts/ephox/katamari-assertions/api/KAssert.ts
+++ b/modules/katamari-assertions/src/main/ts/ephox/katamari-assertions/api/KAssert.ts
@@ -1,4 +1,4 @@
-import { Assert, TestLabel } from '@ephox/bedrock-client';
+import { Assert, type TestLabel } from '@ephox/bedrock-client';
 import { Testable } from '@ephox/dispute';
 import { Optional, OptionalInstances, Result, ResultInstances } from '@ephox/katamari';
 

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Main.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Main.ts
@@ -11,7 +11,7 @@ import * as Id from './Id';
 import * as Jam from './Jam';
 import { LazyValue } from './LazyValue';
 import * as LazyValues from './LazyValues';
-import { Maybe } from './Maybe';
+import type { Maybe } from './Maybe';
 import * as Maybes from './Maybes';
 import * as Merger from './Merger';
 import * as Namespace from './Namespace';
@@ -35,6 +35,7 @@ import * as Unicode from './Unicode';
 import * as Unique from './Unique';
 import * as Zip from './Zip';
 
+export type { Maybe };
 export {
   Adt,
   Arr,
@@ -50,7 +51,6 @@ export {
   Jam,
   LazyValue,
   LazyValues,
-  Maybe,
   Maybes,
   Merger,
   Namespace,

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Maybe.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Maybe.ts
@@ -1,4 +1,4 @@
-import { Just, Nothing } from './Maybes';
+import type { Just, Nothing } from './Maybes';
 
 // The Maybe type, representing a value that either does or doesn't exist. For
 // a series of functions that you can use on this Maybe type, check out

--- a/modules/katamari/src/main/ts/ephox/katamari/api/OptionalInstances.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/OptionalInstances.ts
@@ -1,6 +1,6 @@
 import { Eq, Pnode, Pprint, Testable } from '@ephox/dispute';
 
-import { Optional } from './Optional';
+import type { Optional } from './Optional';
 import * as Optionals from './Optionals';
 
 type PprintType<A> = Pprint.Pprint<A>;

--- a/modules/katamari/src/main/ts/ephox/katamari/api/ResultInstances.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/ResultInstances.ts
@@ -1,7 +1,7 @@
 import { Eq, Pnode, Pprint, Testable } from '@ephox/dispute';
 
 import * as Fun from './Fun';
-import { Result } from './Result';
+import type { Result } from './Result';
 
 type PprintType<A> = Pprint.Pprint<A>;
 type EqType<A> = Eq.Eq<A>;

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Results.ts
@@ -1,7 +1,7 @@
 import { Adt } from './Adt';
 import * as Arr from './Arr';
 import * as Fun from './Fun';
-import { Result } from './Result';
+import type { Result } from './Result';
 
 interface ComparisonAdt<A, B> {
   readonly fold: <T> (

--- a/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/ArrFindTest.ts
@@ -3,7 +3,7 @@ import fc from 'fast-check';
 
 import * as Arr from 'ephox/katamari/api/Arr';
 import * as Fun from 'ephox/katamari/api/Fun';
-import { Optional } from 'ephox/katamari/api/Optional';
+import type { Optional } from 'ephox/katamari/api/Optional';
 import { assertNone, assertSome } from 'ephox/katamari/test/AssertOptional';
 
 describe('atomic.katamari.api.arr.ArrFindTest', () => {

--- a/modules/katamari/src/test/ts/atomic/api/maybe/ApplicativeTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/maybe/ApplicativeTest.ts
@@ -2,7 +2,7 @@ import { context, describe } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
 import * as Fun from 'ephox/katamari/api/Fun';
-import { Maybe } from 'ephox/katamari/api/Maybe';
+import type { Maybe } from 'ephox/katamari/api/Maybe';
 import * as Maybes from 'ephox/katamari/api/Maybes';
 
 const boom = Fun.die('this should not be called');

--- a/modules/katamari/src/test/ts/atomic/api/maybe/MonadTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/maybe/MonadTest.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import fc from 'fast-check';
 
 import * as Fun from 'ephox/katamari/api/Fun';
-import { Maybe } from 'ephox/katamari/api/Maybe';
+import type { Maybe } from 'ephox/katamari/api/Maybe';
 import * as Maybes from 'ephox/katamari/api/Maybes';
 
 describe('atomic.katamari.maybe.MonadTest', () => {

--- a/modules/katamari/src/test/ts/module/ephox/katamari/test/AssertResult.ts
+++ b/modules/katamari/src/test/ts/module/ephox/katamari/test/AssertResult.ts
@@ -1,7 +1,7 @@
 import { Testable } from '@ephox/dispute';
 import { assert } from 'chai';
 
-import { Result } from 'ephox/katamari/api/Result';
+import type { Result } from 'ephox/katamari/api/Result';
 import { tResult } from 'ephox/katamari/api/ResultInstances';
 
 type Testable<A> = Testable.Testable<A>;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/alien/Options.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/alien/Options.ts
@@ -1,4 +1,4 @@
-import { Editor } from './EditorTypes';
+import type { Editor } from './EditorTypes';
 
 /*
   This file exists to avoid depending on the tinymce package, because mcagar supports multiple versions of the editor.

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/McEditor.ts
@@ -2,7 +2,7 @@ import { Chain } from '@ephox/agar';
 import { Global, Id, Type } from '@ephox/katamari';
 import { Attribute, Insert, Remove, Selectors, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import { Editor as EditorType } from '../alien/EditorTypes';
+import type { Editor as EditorType } from '../alien/EditorTypes';
 import { loadScript } from '../loader/Loader';
 import { detectTinymceBaseUrl, setupTinymceBaseUrl } from '../loader/Urls';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/ThemeSelectors.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun, Global, Obj } from '@ephox/katamari';
 
-import { Editor } from '../alien/EditorTypes';
+import type { Editor } from '../alien/EditorTypes';
 import { get as getOption } from '../alien/Options';
 
 const isSilver = (): boolean => {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyDom.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/TinyDom.ts
@@ -1,6 +1,6 @@
 import { SimRange, SugarElement } from '@ephox/sugar';
 
-import { Editor } from '../alien/EditorTypes';
+import type { Editor } from '../alien/EditorTypes';
 
 export interface TinyDom {
   readonly fromDom: <T extends Node | Window>(elm: T) => SugarElement<T>;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyAssertions.ts
@@ -1,9 +1,9 @@
-import { Assertions, Cursors, StructAssert } from '@ephox/agar';
+import { Assertions, Cursors, type StructAssert } from '@ephox/agar';
 import { Optional } from '@ephox/katamari';
 import { Hierarchy, Html, SugarElement } from '@ephox/sugar';
 
-import { Editor, GetContentArgs } from '../../alien/EditorTypes';
-import { Presence } from '../pipeline/TinyApis';
+import type { Editor, GetContentArgs } from '../../alien/EditorTypes';
+import type { Presence } from '../pipeline/TinyApis';
 import { TinyDom } from '../TinyDom';
 
 const assertPath = (label: string, root: SugarElement<Node>, expPath: number[], expOffset: number, actElement: Node, actOffset: number): void => {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyContentActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyContentActions.ts
@@ -1,6 +1,6 @@
 import { Keyboard, Mouse } from '@ephox/agar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import * as TypeText from '../../keyboard/TypeText';
 import { TinyDom } from '../TinyDom';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyHooks.ts
@@ -2,7 +2,7 @@ import { after, afterEach, before } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
-import { Editor as EditorType } from '../../alien/EditorTypes';
+import type { Editor as EditorType } from '../../alien/EditorTypes';
 import * as Loader from '../../loader/Loader';
 import { setupTinymceBaseUrl } from '../../loader/Urls';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinySelections.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinySelections.ts
@@ -1,6 +1,6 @@
 import { Cursors, UiFinder } from '@ephox/agar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import { createDomSelection } from '../../selection/SelectionTools';
 import { TinyDom } from '../TinyDom';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyState.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyState.ts
@@ -1,4 +1,4 @@
-import { Editor as EditorType } from '../../alien/EditorTypes';
+import type { Editor as EditorType } from '../../alien/EditorTypes';
 
 const setEditableRoot = <T extends EditorType = EditorType>(editor: T, state: boolean) => {
   if (editor.setEditableRoot) {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/bdd/TinyUiActions.ts
@@ -1,8 +1,8 @@
 import { Keyboard, Mouse, Touch, UiFinder } from '@ephox/agar';
 import { Type } from '@ephox/katamari';
-import { SelectorFind, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { SelectorFind, type SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import { getThemeSelectors } from '../ThemeSelectors';
 import { TinyDom } from '../TinyDom';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/legacy/LegacyUnit.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/legacy/LegacyUnit.ts
@@ -1,6 +1,6 @@
 import { Assertions, Logger, Step } from '@ephox/agar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import { TinyDom } from '../TinyDom';
 
 type SyncTestCallback<T> = (initValue: T) => void;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ActionChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ActionChains.ts
@@ -2,7 +2,7 @@ import { Chain, FocusTools, Keyboard, NamedChain } from '@ephox/agar';
 import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 
 export interface ActionChains {
   cContentKeypress: <T extends Editor> (code: number, modifiers?: Record<string, any>) => Chain<T, T>;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ApiChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/ApiChains.ts
@@ -1,11 +1,11 @@
-import { Chain, Cursors, StructAssert } from '@ephox/agar';
+import { Chain, Cursors, type StructAssert } from '@ephox/agar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import * as Options from '../../alien/Options';
 import * as TinyAssertions from '../bdd/TinyAssertions';
 import * as TinySelections from '../bdd/TinySelections';
 
-import { Presence } from './TinyApis';
+import type { Presence } from './TinyApis';
 
 export interface ApiChains {
   cNodeChanged: <T extends Editor> () => Chain<T, T>;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/RemoteTinyLoader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/RemoteTinyLoader.ts
@@ -1,6 +1,6 @@
 import { TestLogs } from '@ephox/agar';
 import { Arr, FutureResult, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Loader from '../../loader/Loader';
 import { setTinymceBaseUrl } from '../../loader/Urls';

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyActions.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyActions.ts
@@ -1,7 +1,7 @@
-import { Keyboard, Step } from '@ephox/agar';
+import { Keyboard, type Step } from '@ephox/agar';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 
 export interface TinyActions {
   sContentKeydown: <T> (code: number, modifiers?: Record<string, any>) => Step<T, T>;

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyApis.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyApis.ts
@@ -1,7 +1,7 @@
-import { Assertions, Chain, Cursors, Step, StructAssert, Waiter } from '@ephox/agar';
+import { Assertions, Chain, type Cursors, Step, type StructAssert, Waiter } from '@ephox/agar';
 import { Fun } from '@ephox/katamari';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import * as Options from '../../alien/Options';
 import * as TinyAssertions from '../bdd/TinyAssertions';
 import * as TinySelections from '../bdd/TinySelections';

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyScenarios.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyScenarios.ts
@@ -1,8 +1,8 @@
-import { Generators, PropertySteps, Step } from '@ephox/agar';
-import { Html, SimRange, SugarElement } from '@ephox/sugar';
-import * as fc from 'fast-check';
+import { Generators, PropertySteps, type Step } from '@ephox/agar';
+import { Html, type SimRange, SugarElement } from '@ephox/sugar';
+import type * as fc from 'fast-check';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 
 type ContentGenerator = fc.Arbitrary<SugarElement<HTMLElement>>;
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyUi.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/TinyUi.ts
@@ -2,7 +2,7 @@ import { Assertions, Chain, Mouse, Step, UiFinder } from '@ephox/agar';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarElement, SugarShadowDom, Visibility } from '@ephox/sugar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import * as TinyUiActions from '../bdd/TinyUiActions';
 import { getThemeSelectors } from '../ThemeSelectors';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/UiChains.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/api/pipeline/UiChains.ts
@@ -2,7 +2,7 @@ import { Chain, Guard, Mouse, NamedChain, UiFinder } from '@ephox/agar';
 import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarElement, Visibility } from '@ephox/sugar';
 
-import { Editor } from '../../alien/EditorTypes';
+import type { Editor } from '../../alien/EditorTypes';
 import { getThemeSelectors } from '../ThemeSelectors';
 
 export interface UiChains {

--- a/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/loader/Loader.ts
@@ -1,8 +1,8 @@
-import { TestLogs } from '@ephox/agar';
-import { Arr, Fun, FutureResult, Global, Id, Optional, Result, Type } from '@ephox/katamari';
+import type { TestLogs } from '@ephox/agar';
+import { Arr, Fun, FutureResult, Global, Id, type Optional, Result, Type } from '@ephox/katamari';
 import { Attribute, DomEvent, Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarHead, SugarShadowDom } from '@ephox/sugar';
 
-import { Editor } from '../alien/EditorTypes';
+import type { Editor } from '../alien/EditorTypes';
 
 import { detectTinymceBaseUrl } from './Urls';
 

--- a/modules/mcagar/src/main/ts/ephox/mcagar/selection/SelectionTools.ts
+++ b/modules/mcagar/src/main/ts/ephox/mcagar/selection/SelectionTools.ts
@@ -1,5 +1,5 @@
 import { Chain, Cursors } from '@ephox/agar';
-import { SimRange, SugarElement, Traverse } from '@ephox/sugar';
+import { type SimRange, type SugarElement, Traverse } from '@ephox/sugar';
 
 const toDomRange = (range: SimRange): Range => {
   const doc = Traverse.owner(range.start);

--- a/modules/mcagar/src/test/ts/browser/api/ActionsTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/ActionsTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Chain, Pipeline, Step, Waiter } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 
-import { Editor as EditorType } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor as EditorType } from 'ephox/mcagar/alien/EditorTypes';
 import * as McEditor from 'ephox/mcagar/api/McEditor';
 import { ActionChains } from 'ephox/mcagar/api/pipeline/ActionChains';
 

--- a/modules/mcagar/src/test/ts/browser/api/TinyLoaderErrorTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyLoaderErrorTest.ts
@@ -1,7 +1,7 @@
 import { UnitTest } from '@ephox/bedrock-client';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
-import { Editor } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
 
 UnitTest.asynctest('TinyLoader should fail (instead of timeout) when exception is thrown in callback function', (success, failure) => {

--- a/modules/mcagar/src/test/ts/browser/api/TinyLoaderTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyLoaderTest.ts
@@ -1,7 +1,7 @@
 import { Assertions, Logger, Pipeline, Step, TestLogs } from '@ephox/agar';
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 
-import { Editor } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
 import { TinyUi } from 'ephox/mcagar/api/pipeline/TinyUi';
 

--- a/modules/mcagar/src/test/ts/browser/api/TinyScenariosTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinyScenariosTest.ts
@@ -3,7 +3,7 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarNode } from '@ephox/sugar';
 
-import { Editor } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import { TinyApis } from 'ephox/mcagar/api/pipeline/TinyApis';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
 import { TinyScenarios } from 'ephox/mcagar/api/pipeline/TinyScenarios';

--- a/modules/mcagar/src/test/ts/browser/api/TinySetAndDeleteSettingTest.ts
+++ b/modules/mcagar/src/test/ts/browser/api/TinySetAndDeleteSettingTest.ts
@@ -2,7 +2,7 @@ import { Assertions, GeneralSteps, Logger, Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 
-import { Editor } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import { TinyApis } from 'ephox/mcagar/api/pipeline/TinyApis';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
 

--- a/modules/mcagar/src/test/ts/browser/doc/McagarTutorialTest.ts
+++ b/modules/mcagar/src/test/ts/browser/doc/McagarTutorialTest.ts
@@ -1,7 +1,7 @@
 import { Pipeline, Step } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 
-import { Editor } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import { TinyApis } from 'ephox/mcagar/api/pipeline/TinyApis';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
 import { TinyUi } from 'ephox/mcagar/api/pipeline/TinyUi';

--- a/modules/mcagar/src/test/ts/browser/doc/ScenarioTutorialTest.ts
+++ b/modules/mcagar/src/test/ts/browser/doc/ScenarioTutorialTest.ts
@@ -1,9 +1,9 @@
 import { Arbitraries, Assertions, Pipeline, Step, UiFinder } from '@ephox/agar';
 import { UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { Editor } from 'ephox/mcagar/alien/EditorTypes';
+import type { Editor } from 'ephox/mcagar/alien/EditorTypes';
 import { TinyApis } from 'ephox/mcagar/api/pipeline/TinyApis';
 import * as TinyLoader from 'ephox/mcagar/api/pipeline/TinyLoader';
 import { TinyScenarios } from 'ephox/mcagar/api/pipeline/TinyScenarios';

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.stories.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react-vite';
-import { type ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import type { PartialStoryFn } from 'storybook/internal/csf';
 
 import { FlowKeyingWithCycles } from './stories/FlowKeyingWithCycles.story';

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithCycles.story.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithCycles.story.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import { useFlowKeyNavigation } from '../../../KeyboardNavigationHooks';
-import { type Story } from '../FlowType.stories';
+import type { Story } from '../FlowType.stories';
 
 import { Container } from './Container';
 

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithoutCycles.story.tsx
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/stories/FlowKeyingWithoutCycles.story.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef } from 'react';
 
 import { useFlowKeyNavigation } from '../../../KeyboardNavigationHooks';
-import { type Story } from '../FlowType.stories';
+import type { Story } from '../FlowType.stories';
 
 import { Container } from './Container';
 

--- a/modules/phoenix/src/demo/ts/ephox/phoenix/demo/LatinDemo.ts
+++ b/modules/phoenix/src/demo/ts/ephox/phoenix/demo/LatinDemo.ts
@@ -1,7 +1,7 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
 import { Attribute, Css, DomEvent, Insert, SugarElement, SugarText } from '@ephox/sugar';
 
-import { Wrapter } from 'ephox/phoenix/api/data/Types';
+import type { Wrapter } from 'ephox/phoenix/api/data/Types';
 import * as DomSearch from 'ephox/phoenix/api/dom/DomSearch';
 import * as DomWrapping from 'ephox/phoenix/api/dom/DomWrapping';
 

--- a/modules/phoenix/src/demo/ts/ephox/phoenix/demo/SearchDemo.ts
+++ b/modules/phoenix/src/demo/ts/ephox/phoenix/demo/SearchDemo.ts
@@ -1,7 +1,7 @@
 import { Arr, Optional } from '@ephox/katamari';
 import { Attribute, Class, Css, DomEvent, Insert, InsertAll, SugarElement, Value } from '@ephox/sugar';
 
-import { SearchResult } from 'ephox/phoenix/api/data/Types';
+import type { SearchResult } from 'ephox/phoenix/api/data/Types';
 import * as DomSearch from 'ephox/phoenix/api/dom/DomSearch';
 import * as DomWrapping from 'ephox/phoenix/api/dom/DomWrapping';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/Main.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/Main.ts
@@ -8,7 +8,7 @@ import { SplitPosition } from './data/SplitPosition';
 import * as Spot from './data/Spot';
 import { TextSplit } from './data/TextSplit';
 import { TypedItem } from './data/TypedItem';
-import {
+import type {
   Direction, SearchResult, SpanWrapRange, SpotDelta, SpotPoint, SpotPoints, SpotRange, SpotText, Successor, Transition, Traverse, Wrapter
 } from './data/Types';
 import * as DomDescent from './dom/DomDescent';
@@ -28,15 +28,7 @@ import * as Search from './general/Search';
 import * as Split from './general/Split';
 import * as Wrapping from './general/Wrapping';
 
-export {
-  Focus,
-  GatherResult,
-  InjectPosition,
-  NamedPattern,
-  SplitPosition,
-  Spot,
-  TextSplit,
-  TypedItem,
+export type {
   SpotPoint,
   SpotDelta,
   SpotRange,
@@ -48,7 +40,17 @@ export {
   Traverse,
   Successor,
   Wrapter,
-  SpanWrapRange,
+  SpanWrapRange
+};
+export {
+  Focus,
+  GatherResult,
+  InjectPosition,
+  NamedPattern,
+  SplitPosition,
+  Spot,
+  TextSplit,
+  TypedItem,
   DomDescent,
   DomExtract,
   DomFamily,

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/NamedPattern.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/NamedPattern.ts
@@ -1,4 +1,4 @@
-import { PRegExp } from '@ephox/polaris';
+import type { PRegExp } from '@ephox/polaris';
 
 export interface NamedPattern {
   word: string;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Spot.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Spot.ts
@@ -1,4 +1,4 @@
-import { SpotDelta, SpotPoint, SpotPoints, SpotRange, SpotText } from './Types';
+import type { SpotDelta, SpotPoint, SpotPoints, SpotRange, SpotText } from './Types';
 
 const point = <E>(element: E, offset: number): SpotPoint<E> => ({
   element,

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/TextSplit.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/TextSplit.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 export interface TextSplit<E> {
   readonly before: Optional<E>;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/TypedItem.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/TypedItem.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Adt, Fun, Optional } from '@ephox/katamari';
 
 type Handler<E, D, U> = (item: E, universe: Universe<E, D>) => U;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Types.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/data/Types.ts
@@ -1,5 +1,5 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
 export interface SpotPoint<E> {
   readonly element: E;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomDescent.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomDescent.ts
@@ -1,7 +1,7 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SpotPoint } from '../data/Types';
+import type { SpotPoint } from '../data/Types';
 import * as Descent from '../general/Descent';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomExtract.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomExtract.ts
@@ -1,9 +1,9 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { TypedItem } from '../data/TypedItem';
-import { SpotPoint } from '../data/Types';
+import type { TypedItem } from '../data/TypedItem';
+import type { SpotPoint } from '../data/Types';
 import * as Extract from '../general/Extract';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomFamily.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomFamily.ts
@@ -1,7 +1,7 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { TypedItem } from '../data/TypedItem';
+import type { TypedItem } from '../data/TypedItem';
 import * as Family from '../general/Family';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomGather.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomGather.ts
@@ -1,8 +1,8 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { Direction, Successor, Transition, Traverse } from '../data/Types';
+import type { Direction, Successor, Transition, Traverse } from '../data/Types';
 import * as Gather from '../general/Gather';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomInjection.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomInjection.ts
@@ -1,5 +1,5 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Injection from '../general/Injection';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomSearch.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomSearch.ts
@@ -1,8 +1,8 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { NamedPattern } from '../data/NamedPattern';
-import { SearchResult } from '../data/Types';
+import type { NamedPattern } from '../data/NamedPattern';
+import type { SearchResult } from '../data/Types';
 import * as Search from '../general/Search';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomSplit.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomSplit.ts
@@ -1,9 +1,9 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SplitPosition } from '../data/SplitPosition';
-import { TextSplit } from '../data/TextSplit';
-import { SpotRange } from '../data/Types';
+import type { SplitPosition } from '../data/SplitPosition';
+import type { TextSplit } from '../data/TextSplit';
+import type { SpotRange } from '../data/Types';
 import * as Split from '../general/Split';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomWrapping.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/dom/DomWrapping.ts
@@ -1,8 +1,8 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SpanWrapRange, SpotPoints, Wrapter } from '../data/Types';
+import type { SpanWrapRange, SpotPoints, Wrapter } from '../data/Types';
 import * as Wrapping from '../general/Wrapping';
 
 const universe = DomUniverse();

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Descent.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Descent.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Navigation from '../../wrap/Navigation';
-import { SpotPoint } from '../data/Types';
+import type { SpotPoint } from '../data/Types';
 
 type ToLeafApi = <E, D>(universe: Universe<E, D>, element: E, offset: number) => SpotPoint<E>;
 const toLeaf: ToLeafApi = Navigation.toLeaf;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Extract.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Extract.ts
@@ -1,11 +1,11 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
 import * as Extract from '../../extract/Extract';
 import * as ExtractText from '../../extract/ExtractText';
 import * as Find from '../../extract/Find';
-import { TypedItem } from '../data/TypedItem';
-import { SpotPoint } from '../data/Types';
+import type { TypedItem } from '../data/TypedItem';
+import type { SpotPoint } from '../data/Types';
 
 type FromApi = <E, D>(universe: Universe<E, D>, item: E, optimise?: (e: E) => boolean) => TypedItem<E, D>[];
 const from: FromApi = Extract.typed;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Family.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Family.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Group from '../../family/Group';
 import * as Range from '../../family/Range';
-import { TypedItem } from '../data/TypedItem';
+import type { TypedItem } from '../data/TypedItem';
 
 type RangeApi = <E, D>(universe: Universe<E, D>, item1: E, delta1: number, item2: E, delta2: number) => E[];
 const range: RangeApi = Range.range;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Gather.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Gather.ts
@@ -1,10 +1,10 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
 import * as Seeker from '../../gather/Seeker';
 import { advance, backtrack, go, sidestep } from '../../gather/Walker';
 import { Walkers } from '../../gather/Walkers';
-import { Direction, Successor, Transition, Traverse } from '../data/Types';
+import type { Direction, Successor, Transition, Traverse } from '../data/Types';
 
 const isLeaf = <E, D>(universe: Universe<E, D>) => (element: E) => universe.property().children(element).length === 0;
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Injection.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Injection.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Injection from '../../injection/Injection';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Search.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Search.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Searcher from '../../search/Searcher';
-import { NamedPattern } from '../data/NamedPattern';
-import { SearchResult } from '../data/Types';
+import type { NamedPattern } from '../data/NamedPattern';
+import type { SearchResult } from '../data/Types';
 
 type RunApi = <E, D>(universe: Universe<E, D>, elements: E[], patterns: NamedPattern[], optimise?: (e: E) => boolean) => SearchResult<E>[];
 const run: RunApi = Searcher.run;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Split.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Split.ts
@@ -1,12 +1,12 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Splitter from '../../search/Splitter';
 import * as Positions from '../../split/Positions';
 import * as Range from '../../split/Range';
 import * as Split from '../../split/Split';
-import { SplitPosition } from '../data/SplitPosition';
-import { TextSplit } from '../data/TextSplit';
-import { SpotRange } from '../data/Types';
+import type { SplitPosition } from '../data/SplitPosition';
+import type { TextSplit } from '../data/TextSplit';
+import type { SpotRange } from '../data/Types';
 
 type SplitApi = <E, D>(universe: Universe<E, D>, item: E, position: number) => TextSplit<E>;
 const split: SplitApi = Split.split;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Wrapping.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/api/general/Wrapping.ts
@@ -1,10 +1,10 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
 import * as SpanWrap from '../../wrap/SpanWrap';
 import * as Wrapper from '../../wrap/Wrapper';
 import { Wraps } from '../../wrap/Wraps';
-import { SpanWrapRange, SpotPoints, Wrapter } from '../data/Types';
+import type { SpanWrapRange, SpotPoints, Wrapter } from '../data/Types';
 
 type NuApi = <E, D>(universe: Universe<E, D>, item: E) => Wrapter<E>;
 const nu: NuApi = Wraps;

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/Extract.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/Extract.ts
@@ -1,9 +1,9 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
 import * as Spot from '../api/data/Spot';
 import { TypedItem } from '../api/data/TypedItem';
-import { SpotPoint } from '../api/data/Types';
+import type { SpotPoint } from '../api/data/Types';
 
 import * as TypedList from './TypedList';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/ExtractText.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/ExtractText.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 
 import * as Extract from './Extract';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/Find.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/Find.ts
@@ -1,9 +1,9 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 import { PositionArray } from '@ephox/polaris';
 
 import * as Spot from '../api/data/Spot';
-import { SpotPoint } from '../api/data/Types';
+import type { SpotPoint } from '../api/data/Types';
 
 import * as Extract from './Extract';
 import * as TypedList from './TypedList';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/extract/TypedList.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/extract/TypedList.ts
@@ -2,8 +2,8 @@ import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Arrays } from '@ephox/polaris';
 
 import * as Spot from '../api/data/Spot';
-import { TypedItem } from '../api/data/TypedItem';
-import { SpotRange } from '../api/data/Types';
+import type { TypedItem } from '../api/data/TypedItem';
+import type { SpotRange } from '../api/data/Types';
 
 const count = <E, D>(parray: TypedItem<E, D>[]): number => {
   return Arr.foldr(parray, (b, a) => {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/family/Group.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/family/Group.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 import { Arrays, Splitting } from '@ephox/polaris';
 
-import { TypedItem } from '../api/data/TypedItem';
+import type { TypedItem } from '../api/data/TypedItem';
 import * as Extract from '../api/general/Extract';
 
 /**

--- a/modules/phoenix/src/main/ts/ephox/phoenix/family/Parents.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/family/Parents.ts
@@ -1,5 +1,5 @@
-import { Universe } from '@ephox/boss';
-import { Arr, Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import { Arr, type Optional } from '@ephox/katamari';
 
 /**
  * Search the parents of both items for a common element

--- a/modules/phoenix/src/main/ts/ephox/phoenix/family/Range.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/family/Range.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 
 import * as Extract from '../api/general/Extract';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/gather/Seeker.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/gather/Seeker.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
-import { Direction, Transition } from '../api/data/Types';
+import type { Direction, Transition } from '../api/data/Types';
 
 import * as Walker from './Walker';
 import { Walkers } from './Walkers';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/gather/Walker.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/gather/Walker.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 
-import { Direction, Successor, Transition, Traverse } from '../api/data/Types';
+import type { Direction, Successor, Transition, Traverse } from '../api/data/Types';
 
 const traverse = <E>(item: E, mode: Transition): Traverse<E> => ({
   item,

--- a/modules/phoenix/src/main/ts/ephox/phoenix/gather/Walkers.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/gather/Walkers.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
-import { Direction } from '../api/data/Types';
+import type { Direction } from '../api/data/Types';
 
 const left = (): Direction => {
   const sibling = <E, D>(universe: Universe<E, D>, item: E) => {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/injection/Injection.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/injection/Injection.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Fun } from '@ephox/katamari';
 
 import { InjectPosition } from '../api/data/InjectPosition';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/MatchSplitter.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/MatchSplitter.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
-import { PositionArray, PRange } from '@ephox/polaris';
+import { PositionArray, type PRange } from '@ephox/polaris';
 
-import { SearchResult, SpotRange } from '../api/data/Types';
+import type { SearchResult, SpotRange } from '../api/data/Types';
 
 import * as Splitter from './Splitter';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/Searcher.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/Searcher.ts
@@ -1,11 +1,11 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 import { Pattern, PositionArray, Search } from '@ephox/polaris';
 
 import { NamedPattern } from '../api/data/NamedPattern';
 import * as Spot from '../api/data/Spot';
-import { TypedItem } from '../api/data/TypedItem';
-import { SearchResult, SpotRange } from '../api/data/Types';
+import type { TypedItem } from '../api/data/TypedItem';
+import type { SearchResult, SpotRange } from '../api/data/Types';
 import * as Family from '../api/general/Family';
 import * as TypedList from '../extract/TypedList';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/search/Splitter.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/search/Splitter.ts
@@ -1,9 +1,9 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 import { PositionArray, Strings } from '@ephox/polaris';
 
 import * as Spot from '../api/data/Spot';
-import { SpotRange } from '../api/data/Types';
+import type { SpotRange } from '../api/data/Types';
 
 /**
  * Re-generates an item's text nodes, split as defined by the positions array.

--- a/modules/phoenix/src/main/ts/ephox/phoenix/split/Positions.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/split/Positions.ts
@@ -1,5 +1,5 @@
 import { SplitPosition } from '../api/data/SplitPosition';
-import { TextSplit } from '../api/data/TextSplit';
+import type { TextSplit } from '../api/data/TextSplit';
 
 /*
  * Categorise a split of a text node as: none, start, middle, or end

--- a/modules/phoenix/src/main/ts/ephox/phoenix/split/Range.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/split/Range.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Spot from '../api/data/Spot';
 import * as Family from '../api/general/Family';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/split/Split.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/split/Split.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 import { Strings } from '@ephox/polaris';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/util/Contiguous.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/util/Contiguous.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 
 export interface Group<E> {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Navigation.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Navigation.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
 import * as Spot from '../api/data/Spot';
-import { SpotPoint } from '../api/data/Types';
+import type { SpotPoint } from '../api/data/Types';
 
 /**
  * Return the last available cursor position in the node.

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/OrphanText.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/OrphanText.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
 export interface OrphanText<E> {

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/SpanWrap.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/SpanWrap.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Fun, Optional, Unicode } from '@ephox/katamari';
 
 import * as Spot from '../api/data/Spot';
-import { SpanWrapRange, SpotPoint } from '../api/data/Types';
+import type { SpanWrapRange, SpotPoint } from '../api/data/Types';
 import * as Injection from '../api/general/Injection';
 
 import * as Wrapper from './Wrapper';

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Wrapper.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Wrapper.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 
 import * as Spot from '../api/data/Spot';
-import { SpotPoints, Wrapter } from '../api/data/Types';
+import type { SpotPoints, Wrapter } from '../api/data/Types';
 import * as Split from '../api/general/Split';
 import * as Contiguous from '../util/Contiguous';
 

--- a/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Wraps.ts
+++ b/modules/phoenix/src/main/ts/ephox/phoenix/wrap/Wraps.ts
@@ -1,6 +1,6 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
-import { Wrapter } from '../api/data/Types';
+import type { Wrapter } from '../api/data/Types';
 
 export const Wraps = <E, D>(universe: Universe<E, D>, item: E): Wrapter<E> => {
   const wrap = (contents: E) => {

--- a/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTextTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/api/extract/ExtractTextTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Gene, TestUniverse, TextGene, Universe } from '@ephox/boss';
+import { Gene, TestUniverse, TextGene, type Universe } from '@ephox/boss';
 
 import * as Extract from 'ephox/phoenix/api/general/Extract';
 import * as Finder from 'ephox/phoenix/test/Finder';

--- a/modules/phoenix/src/test/ts/atomic/gather/WalkerPathTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/gather/WalkerPathTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
-import { Direction, Traverse } from 'ephox/phoenix/api/data/Types';
+import type { Direction, Traverse } from 'ephox/phoenix/api/data/Types';
 import * as Walker from 'ephox/phoenix/gather/Walker';
 import { Walkers } from 'ephox/phoenix/gather/Walkers';
 import * as Finder from 'ephox/phoenix/test/Finder';

--- a/modules/phoenix/src/test/ts/atomic/gather/WalkerTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/gather/WalkerTest.ts
@@ -2,7 +2,7 @@ import { UnitTest } from '@ephox/bedrock-client';
 import { Gene, TestUniverse } from '@ephox/boss';
 import { KAssert } from '@ephox/katamari-assertions';
 
-import { Direction, Transition } from 'ephox/phoenix/api/data/Types';
+import type { Direction, Transition } from 'ephox/phoenix/api/data/Types';
 import * as Walker from 'ephox/phoenix/gather/Walker';
 import { Walkers } from 'ephox/phoenix/gather/Walkers';
 import * as Finder from 'ephox/phoenix/test/Finder';

--- a/modules/phoenix/src/test/ts/atomic/search/MatchSplitterTest.ts
+++ b/modules/phoenix/src/test/ts/atomic/search/MatchSplitterTest.ts
@@ -1,7 +1,7 @@
 import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
-import { PositionArray, PRange } from '@ephox/polaris';
+import { PositionArray, type PRange } from '@ephox/polaris';
 
 import * as Spot from 'ephox/phoenix/api/data/Spot';
 import * as MatchSplitter from 'ephox/phoenix/search/MatchSplitter';

--- a/modules/phoenix/src/test/ts/browser/DomDescentTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomDescentTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
 import { Hierarchy, SugarElement } from '@ephox/sugar';
 
-import { SpotPoint } from 'ephox/phoenix/api/data/Types';
+import type { SpotPoint } from 'ephox/phoenix/api/data/Types';
 import * as DomDescent from 'ephox/phoenix/api/dom/DomDescent';
 
 UnitTest.test('DomDescentTest', () => {

--- a/modules/phoenix/src/test/ts/browser/DomGatherTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomGatherTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Arr, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, type Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as DomGather from 'ephox/phoenix/api/dom/DomGather';
 

--- a/modules/phoenix/src/test/ts/browser/DomSplitTest.ts
+++ b/modules/phoenix/src/test/ts/browser/DomSplitTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SugarElement, SugarText, Traverse } from '@ephox/sugar';
+import { type SugarElement, SugarText, Traverse } from '@ephox/sugar';
 
 import * as DomSplit from 'ephox/phoenix/api/dom/DomSplit';
 

--- a/modules/phoenix/src/test/ts/browser/FamilyGroupTest.ts
+++ b/modules/phoenix/src/test/ts/browser/FamilyGroupTest.ts
@@ -3,7 +3,7 @@ import { DomUniverse } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarElement, SugarText } from '@ephox/sugar';
 
-import { TypedItem } from 'ephox/phoenix/api/data/TypedItem';
+import type { TypedItem } from 'ephox/phoenix/api/data/TypedItem';
 import * as Family from 'ephox/phoenix/api/general/Family';
 
 UnitTest.test('FamilyGroupTest', () => {

--- a/modules/phoenix/src/test/ts/module/ephox/phoenix/test/Finder.ts
+++ b/modules/phoenix/src/test/ts/module/ephox/phoenix/test/Finder.ts
@@ -1,4 +1,4 @@
-import { Gene, TestUniverse } from '@ephox/boss';
+import type { Gene, TestUniverse } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
 const get = (universe: TestUniverse, id: string): Gene => {

--- a/modules/phoenix/src/test/ts/module/ephox/phoenix/test/TestRenders.ts
+++ b/modules/phoenix/src/test/ts/module/ephox/phoenix/test/TestRenders.ts
@@ -1,7 +1,7 @@
-import { Gene } from '@ephox/boss';
+import type { Gene } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 
-import { TypedItem } from 'ephox/phoenix/api/data/TypedItem';
+import type { TypedItem } from 'ephox/phoenix/api/data/TypedItem';
 
 const typeditem = (a: TypedItem<Gene, undefined>): string => {
   return a.fold((item) => {

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Arrays.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Arrays.ts
@@ -2,7 +2,7 @@ import * as Boundaries from '../array/Boundaries';
 import * as Slice from '../array/Slice';
 import * as Split from '../array/Split';
 
-import { Splitting } from './Splitting';
+import type { Splitting } from './Splitting';
 
 type BoundAtApi = <T, T2>(xs: T[], left: T2, right: T2, comparator: (a: T2, b: T) => boolean) => T[];
 const boundAt: BoundAtApi = Boundaries.boundAt;

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Main.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Main.ts
@@ -1,5 +1,5 @@
-import { PRange, PRegExp } from '../pattern/Types';
-import { WordOptions } from '../words/Words';
+import type { PRange, PRegExp } from '../pattern/Types';
+import type { WordOptions } from '../words/Words';
 
 import * as Arrays from './Arrays';
 import * as Pattern from './Pattern';
@@ -11,17 +11,5 @@ import * as Strings from './Strings';
 import * as Url from './Url';
 import * as Words from './Words';
 
-export {
-  Arrays,
-  Pattern,
-  PositionArray,
-  PRange,
-  PRegExp,
-  Regexes,
-  Search,
-  Splitting,
-  Strings,
-  Url,
-  Words,
-  WordOptions
-};
+export type { PRange, PRegExp, WordOptions };
+export { Arrays, Pattern, PositionArray, Regexes, Search, Splitting, Strings, Url, Words };

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Pattern.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Pattern.ts
@@ -1,9 +1,9 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 import * as Chars from '../pattern/Chars';
 import { Custom } from '../pattern/Custom';
 import * as Safe from '../pattern/Safe';
-import { PRegExp } from '../pattern/Types';
+import type { PRegExp } from '../pattern/Types';
 import * as Unsafe from '../pattern/Unsafe';
 
 type SafewordApi = (input: string) => PRegExp;

--- a/modules/polaris/src/main/ts/ephox/polaris/api/PositionArray.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/PositionArray.ts
@@ -1,10 +1,10 @@
-import { Arr, Optional } from '@ephox/katamari';
+import type { Arr, Optional } from '@ephox/katamari';
 
 import * as Generator from '../parray/Generator';
 import * as Query from '../parray/Query';
 import * as Split from '../parray/Split';
 import * as Translate from '../parray/Translate';
-import { PRange } from '../pattern/Types';
+import type { PRange } from '../pattern/Types';
 
 type GenerateApi = <T, R extends { finish: number }>(xs: T[], f: (x: T, offset: number) => Optional<R>, start?: number) => R[];
 const generate: GenerateApi = Generator.make;

--- a/modules/polaris/src/main/ts/ephox/polaris/api/Search.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/api/Search.ts
@@ -1,4 +1,4 @@
-import { PRange, PRegExp } from '../pattern/Types';
+import type { PRange, PRegExp } from '../pattern/Types';
 import * as Find from '../search/Find';
 import * as Sleuth from '../search/Sleuth';
 

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Generator.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Generator.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
 
 /**
  * Generate a PositionArray

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Query.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Query.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { PRange } from '../pattern/Types';
+import type { PRange } from '../pattern/Types';
 
 /**
  * Simple "is position within unit" utility function

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Split.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Split.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { PRange } from '../pattern/Types';
+import type { PRange } from '../pattern/Types';
 
 import * as Query from './Query';
 import * as Translate from './Translate';

--- a/modules/polaris/src/main/ts/ephox/polaris/parray/Translate.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/parray/Translate.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { PRange } from '../pattern/Types';
+import type { PRange } from '../pattern/Types';
 
 /** Adjust a PositionArray positions by an offset */
 const translate = <T extends PRange>(parray: T[], offset: number): T[] => {

--- a/modules/polaris/src/main/ts/ephox/polaris/pattern/Custom.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/pattern/Custom.ts
@@ -1,6 +1,6 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
-import { PRegExp } from './Types';
+import type { PRegExp } from './Types';
 
 // tslint:disable-next-line:variable-name
 export const Custom = (regex: string, prefix: PRegExp['prefix'], suffix: PRegExp['suffix'], flags: Optional<string>): PRegExp => {

--- a/modules/polaris/src/main/ts/ephox/polaris/pattern/Safe.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/pattern/Safe.ts
@@ -1,6 +1,6 @@
 import { Regex } from '@ephox/katamari';
 
-import { PRegExp } from './Types';
+import type { PRegExp } from './Types';
 import * as Unsafe from './Unsafe';
 
 /** Escapes regex characters in a string */

--- a/modules/polaris/src/main/ts/ephox/polaris/pattern/Unsafe.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/pattern/Unsafe.ts
@@ -2,7 +2,7 @@ import { Fun, Optional } from '@ephox/katamari';
 
 import * as Chars from './Chars';
 import { Custom } from './Custom';
-import { PRegExp } from './Types';
+import type { PRegExp } from './Types';
 
 /**
  * Tokens have no prefix or suffix

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Find.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Find.ts
@@ -1,4 +1,4 @@
-import { PRange, PRegExp } from '../pattern/Types';
+import type { PRange, PRegExp } from '../pattern/Types';
 
 /**
  * Returns the offset pairs of all matches of pattern on the input string, adjusting for prefix and suffix offsets

--- a/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/search/Sleuth.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { PRange, PRegExp } from '../pattern/Types';
+import type { PRange, PRegExp } from '../pattern/Types';
 
 import * as Find from './Find';
 

--- a/modules/polaris/src/main/ts/ephox/polaris/words/WordBoundary.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/WordBoundary.ts
@@ -1,4 +1,4 @@
-import { CharacterMap } from './StringMapper';
+import type { CharacterMap } from './StringMapper';
 import { characterIndices as ci } from './UnicodeData';
 
 const isWordBoundary = (map: CharacterMap, index: number): boolean => {

--- a/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
+++ b/modules/polaris/src/main/ts/ephox/polaris/words/Words.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { CharacterMap, classify } from './StringMapper';
+import { type CharacterMap, classify } from './StringMapper';
 import * as UnicodeData from './UnicodeData';
 import { isWordBoundary } from './WordBoundary';
 

--- a/modules/polaris/src/test/ts/atomic/api/ParrayGenerateTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/ParrayGenerateTest.ts
@@ -3,7 +3,7 @@ import { Arr, Optional } from '@ephox/katamari';
 
 import * as PositionArray from 'ephox/polaris/api/PositionArray';
 
-import { PArrayTestItem } from '../../module/ephox/polaris/test/Parrays';
+import type { PArrayTestItem } from '../../module/ephox/polaris/test/Parrays';
 
 UnitTest.test('api.PositionArray.generate', () => {
   const generator = (item: string, start: number): Optional<PArrayTestItem> => {

--- a/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/SearchFindTest.ts
@@ -4,7 +4,7 @@ import { Arr, Unicode } from '@ephox/katamari';
 import * as Pattern from 'ephox/polaris/api/Pattern';
 import * as Search from 'ephox/polaris/api/Search';
 import * as Safe from 'ephox/polaris/pattern/Safe';
-import { PRegExp } from 'ephox/polaris/pattern/Types';
+import type { PRegExp } from 'ephox/polaris/pattern/Types';
 
 describe('atomic.polaris.api.SearchFindTest', () => {
   const checkAll = (expected: [number, number][], input: string, pattern: PRegExp) => {

--- a/modules/polaris/src/test/ts/atomic/api/WordsTest.ts
+++ b/modules/polaris/src/test/ts/atomic/api/WordsTest.ts
@@ -1,7 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
-import { getWords, WordOptions } from 'ephox/polaris/words/Words';
+import { getWords, type WordOptions } from 'ephox/polaris/words/Words';
 
 UnitTest.test('api.Words.words', () => {
   interface Char {

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Outlaw.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Outlaw.ts
@@ -1,9 +1,9 @@
 import { Fun, Singleton } from '@ephox/katamari';
 
-import { Bindable, Event } from 'ephox/porkbun/Event';
+import { type Bindable, Event } from 'ephox/porkbun/Event';
 import * as Events from 'ephox/porkbun/Events';
 
-import { DieEvent, Outlaw, Saloon, ShootEvent } from './Types';
+import type { DieEvent, Outlaw, Saloon, ShootEvent } from './Types';
 
 interface OutlawEvents {
   registry: {

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Saloon.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Saloon.ts
@@ -1,10 +1,10 @@
 import { Fun } from '@ephox/katamari';
 
 import * as Binder from 'ephox/porkbun/Binder';
-import { Bindable, Event } from 'ephox/porkbun/Event';
+import { type Bindable, Event } from 'ephox/porkbun/Event';
 import * as Events from 'ephox/porkbun/Events';
 
-import { Outlaw, Saloon, ShootingEvent } from './Types';
+import type { Outlaw, Saloon, ShootingEvent } from './Types';
 
 interface SaloonEvents {
   registry: {

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Sheriff.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Sheriff.ts
@@ -1,6 +1,6 @@
 import { Fun } from '@ephox/katamari';
 
-import { Saloon, Sherif, ShootingEvent } from './Types';
+import type { Saloon, Sherif, ShootingEvent } from './Types';
 
 declare const $: any;
 

--- a/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Types.ts
+++ b/modules/porkbun/src/demo/ts/ephox/porkbun/demo/Types.ts
@@ -1,4 +1,4 @@
-import { Bindable } from 'ephox/porkbun/Event';
+import type { Bindable } from 'ephox/porkbun/Event';
 
 export interface ShootEvent {
   readonly target: any;

--- a/modules/porkbun/src/main/ts/ephox/porkbun/Binder.ts
+++ b/modules/porkbun/src/main/ts/ephox/porkbun/Binder.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { Bindable, EventHandler } from './Event';
+import type { Bindable, EventHandler } from './Event';
 
 export interface Binder {
   readonly bind: <T>(registration: Bindable<T>, handler: EventHandler<T>) => void;

--- a/modules/porkbun/src/main/ts/ephox/porkbun/Events.ts
+++ b/modules/porkbun/src/main/ts/ephox/porkbun/Events.ts
@@ -1,6 +1,6 @@
 import { Obj } from '@ephox/katamari';
 
-import { Bindable, Event } from './Event';
+import type { Bindable, Event } from './Event';
 
 interface Events<T extends Record<string, Event>> {
   readonly registry: Record<keyof T, Bindable<any>>;

--- a/modules/porkbun/src/main/ts/ephox/porkbun/SourceEvent.ts
+++ b/modules/porkbun/src/main/ts/ephox/porkbun/SourceEvent.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun } from '@ephox/katamari';
 
-import { Bindable, Event, EventHandler } from './Event';
+import { type Bindable, Event, type EventHandler } from './Event';
 
 export default (fields: string[], source: Bindable<any>): Event => {
   const mine = Event(fields);

--- a/modules/porkbun/src/main/ts/ephox/porkbun/api/Main.ts
+++ b/modules/porkbun/src/main/ts/ephox/porkbun/api/Main.ts
@@ -1,13 +1,7 @@
 import * as Binder from '../Binder';
-import { Bindable, Event, EventHandler } from '../Event';
+import { type Bindable, Event, type EventHandler } from '../Event';
 import * as Events from '../Events';
 import SourceEvent from '../SourceEvent';
 
-export {
-  Binder,
-  Event,
-  EventHandler,
-  Bindable,
-  Events,
-  SourceEvent
-};
+export type { EventHandler, Bindable };
+export { Binder, Event, Events, SourceEvent };

--- a/modules/porkbun/src/test/ts/atomic/EventsTest.ts
+++ b/modules/porkbun/src/test/ts/atomic/EventsTest.ts
@@ -1,7 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
 
-import { Bindable, Event } from 'ephox/porkbun/Event';
+import { type Bindable, Event } from 'ephox/porkbun/Event';
 import * as Events from 'ephox/porkbun/Events';
 import SourceEvent from 'ephox/porkbun/SourceEvent';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomClumps.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomClumps.ts
@@ -1,6 +1,6 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Clumps from '../general/Clumps';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomLeftBlock.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomLeftBlock.ts
@@ -1,5 +1,5 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as LeftBlock from '../general/LeftBlock';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomLook.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomLook.ts
@@ -1,6 +1,6 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Look from '../general/Look';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomParent.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomParent.ts
@@ -1,8 +1,8 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { BrokenPath, LeftRight } from '../../parent/Breaker';
+import type { BrokenPath, LeftRight } from '../../parent/Breaker';
 import * as Parent from '../general/Parent';
 
 const universe = DomUniverse();

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomPathway.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomPathway.ts
@@ -1,5 +1,5 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Pathway from '../general/Pathway';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomSmartSelect.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomSmartSelect.ts
@@ -1,8 +1,8 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { WordRange } from '../../data/WordRange';
+import type { WordRange } from '../../data/WordRange';
 import * as SmartSelect from '../general/SmartSelect';
 
 const universe = DomUniverse();

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomStructure.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomStructure.ts
@@ -1,5 +1,5 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structure from '../general/Structure';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextSearch.ts
@@ -1,11 +1,11 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SpotPoint } from '@ephox/phoenix';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SpotPoint } from '@ephox/phoenix';
+import type { SugarElement } from '@ephox/sugar';
 
-import { CharPos } from '../../textdata/TextSearch';
-import { TextSeekerOutcome, TextSeekerPhaseProcessor } from '../../textdata/TextSeeker';
-import { TextSearch, TextSearchSeeker } from '../general/TextSearch';
+import type { CharPos } from '../../textdata/TextSearch';
+import type { TextSeekerOutcome, TextSeekerPhaseProcessor } from '../../textdata/TextSeeker';
+import { TextSearch, type TextSearchSeeker } from '../general/TextSearch';
 
 const universe = DomUniverse();
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextZone.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextZone.ts
@@ -1,6 +1,6 @@
 import { DomUniverse } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as TextZone from '../general/TextZone';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextZones.ts
@@ -1,8 +1,8 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as TextZones from '../general/TextZones';
-import { ZoneViewports } from '../general/ZoneViewports';
+import type { ZoneViewports } from '../general/ZoneViewports';
 
 const universe = DomUniverse();
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextdata.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomTextdata.ts
@@ -1,5 +1,5 @@
 import { DomUniverse } from '@ephox/boss';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import { Textdata } from '../general/Textdata';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/dom/DomWords.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/dom/DomWords.ts
@@ -1,6 +1,6 @@
 import { DomUniverse } from '@ephox/boss';
 
-import { WordScope } from '../../data/WordScope';
+import type { WordScope } from '../../data/WordScope';
 import * as Words from '../general/Words';
 
 const universe = DomUniverse();

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Clumps.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Clumps.ts
@@ -1,5 +1,5 @@
-import { Universe } from '@ephox/boss';
-import { Arr, Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import { Arr, type Optional } from '@ephox/katamari';
 import { Split } from '@ephox/phoenix';
 
 import * as Clumps from '../../clumps/Clumps';

--- a/modules/robin/src/main/ts/ephox/robin/api/general/LeftBlock.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/LeftBlock.ts
@@ -1,6 +1,6 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
-import { Gather, Transition } from '@ephox/phoenix';
+import { Gather, type Transition } from '@ephox/phoenix';
 
 import { Walks } from '../../leftblock/Walks';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Look.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Look.ts
@@ -1,5 +1,5 @@
-import { Universe } from '@ephox/boss';
-import { Fun, Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import { Fun, type Optional } from '@ephox/katamari';
 
 import * as Look from '../../look/Look';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Parent.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Parent.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
-import { breakPath as xBreakPath, breakToLeft as xBreakToLeft, breakToRight as xBreakToRight, BrokenPath, LeftRight } from '../../parent/Breaker';
-import { Looker, oneAll } from '../../parent/Shared';
+import { breakPath as xBreakPath, breakToLeft as xBreakToLeft, breakToRight as xBreakToRight, type BrokenPath, type LeftRight } from '../../parent/Breaker';
+import { type Looker, oneAll } from '../../parent/Shared';
 import * as SubsetFn from '../../parent/Subset';
 
 export interface AncestorsFnResult<E> {

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Pathway.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Pathway.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import * as Simplify from '../../pathway/Simplify';
 

--- a/modules/robin/src/main/ts/ephox/robin/api/general/SmartSelect.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/SmartSelect.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
-import { WordRange } from '../../data/WordRange';
+import type { WordRange } from '../../data/WordRange';
 import * as Selection from '../../smartselect/Selection';
 
 // The optimise parameter is no longer required in this API.

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Structure.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Structure.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
 const blockList = [

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextSearch.ts
@@ -1,9 +1,9 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Contracts, Fun, Optional } from '@ephox/katamari';
-import { Gather, Spot, SpotPoint } from '@ephox/phoenix';
+import { Gather, Spot, type SpotPoint } from '@ephox/phoenix';
 
 import * as TextSearchBase from '../../textdata/TextSearch';
-import { TextSeeker, TextSeekerOutcome, TextSeekerPhase, TextSeekerPhaseConstructor, TextSeekerPhaseProcessor } from '../../textdata/TextSeeker';
+import { TextSeeker, type TextSeekerOutcome, type TextSeekerPhase, type TextSeekerPhaseConstructor, type TextSeekerPhaseProcessor } from '../../textdata/TextSeeker';
 
 type CharPos = TextSearchBase.CharPos;
 

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextZone.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextZone.ts
@@ -1,9 +1,9 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 import { Descent } from '@ephox/phoenix';
 
 import * as TextZone from '../../zone/TextZone';
-import { Zone } from '../../zone/Zones';
+import type { Zone } from '../../zone/Zones';
 
 /*
  * TextZone returns an Optional zone if that zone is the right language (onlyLang)
@@ -28,8 +28,5 @@ const range = <E, D>(universe: Universe<E, D>, start: E, soffset: number, finish
   return TextZone.fromRange(universe, startPt.element, finishPt.element, envLang, onlyLang);
 };
 
-export {
-  Zone,
-  single,
-  range
-};
+export type { Zone };
+export { single, range };

--- a/modules/robin/src/main/ts/ephox/robin/api/general/TextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/TextZones.ts
@@ -1,10 +1,10 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Descent } from '@ephox/phoenix';
 
 import * as TextZones from '../../zone/TextZones';
-import { Zones, Zone } from '../../zone/Zones';
+import type { Zones, Zone } from '../../zone/Zones';
 
-import { ZoneViewports } from './ZoneViewports';
+import type { ZoneViewports } from './ZoneViewports';
 
 /*
  * TextZones return an array of zones based on an area being scanned. It will use the viewport
@@ -43,10 +43,5 @@ const range = <E, D>(
 type EmptyFn = <E>() => Zones<E>;
 const empty: EmptyFn = TextZones.empty;
 
-export {
-  Zone,
-  Zones,
-  single,
-  range,
-  empty
-};
+export type { Zone, Zones };
+export { single, range, empty };

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Textdata.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Textdata.ts
@@ -1,6 +1,6 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
-import { Spot, SpotRange } from '@ephox/phoenix';
+import { Spot, type SpotRange } from '@ephox/phoenix';
 import { PositionArray } from '@ephox/polaris';
 
 interface TextdataGet<E> {

--- a/modules/robin/src/main/ts/ephox/robin/api/general/Words.ts
+++ b/modules/robin/src/main/ts/ephox/robin/api/general/Words.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 
 import { WordScope } from '../../data/WordScope';
 import * as WordUtil from '../../util/WordUtil';

--- a/modules/robin/src/main/ts/ephox/robin/clumps/Clumps.ts
+++ b/modules/robin/src/main/ts/ephox/robin/clumps/Clumps.ts
@@ -1,6 +1,6 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Adt, Arr, Optional } from '@ephox/katamari';
-import { Descent, Gather, Spot, SpotPoint, Transition } from '@ephox/phoenix';
+import { Descent, Gather, Spot, type SpotPoint, type Transition } from '@ephox/phoenix';
 
 import * as Structure from '../api/general/Structure';
 

--- a/modules/robin/src/main/ts/ephox/robin/clumps/EntryPoints.ts
+++ b/modules/robin/src/main/ts/ephox/robin/clumps/EntryPoints.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Adt, Fun } from '@ephox/katamari';
 import { Gather, Split } from '@ephox/phoenix';
 

--- a/modules/robin/src/main/ts/ephox/robin/clumps/Fractures.ts
+++ b/modules/robin/src/main/ts/ephox/robin/clumps/Fractures.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
 import * as Parent from '../api/general/Parent';
-import { breakToLeft, breakToRight, BrokenPath, LeftRight } from '../parent/Breaker';
+import { breakToLeft, breakToRight, type BrokenPath, type LeftRight } from '../parent/Breaker';
 import * as Subset from '../parent/Subset';
 
 // Find the subsection of DIRECT children of parent from [first, last])

--- a/modules/robin/src/main/ts/ephox/robin/data/BeforeAfter.ts
+++ b/modules/robin/src/main/ts/ephox/robin/data/BeforeAfter.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 export interface BeforeAfter {
   readonly before: Optional<number>;

--- a/modules/robin/src/main/ts/ephox/robin/data/WordScope.ts
+++ b/modules/robin/src/main/ts/ephox/robin/data/WordScope.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 export interface WordScope {
   readonly word: string;

--- a/modules/robin/src/main/ts/ephox/robin/leftblock/Walks.ts
+++ b/modules/robin/src/main/ts/ephox/robin/leftblock/Walks.ts
@@ -1,6 +1,6 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
-import { Gather, Transition, Traverse } from '@ephox/phoenix';
+import { Gather, type Transition, type Traverse } from '@ephox/phoenix';
 
 export interface Walks {
   rules?: {

--- a/modules/robin/src/main/ts/ephox/robin/look/Look.ts
+++ b/modules/robin/src/main/ts/ephox/robin/look/Look.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
 /**

--- a/modules/robin/src/main/ts/ephox/robin/parent/Breaker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/parent/Breaker.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
 interface Bisect<E> {

--- a/modules/robin/src/main/ts/ephox/robin/parent/Shared.ts
+++ b/modules/robin/src/main/ts/ephox/robin/parent/Shared.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
 export type Looker<E, D> = (universe: Universe<E, D>, elem: E) => Optional<E>;

--- a/modules/robin/src/main/ts/ephox/robin/parent/Subset.ts
+++ b/modules/robin/src/main/ts/ephox/robin/parent/Subset.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
 interface SubsetAncestors<E> {

--- a/modules/robin/src/main/ts/ephox/robin/pathway/Simplify.ts
+++ b/modules/robin/src/main/ts/ephox/robin/pathway/Simplify.ts
@@ -1,4 +1,4 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 
 const eq = <E, D>(universe: Universe<E, D>, e1: E): (e2: E) => boolean => {

--- a/modules/robin/src/main/ts/ephox/robin/smartselect/EndofWord.ts
+++ b/modules/robin/src/main/ts/ephox/robin/smartselect/EndofWord.ts
@@ -1,9 +1,9 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Optional, Unicode } from '@ephox/katamari';
 
 import { WordRange } from '../data/WordRange';
 import * as Clustering from '../words/Clustering';
-import { WordDecisionItem } from '../words/WordDecision';
+import type { WordDecisionItem } from '../words/WordDecision';
 
 interface ScanResult<E> {
   readonly all: WordDecisionItem<E>[];

--- a/modules/robin/src/main/ts/ephox/robin/smartselect/Selection.ts
+++ b/modules/robin/src/main/ts/ephox/robin/smartselect/Selection.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 
-import { WordRange } from '../data/WordRange';
+import type { WordRange } from '../data/WordRange';
 import * as CurrentWord from '../util/CurrentWord';
 
 import * as EndofWord from './EndofWord';

--- a/modules/robin/src/main/ts/ephox/robin/textdata/TextSeeker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/textdata/TextSeeker.ts
@@ -1,6 +1,6 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Adt, Optional } from '@ephox/katamari';
-import { Descent, Direction, Gather, Seeker, Spot, SpotPoint, Transition } from '@ephox/phoenix';
+import { Descent, type Direction, Gather, Seeker, Spot, type SpotPoint, type Transition } from '@ephox/phoenix';
 
 import * as Structure from '../api/general/Structure';
 

--- a/modules/robin/src/main/ts/ephox/robin/words/ClusterSearch.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/ClusterSearch.ts
@@ -1,8 +1,8 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
-import { Gather, Transition } from '@ephox/phoenix';
+import { Gather, type Transition } from '@ephox/phoenix';
 
-import { WordDecision, WordDecisionItem } from './WordDecision';
+import { WordDecision, type WordDecisionItem } from './WordDecision';
 import { WordWalking } from './WordWalking';
 
 /*

--- a/modules/robin/src/main/ts/ephox/robin/words/Clustering.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/Clustering.ts
@@ -1,10 +1,10 @@
-import { Universe } from '@ephox/boss';
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
 
 import { LanguageZones } from '../zone/LanguageZones';
 
 import * as ClusterSearch from './ClusterSearch';
-import { WordDecision, WordDecisionItem } from './WordDecision';
+import { WordDecision, type WordDecisionItem } from './WordDecision';
 
 interface Edges<E> {
   readonly left: WordDecisionItem<E>;

--- a/modules/robin/src/main/ts/ephox/robin/words/WordDecision.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/WordDecision.ts
@@ -1,5 +1,5 @@
-import { Universe } from '@ephox/boss';
-import { Optional } from '@ephox/katamari';
+import type { Universe } from '@ephox/boss';
+import type { Optional } from '@ephox/katamari';
 
 export interface WordDecisionItem<E> {
   readonly item: E;

--- a/modules/robin/src/main/ts/ephox/robin/words/WordWalking.ts
+++ b/modules/robin/src/main/ts/ephox/robin/words/WordWalking.ts
@@ -1,5 +1,5 @@
-import { Optional } from '@ephox/katamari';
-import { Direction, Gather } from '@ephox/phoenix';
+import type { Optional } from '@ephox/katamari';
+import { type Direction, Gather } from '@ephox/phoenix';
 
 import * as WordUtil from '../util/WordUtil';
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/LanguageZones.ts
@@ -1,7 +1,7 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 
-import { WordDecisionItem } from '../words/WordDecision';
+import type { WordDecisionItem } from '../words/WordDecision';
 
 export interface ZoneDetails<E> {
   readonly lang: string;

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZone.ts
@@ -1,14 +1,14 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Optional } from '@ephox/katamari';
 import { Descent } from '@ephox/phoenix';
 
 import { ZoneViewports } from '../api/general/ZoneViewports';
 import * as Clustering from '../words/Clustering';
-import { WordDecision, WordDecisionItem } from '../words/WordDecision';
+import { WordDecision, type WordDecisionItem } from '../words/WordDecision';
 
 import { LanguageZones } from './LanguageZones';
 import * as TextZones from './TextZones';
-import { Zone } from './Zones';
+import type { Zone } from './Zones';
 
 // Since we support these formats both mixed cases and either - and _ we need to normalize the code
 const normalizeCode = (lang: string): string => lang.toLowerCase().replace(/_/g, '-');

--- a/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/TextZones.ts
@@ -1,12 +1,12 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Fun, Optional } from '@ephox/katamari';
 
 import * as Parent from '../api/general/Parent';
-import { ZoneViewports } from '../api/general/ZoneViewports';
+import type { ZoneViewports } from '../api/general/ZoneViewports';
 import * as Clustering from '../words/Clustering';
-import { WordDecision, WordDecisionItem } from '../words/WordDecision';
+import { WordDecision, type WordDecisionItem } from '../words/WordDecision';
 
-import { LanguageZones, ZoneDetails } from './LanguageZones';
+import { LanguageZones, type ZoneDetails } from './LanguageZones';
 import * as Zones from './Zones';
 import * as ZoneWalker from './ZoneWalker';
 

--- a/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/ZoneWalker.ts
@@ -1,12 +1,12 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Fun, Optional } from '@ephox/katamari';
-import { Gather, Traverse } from '@ephox/phoenix';
+import { Gather, type Traverse } from '@ephox/phoenix';
 
 import { ZonePosition } from '../api/general/ZonePosition';
-import { ZoneViewports } from '../api/general/ZoneViewports';
-import { WordDecisionItem } from '../words/WordDecision';
+import type { ZoneViewports } from '../api/general/ZoneViewports';
+import type { WordDecisionItem } from '../words/WordDecision';
 
-import { LanguageZones, ZoneDetails } from './LanguageZones';
+import { LanguageZones, type ZoneDetails } from './LanguageZones';
 
 // Figure out which direction to take the next step in. Returns None if the traversal should stop.
 const getNextStep = <E, D>(

--- a/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
+++ b/modules/robin/src/main/ts/ephox/robin/zone/Zones.ts
@@ -1,10 +1,10 @@
-import { Universe } from '@ephox/boss';
+import type { Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
-import { WordScope } from '../data/WordScope';
+import type { WordScope } from '../data/WordScope';
 import * as Identify from '../words/Identify';
 
-import { ZoneDetails } from './LanguageZones';
+import type { ZoneDetails } from './LanguageZones';
 
 export interface Zone<E> {
   readonly elements: E[];

--- a/modules/robin/src/test/ts/atomic/api/TextZoneTest.ts
+++ b/modules/robin/src/test/ts/atomic/api/TextZoneTest.ts
@@ -3,10 +3,10 @@ import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Fun, Optional } from '@ephox/katamari';
 
 import * as TextZone from 'ephox/robin/api/general/TextZone';
-import { ArbIds, arbIds, ArbRangeIds, arbRangeIds } from 'ephox/robin/test/Arbitraries';
+import { type ArbIds, arbIds, type ArbRangeIds, arbRangeIds } from 'ephox/robin/test/Arbitraries';
 import * as PropertyAssertions from 'ephox/robin/test/PropertyAssertions';
-import { assertProps, rawOne, RawZone } from 'ephox/robin/test/ZoneObjects';
-import { Zone } from 'ephox/robin/zone/Zones';
+import { assertProps, rawOne, type RawZone } from 'ephox/robin/test/ZoneObjects';
+import type { Zone } from 'ephox/robin/zone/Zones';
 
 describe('atomic.robin.zone.TextZoneTest', () => {
   const doc1 = TestUniverse(Gene('root', 'root', [

--- a/modules/robin/src/test/ts/atomic/api/TextZonesTest.ts
+++ b/modules/robin/src/test/ts/atomic/api/TextZonesTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 
 import * as TextZones from 'ephox/robin/api/general/TextZones';
 import { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
-import { ArbIds, arbIds, ArbRangeIds, arbRangeIds } from 'ephox/robin/test/Arbitraries';
+import { type ArbIds, arbIds, type ArbRangeIds, arbRangeIds } from 'ephox/robin/test/Arbitraries';
 import * as PropertyAssertions from 'ephox/robin/test/PropertyAssertions';
 import { assertProps, raw } from 'ephox/robin/test/ZoneObjects';
 

--- a/modules/robin/src/test/ts/atomic/examples/BlockTest.ts
+++ b/modules/robin/src/test/ts/atomic/examples/BlockTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Gene, TestUniverse, TextGene, Universe } from '@ephox/boss';
+import { Gene, TestUniverse, TextGene, type Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 
 import * as Look from 'ephox/robin/api/general/Look';

--- a/modules/robin/src/test/ts/atomic/parent/SharedTest.ts
+++ b/modules/robin/src/test/ts/atomic/parent/SharedTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest } from '@ephox/bedrock-client';
-import { Gene, TestUniverse, Universe } from '@ephox/boss';
+import { Gene, TestUniverse, type Universe } from '@ephox/boss';
 import { Arr, Optional } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 

--- a/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
+++ b/modules/robin/src/test/ts/atomic/words/ClusteringTest.ts
@@ -6,7 +6,7 @@ import * as fc from 'fast-check';
 
 import { arbTextIds } from 'ephox/robin/test/Arbitraries';
 import * as Clustering from 'ephox/robin/words/Clustering';
-import { WordDecisionItem } from 'ephox/robin/words/WordDecision';
+import type { WordDecisionItem } from 'ephox/robin/words/WordDecision';
 import { LanguageZones } from 'ephox/robin/zone/LanguageZones';
 
 UnitTest.test('ClusteringTest', () => {

--- a/modules/robin/src/test/ts/atomic/zone/AvoidSpecialTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/AvoidSpecialTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
 import { WordDecision } from 'ephox/robin/words/WordDecision';
-import { ZoneDetails } from 'ephox/robin/zone/LanguageZones';
+import type { ZoneDetails } from 'ephox/robin/zone/LanguageZones';
 import * as ZoneWalker from 'ephox/robin/zone/ZoneWalker';
 
 describe('atomic.robin.zone.AvoidSpecialTest', () => {

--- a/modules/robin/src/test/ts/atomic/zone/BoundedZoneTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/BoundedZoneTest.ts
@@ -4,7 +4,7 @@ import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
 import { arbRangeIds } from 'ephox/robin/test/Arbitraries';
 import * as PropertyAssertions from 'ephox/robin/test/PropertyAssertions';
-import { assertProps, assertZones, RawZone } from 'ephox/robin/test/ZoneObjects';
+import { assertProps, assertZones, type RawZone } from 'ephox/robin/test/ZoneObjects';
 import * as TextZones from 'ephox/robin/zone/TextZones';
 
 describe('atomic.robin.zone.BoundedZoneTest', () => {

--- a/modules/robin/src/test/ts/atomic/zone/InViewportTest.ts
+++ b/modules/robin/src/test/ts/atomic/zone/InViewportTest.ts
@@ -4,9 +4,9 @@ import { Gene, TestUniverse, TextGene } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 
 import { ZonePosition } from 'ephox/robin/api/general/ZonePosition';
-import { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
+import type { ZoneViewports } from 'ephox/robin/api/general/ZoneViewports';
 import { WordDecision } from 'ephox/robin/words/WordDecision';
-import { ZoneDetails } from 'ephox/robin/zone/LanguageZones';
+import type { ZoneDetails } from 'ephox/robin/zone/LanguageZones';
 import * as ZoneWalker from 'ephox/robin/zone/ZoneWalker';
 
 UnitTest.asyncTest('atomic.robin.zone.InViewportTest', (success, failure) => {

--- a/modules/robin/src/test/ts/browser/LanguageOverrideTest.ts
+++ b/modules/robin/src/test/ts/browser/LanguageOverrideTest.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { DomUniverse, Universe } from '@ephox/boss';
+import { DomUniverse, type Universe } from '@ephox/boss';
 import { Arr, Fun } from '@ephox/katamari';
 import { SugarElement, Traverse } from '@ephox/sugar';
 import { assert } from 'chai';

--- a/modules/robin/src/test/ts/browser/LeftBlockTest.ts
+++ b/modules/robin/src/test/ts/browser/LeftBlockTest.ts
@@ -1,5 +1,5 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { DomUniverse, Universe } from '@ephox/boss';
+import { DomUniverse, type Universe } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 import { Hierarchy, Insert, InsertAll, Remove, Replication, SugarBody, SugarElement } from '@ephox/sugar';
 

--- a/modules/robin/src/test/ts/browser/api/DomTextSearchTest.ts
+++ b/modules/robin/src/test/ts/browser/api/DomTextSearchTest.ts
@@ -6,7 +6,7 @@ import { Pattern } from '@ephox/polaris';
 import { Compare, Html, Insert, InsertAll, SugarElement } from '@ephox/sugar';
 
 import * as DomTextSearch from 'ephox/robin/api/dom/DomTextSearch';
-import { TextSeekerOutcome, TextSeekerPhaseConstructor } from 'ephox/robin/textdata/TextSeeker';
+import type { TextSeekerOutcome, TextSeekerPhaseConstructor } from 'ephox/robin/textdata/TextSeeker';
 
 UnitTest.test('DomTextSearchTest', () => {
   const wordbreaker = () => {

--- a/modules/robin/src/test/ts/browser/examples/BlockTest.ts
+++ b/modules/robin/src/test/ts/browser/examples/BlockTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Optional } from '@ephox/katamari';
-import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import { type SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import * as DomLook from 'ephox/robin/api/dom/DomLook';
 import * as DomParent from 'ephox/robin/api/dom/DomParent';

--- a/modules/robin/src/test/ts/module/ephox/robin/test/Arbitraries.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/Arbitraries.ts
@@ -1,4 +1,4 @@
-import { Gene, TestUniverse } from '@ephox/boss';
+import type { Gene, TestUniverse } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 import * as fc from 'fast-check';
 

--- a/modules/robin/src/test/ts/module/ephox/robin/test/BrowserCheck.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/BrowserCheck.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 import { Insert, Remove, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
 const getNode = (container: SugarElement): SugarElement<Node> => {

--- a/modules/robin/src/test/ts/module/ephox/robin/test/ZoneObjects.ts
+++ b/modules/robin/src/test/ts/module/ephox/robin/test/ZoneObjects.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@ephox/agar';
 import { Assert } from '@ephox/bedrock-client';
-import { Gene, TestUniverse } from '@ephox/boss';
+import type { Gene, TestUniverse } from '@ephox/boss';
 import { Arr } from '@ephox/katamari';
 
 import { LanguageZones } from 'ephox/robin/zone/LanguageZones';
-import { Zone } from 'ephox/robin/zone/Zones';
+import type { Zone } from 'ephox/robin/zone/Zones';
 
 export interface RawZone {
   lang: string;

--- a/modules/sand/src/main/ts/ephox/sand/api/PlatformDetection.ts
+++ b/modules/sand/src/main/ts/ephox/sand/api/PlatformDetection.ts
@@ -1,9 +1,9 @@
 import { Fun, Optional, Thunk } from '@ephox/katamari';
 
-import { Browser as BrowserCore } from '../core/Browser';
-import { OperatingSystem as OperatingSystemCore } from '../core/OperatingSystem';
+import type { Browser as BrowserCore } from '../core/Browser';
+import type { OperatingSystem as OperatingSystemCore } from '../core/OperatingSystem';
 import { PlatformDetection } from '../core/PlatformDetection';
-import { DeviceType as DeviceTypeCore } from '../detect/DeviceType';
+import type { DeviceType as DeviceTypeCore } from '../detect/DeviceType';
 
 export type Browser = BrowserCore;
 export type OperatingSystem = OperatingSystemCore;

--- a/modules/sand/src/main/ts/ephox/sand/core/Browser.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/Browser.ts
@@ -1,7 +1,7 @@
 import { Fun } from '@ephox/katamari';
 
 import { Version } from '../detect/Version';
-import { UaInfo } from '../info/UaInfo';
+import type { UaInfo } from '../info/UaInfo';
 
 const edge = 'Edge';
 const chromium = 'Chromium';

--- a/modules/sand/src/main/ts/ephox/sand/core/OperatingSystem.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/OperatingSystem.ts
@@ -1,7 +1,7 @@
 import { Fun } from '@ephox/katamari';
 
 import { Version } from '../detect/Version';
-import { UaInfo } from '../info/UaInfo';
+import type { UaInfo } from '../info/UaInfo';
 
 export interface OperatingSystem extends UaInfo {
   readonly isWindows: () => boolean;

--- a/modules/sand/src/main/ts/ephox/sand/core/PlatformDetection.ts
+++ b/modules/sand/src/main/ts/ephox/sand/core/PlatformDetection.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 import { DeviceType } from '../detect/DeviceType';
 import * as UaData from '../detect/UaData';

--- a/modules/sand/src/main/ts/ephox/sand/detect/DeviceType.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/DeviceType.ts
@@ -1,7 +1,7 @@
 import { Fun } from '@ephox/katamari';
 
-import { Browser } from '../core/Browser';
-import { OperatingSystem } from '../core/OperatingSystem';
+import type { Browser } from '../core/Browser';
+import type { OperatingSystem } from '../core/OperatingSystem';
 
 export interface DeviceType {
   readonly isiPad: () => boolean;

--- a/modules/sand/src/main/ts/ephox/sand/detect/UaData.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/UaData.ts
@@ -1,7 +1,7 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, type Optional } from '@ephox/katamari';
 
-import { PlatformInfo } from '../info/PlatformInfo';
-import { UaInfo } from '../info/UaInfo';
+import type { PlatformInfo } from '../info/PlatformInfo';
+import type { UaInfo } from '../info/UaInfo';
 
 import { Version } from './Version';
 

--- a/modules/sand/src/main/ts/ephox/sand/detect/UaString.ts
+++ b/modules/sand/src/main/ts/ephox/sand/detect/UaString.ts
@@ -1,7 +1,7 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, type Optional } from '@ephox/katamari';
 
-import { PlatformInfo } from '../info/PlatformInfo';
-import { UaInfo } from '../info/UaInfo';
+import type { PlatformInfo } from '../info/PlatformInfo';
+import type { UaInfo } from '../info/UaInfo';
 
 import { Version } from './Version';
 

--- a/modules/sand/src/main/ts/ephox/sand/info/UaInfo.ts
+++ b/modules/sand/src/main/ts/ephox/sand/info/UaInfo.ts
@@ -1,4 +1,4 @@
-import { Version } from '../detect/Version';
+import type { Version } from '../detect/Version';
 
 export interface UaInfo {
   readonly current: string | undefined;

--- a/modules/sand/src/test/ts/atomic/core/BrowserTest.ts
+++ b/modules/sand/src/test/ts/atomic/core/BrowserTest.ts
@@ -3,7 +3,7 @@ import { Fun, Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 
 import { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
-import { UserAgentData, UserAgentDataBrand } from 'ephox/sand/detect/UaData';
+import type { UserAgentData, UserAgentDataBrand } from 'ephox/sand/detect/UaData';
 import * as PlatformQuery from 'ephox/sand/test/PlatformQuery';
 
 type PlatformQuery = typeof PlatformQuery;

--- a/modules/sand/src/test/ts/module/ephox/sand/test/PlatformQuery.ts
+++ b/modules/sand/src/test/ts/module/ephox/sand/test/PlatformQuery.ts
@@ -1,4 +1,4 @@
-import { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
+import type { PlatformDetection } from 'ephox/sand/core/PlatformDetection';
 
 const isEdge = (platform: PlatformDetection): boolean => {
   return platform.browser.isEdge();

--- a/modules/snooker/src/demo/ts/ephox/snooker/demo/DetectDemo.ts
+++ b/modules/snooker/src/demo/ts/ephox/snooker/demo/DetectDemo.ts
@@ -1,13 +1,13 @@
 import { Fun, Obj, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, Css, DomEvent, EventArgs, Insert, InsertAll, Ready, Replication, SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
+import { Attribute, Css, DomEvent, type EventArgs, Insert, InsertAll, Ready, Replication, SelectorFind, SugarElement, SugarNode } from '@ephox/sugar';
 
-import { Generators } from 'ephox/snooker/api/Generators';
+import type { Generators } from 'ephox/snooker/api/Generators';
 import * as ResizeBehaviour from 'ephox/snooker/api/ResizeBehaviour';
 import { ResizeWire } from 'ephox/snooker/api/ResizeWire';
 import * as TableOperations from 'ephox/snooker/api/TableOperations';
 import { TableResize } from 'ephox/snooker/api/TableResize';
 import { TableSize } from 'ephox/snooker/api/TableSize';
-import { OperationCallback, TargetElement, TargetSelection } from 'ephox/snooker/model/RunOperation';
+import type { OperationCallback, TargetElement, TargetSelection } from 'ephox/snooker/model/RunOperation';
 
 Ready.document(() => {
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellLocation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellLocation.ts
@@ -1,5 +1,5 @@
 import { Adt } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 /*
  * The CellLocation ADT is used to represent a cell when navigating. The

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellMutations.ts
@@ -1,8 +1,8 @@
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 
 const halve = (main: SugarElement<CellElement>, other: SugarElement<CellElement>): void => {
   // Only set width on the new cell if we have a colspan of 1 (or no colspan) as we can only safely do that for cells

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CellNavigation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CellNavigation.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, SugarElement } from '@ephox/sugar';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
+import { Compare, type SugarElement } from '@ephox/sugar';
 
 import { CellLocation } from './CellLocation';
 import * as TableLookup from './TableLookup';

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyCols.ts
@@ -1,11 +1,11 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, type Optional } from '@ephox/katamari';
 import { Attribute, InsertAll, Replication, SugarElement } from '@ephox/sugar';
 
-import { onUnlockedCells, TargetSelection } from '../model/RunOperation';
+import { onUnlockedCells, type TargetSelection } from '../model/RunOperation';
 import * as CellUtils from '../util/CellUtils';
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 
-import { ColumnExt, DetailExt } from './Structs';
+import type { ColumnExt, DetailExt } from './Structs';
 import { Warehouse } from './Warehouse';
 
 const constrainSpan = (element: SugarElement<CellElement>, property: 'colspan' | 'rowspan' | 'span', value: number) => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopyRows.ts
@@ -1,12 +1,12 @@
-import { Arr, Optional, Optionals } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, type Optional, Optionals } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as GridRow from '../model/GridRow';
-import { onCells, TargetSelection, toDetailList } from '../model/RunOperation';
+import { onCells, type TargetSelection, toDetailList } from '../model/RunOperation';
 import * as Transitions from '../model/Transitions';
 import * as Redraw from '../operate/Redraw';
 
-import { Generators } from './Generators';
+import type { Generators } from './Generators';
 import { Warehouse } from './Warehouse';
 
 const copyRows = (table: SugarElement<HTMLTableElement>, target: TargetSelection, generators: Generators): Optional<SugarElement<HTMLTableRowElement | HTMLTableColElement>[]> => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/CopySelected.ts
@@ -6,7 +6,7 @@ import * as ColumnSizes from '../resize/ColumnSizes';
 import * as LayerSelector from '../util/LayerSelector';
 import { LOCKED_COL_ATTR } from '../util/LockedColumnUtils';
 
-import { Detail, DetailExt, RowDetail } from './Structs';
+import type { Detail, DetailExt, RowDetail } from './Structs';
 import { TableSize } from './TableSize';
 import { Warehouse } from './Warehouse';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Generators.ts
@@ -1,8 +1,8 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
+import { Attribute, Css, type SugarElement, SugarNode } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
-import { CellElement, CompElm, RowElement } from '../util/TableTypes';
+import type { CellElement, CompElm, RowElement } from '../util/TableTypes';
 
 export interface RowData {
   readonly element: SugarElement<RowElement>;

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Main.ts
@@ -8,7 +8,7 @@ import * as CellNavigation from './CellNavigation';
 import * as CopyCols from './CopyCols';
 import * as CopyRows from './CopyRows';
 import * as CopySelected from './CopySelected';
-import { Generators, SimpleGenerators } from './Generators';
+import { Generators, type SimpleGenerators } from './Generators';
 import * as OtherCells from './OtherCells';
 import * as ResizeBehaviour from './ResizeBehaviour';
 import { ResizeWire } from './ResizeWire';
@@ -28,6 +28,7 @@ import { TableSection } from './TableSection';
 import { TableSize } from './TableSize';
 import { Warehouse } from './Warehouse';
 
+export type { SimpleGenerators };
 export {
   Adjustments,
   CellLocation,
@@ -39,7 +40,6 @@ export {
   Generators,
   ResizeBehaviour,
   ResizeWire,
-  SimpleGenerators,
   Sizes,
   Structs,
   TableContent,

--- a/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/OtherCells.ts
@@ -1,12 +1,12 @@
-import { Arr, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, type Optional } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as GridRow from '../model/GridRow';
-import { onCells, TargetSelection, toDetailList } from '../model/RunOperation';
+import { onCells, type TargetSelection, toDetailList } from '../model/RunOperation';
 import * as Transitions from '../model/Transitions';
 
-import { Generators } from './Generators';
-import { DetailExt, RowCells } from './Structs';
+import type { Generators } from './Generators';
+import type { DetailExt, RowCells } from './Structs';
 import { Warehouse } from './Warehouse';
 
 export interface OtherCells {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/ResizeWire.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/ResizeWire.ts
@@ -1,5 +1,5 @@
 import { Fun } from '@ephox/katamari';
-import { SugarElement, SugarLocation, SugarNode, SugarPosition, Traverse } from '@ephox/sugar';
+import { type SugarElement, SugarLocation, SugarNode, SugarPosition, Traverse } from '@ephox/sugar';
 
 // parent: the container where the resize bars are appended
 //         this gets mouse event handlers only if it is not a child of 'view' (eg, detached/inline mode)

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Sizes.ts
@@ -1,12 +1,12 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Css, Height, SugarElement, Width } from '@ephox/sugar';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
+import { Css, Height, type SugarElement, Width } from '@ephox/sugar';
 
 import * as ColumnSizes from '../resize/ColumnSizes';
 import * as Redistribution from '../resize/Redistribution';
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
 
-import { DetailExt, RowDetail, Column, Detail } from './Structs';
+import type { DetailExt, RowDetail, Column, Detail } from './Structs';
 import { Warehouse } from './Warehouse';
 
 const redistributeToW = (newWidths: string[], cells: DetailExt[], unit: string): void => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { CellElement, RowElement, RowCell } from '../util/TableTypes';
+import type { CellElement, RowElement, RowCell } from '../util/TableTypes';
 
 export interface Dimension {
   readonly width: number;

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableConversions.ts
@@ -1,5 +1,5 @@
 import { Arr, Optional } from '@ephox/katamari';
-import { Attribute, Css, SugarElement } from '@ephox/sugar';
+import { Attribute, Css, type SugarElement } from '@ephox/sugar';
 
 import * as Sizes from '../resize/Sizes';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableFill.ts
@@ -1,9 +1,9 @@
-import { Arr, Obj, Optional } from '@ephox/katamari';
+import { Arr, Obj, type Optional } from '@ephox/katamari';
 import { Attribute, Compare, Css, CursorPosition, Insert, Replication, SelectorFilter, SugarElement, SugarNode } from '@ephox/sugar';
 
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 
-import { CellData, Generators, SimpleGenerators } from './Generators';
+import type { CellData, Generators, SimpleGenerators } from './Generators';
 
 const transferableAttributes: Record<string, string[]> = {
   scope: [

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableGridSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableGridSize.ts
@@ -1,6 +1,6 @@
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { Grid } from './Structs';
+import type { Grid } from './Structs';
 import { Warehouse } from './Warehouse';
 
 const getGridSize = (table: SugarElement<HTMLTableElement>): Grid => {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableLookup.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableLookup.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { SelectorFilter, SelectorFind, Selectors, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { SelectorFilter, SelectorFind, Selectors, type SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import { getAttrValue } from '../util/CellUtils';
 import * as LayerSelector from '../util/LayerSelector';

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableOperations.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { ContentEditable, Remove, SugarElement, Width } from '@ephox/sugar';
+import { ContentEditable, Remove, type SugarElement, Width } from '@ephox/sugar';
 
 import * as Blocks from '../lookup/Blocks';
 import { findCommonCellType, findCommonRowType } from '../lookup/Type';
@@ -13,13 +13,13 @@ import * as ModificationOperations from '../operate/ModificationOperations';
 import * as TransformOperations from '../operate/TransformOperations';
 import * as Adjustments from '../resize/Adjustments';
 import * as ColUtils from '../util/ColUtils';
-import { CompElm } from '../util/TableTypes';
+import type { CompElm } from '../util/TableTypes';
 
-import { Generators, GeneratorsMerging, GeneratorsModification, GeneratorsTransform, SimpleGenerators } from './Generators';
+import { Generators, type GeneratorsMerging, type GeneratorsModification, type GeneratorsTransform, type SimpleGenerators } from './Generators';
 import * as Structs from './Structs';
 import * as TableContent from './TableContent';
 import * as TableLookup from './TableLookup';
-import { TableSection } from './TableSection';
+import type { TableSection } from './TableSection';
 import { Warehouse } from './Warehouse';
 
 export interface TableOperationResult {

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TablePositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TablePositions.ts
@@ -1,10 +1,10 @@
 import { Optional } from '@ephox/katamari';
-import { Compare, SugarElement } from '@ephox/sugar';
+import { Compare, type SugarElement } from '@ephox/sugar';
 
 import * as CellFinder from '../selection/CellFinder';
 import * as CellGroup from '../selection/CellGroup';
 
-import { Bounds } from './Structs';
+import type { Bounds } from './Structs';
 import * as TableLookup from './TableLookup';
 import { Warehouse } from './Warehouse';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableRender.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableRender.ts
@@ -1,6 +1,4 @@
-import { render, RenderOptions } from '../operate/Render';
+import { render, type RenderOptions } from '../operate/Render';
 
-export {
-  render,
-  RenderOptions
-};
+export type { RenderOptions };
+export { render };

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableResize.ts
@@ -1,13 +1,13 @@
-import { Bindable, Event, Events } from '@ephox/porkbun';
-import { SugarElement } from '@ephox/sugar';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Adjustments from '../resize/Adjustments';
 import { BarManager } from '../resize/BarManager';
 import * as BarPositions from '../resize/BarPositions';
 
-import { ResizeBehaviour } from './ResizeBehaviour';
-import { ResizeWire } from './ResizeWire';
-import { TableSize } from './TableSize';
+import type { ResizeBehaviour } from './ResizeBehaviour';
+import type { ResizeWire } from './ResizeWire';
+import type { TableSize } from './TableSize';
 
 type BarPositions<A> = BarPositions.BarPositions<A>;
 type ResizeType = 'row' | 'col';

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableSection.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableSection.ts
@@ -1,8 +1,8 @@
 import { Fun } from '@ephox/katamari';
-import { Replication, SugarElement, SugarNode } from '@ephox/sugar';
+import { Replication, type SugarElement, SugarNode } from '@ephox/sugar';
 
-import { findTableRowHeaderType, RowHeaderType } from '../lookup/Type';
-import { CompElm, Subst } from '../util/TableTypes';
+import { findTableRowHeaderType, type RowHeaderType } from '../lookup/Type';
+import type { CompElm, Subst } from '../util/TableTypes';
 
 import * as Structs from './Structs';
 import { Warehouse } from './Warehouse';

--- a/modules/snooker/src/main/ts/ephox/snooker/api/TableSize.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/TableSize.ts
@@ -1,11 +1,11 @@
 import { Fun } from '@ephox/katamari';
-import { Css, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { Css, SugarBody, type SugarElement, Width } from '@ephox/sugar';
 
 import * as ColumnSizes from '../resize/ColumnSizes';
 import * as Sizes from '../resize/Sizes';
 import * as CellUtils from '../util/CellUtils';
 
-import { Warehouse } from './Warehouse';
+import type { Warehouse } from './Warehouse';
 
 export interface TableSize {
   readonly width: () => number;

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Warehouse.ts
@@ -1,10 +1,10 @@
 import { Arr, Obj, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import * as DetailsList from '../model/DetailsList';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
-import { CompElm } from '../util/TableTypes';
+import type { CompElm } from '../util/TableTypes';
 
 import * as TableLookup from './TableLookup';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/calc/Deltas.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/calc/Deltas.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun } from '@ephox/katamari';
 
-import { ResizeBehaviour } from '../api/ResizeBehaviour';
-import { TableSize } from '../api/TableSize';
+import type { ResizeBehaviour } from '../api/ResizeBehaviour';
+import type { TableSize } from '../api/TableSize';
 
 import { ColumnContext } from './ColumnContext';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Blocks.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { DetailExt } from '../api/Structs';
+import type { DetailExt } from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
 
 type ValidCellFn = (cell: SugarElement<HTMLTableCellElement>) => boolean;

--- a/modules/snooker/src/main/ts/ephox/snooker/lookup/Type.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/lookup/Type.ts
@@ -1,9 +1,9 @@
 import { Arr, Optional, Optionals } from '@ephox/katamari';
-import { SugarElement, SugarNode } from '@ephox/sugar';
+import { type SugarElement, SugarNode } from '@ephox/sugar';
 
-import * as Structs from '../api/Structs';
-import { Warehouse } from '../api/Warehouse';
-import { CellElement } from '../util/TableTypes';
+import type * as Structs from '../api/Structs';
+import type { Warehouse } from '../api/Warehouse';
+import type { CellElement } from '../util/TableTypes';
 
 export type RowHeaderType = 'section' | 'cells' | 'sectionCells';
 export type RowType = 'header' | 'body' | 'footer';

--- a/modules/snooker/src/main/ts/ephox/snooker/model/DetailsList.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/DetailsList.ts
@@ -1,5 +1,5 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import { type SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import * as TableLookup from '../api/TableLookup';

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Fitment.ts
@@ -1,10 +1,10 @@
 import { Arr, Fun, Obj, Result } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SimpleGenerators } from '../api/Generators';
+import type { SimpleGenerators } from '../api/Generators';
 import * as Structs from '../api/Structs';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 
 import * as GridRow from './GridRow';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/model/GridRow.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/GridRow.ts
@@ -1,8 +1,8 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
-import { CellElement, RowCell, RowElement } from '../util/TableTypes';
+import type { CellElement, RowCell, RowElement } from '../util/TableTypes';
 
 type RowMorphism<T extends RowElement> = (element: SugarElement<T>) => SugarElement<T>;
 type CellMorphism<T extends CellElement> = (element: Structs.ElementNew<T>, index: number) => Structs.ElementNew<T>;

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -1,17 +1,17 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, Compare, SugarElement } from '@ephox/sugar';
+import { Attribute, Compare, type SugarElement } from '@ephox/sugar';
 
-import { Generators, GeneratorsWrapper, SimpleGenerators } from '../api/Generators';
+import type { Generators, GeneratorsWrapper, SimpleGenerators } from '../api/Generators';
 import * as ResizeBehaviour from '../api/ResizeBehaviour';
-import * as Structs from '../api/Structs';
+import type * as Structs from '../api/Structs';
 import * as TableLookup from '../api/TableLookup';
-import { TableOperationResult } from '../api/TableOperations';
+import type { TableOperationResult } from '../api/TableOperations';
 import { TableSection } from '../api/TableSection';
 import { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Redraw from '../operate/Redraw';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
-import { CompElm, RowCell, RowElement } from '../util/TableTypes';
+import type { CompElm, RowCell, RowElement } from '../util/TableTypes';
 
 import * as Transitions from './Transitions';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/model/TableGrid.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/TableGrid.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
-import { ElementNew, RowCells } from '../api/Structs';
-import { CompElm } from '../util/TableTypes';
+import type { ElementNew, RowCells } from '../api/Structs';
+import type { CompElm } from '../util/TableTypes';
 
 import * as GridRow from './GridRow';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/model/TableMerge.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/TableMerge.ts
@@ -1,11 +1,11 @@
-import { Arr, Fun, Result } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, Fun, type Result } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SimpleGenerators } from '../api/Generators';
+import type { SimpleGenerators } from '../api/Generators';
 import * as Structs from '../api/Structs';
 import * as MergingOperations from '../operate/MergingOperations';
 import * as LockedColumnUtils from '../util/LockedColumnUtils';
-import { CompElm } from '../util/TableTypes';
+import type { CompElm } from '../util/TableTypes';
 
 import * as Fitment from './Fitment';
 import * as GridRow from './GridRow';

--- a/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/Transitions.ts
@@ -1,9 +1,9 @@
 import { Arr, Fun } from '@ephox/katamari';
 
-import { Generators } from '../api/Generators';
+import type { Generators } from '../api/Generators';
 import * as Structs from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
-import { CompElm, RowCell, RowElement } from '../util/TableTypes';
+import type { CompElm, RowCell, RowElement } from '../util/TableTypes';
 
 import * as TableGrid from './TableGrid';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/MergingOperations.ts
@@ -1,9 +1,9 @@
 import { Arr, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import * as GridRow from '../model/GridRow';
-import { CellElement, CompElm } from '../util/TableTypes';
+import type { CellElement, CompElm } from '../util/TableTypes';
 
 type Subst = () => SugarElement<HTMLTableCellElement>;
 

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/ModificationOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/ModificationOperations.ts
@@ -2,7 +2,7 @@ import { Arr } from '@ephox/katamari';
 
 import * as Structs from '../api/Structs';
 import * as GridRow from '../model/GridRow';
-import { CompElm, Subst } from '../util/TableTypes';
+import type { CompElm, Subst } from '../util/TableTypes';
 
 type CloneCell = (elem: Structs.ElementNew<HTMLTableCellElement>, index: number) => Structs.ElementNew<HTMLTableCellElement>;
 

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/Redraw.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
 import { Attribute, Insert, InsertAll, Remove, Replication, SelectorFilter, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
 
-import { Detail, DetailNew, RowDetailNew, Section } from '../api/Structs';
+import type { Detail, DetailNew, RowDetailNew, Section } from '../api/Structs';
 
 interface NewRowsAndCells {
   readonly newRows: SugarElement<HTMLTableRowElement>[];

--- a/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/operate/TransformOperations.ts
@@ -1,12 +1,12 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Attribute, SugarElement, SugarNode } from '@ephox/sugar';
+import { Attribute, type SugarElement, SugarNode } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
-import { TableSection } from '../api/TableSection';
+import type { TableSection } from '../api/TableSection';
 import { isHeaderCell, isHeaderCells } from '../lookup/Type';
 import * as GridRow from '../model/GridRow';
 import * as CellUtils from '../util/CellUtils';
-import { CompElm, Subst } from '../util/TableTypes';
+import type { CompElm, Subst } from '../util/TableTypes';
 
 type CellReplacer = (cell: Structs.ElementNew<HTMLTableCellElement>, comparator: CompElm, substitute: Subst) => Structs.ElementNew<HTMLTableCellElement>;
 type ScopeGenerator = (cell: Structs.ElementNew<HTMLTableCellElement>, rowIndex: number, colIndex: number) => Optional<null | string>;

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Adjustments.ts
@@ -1,13 +1,13 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import { ResizeBehaviour } from '../api/ResizeBehaviour';
-import { Detail, RowDetail } from '../api/Structs';
-import { TableSize } from '../api/TableSize';
+import type { ResizeBehaviour } from '../api/ResizeBehaviour';
+import type { Detail, RowDetail } from '../api/Structs';
+import type { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Deltas from '../calc/Deltas';
 import * as CellUtils from '../util/CellUtils';
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 
 import * as ColumnSizes from './ColumnSizes';
 import * as Recalculations from './Recalculations';

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarManager.ts
@@ -1,9 +1,9 @@
 import { Dragger } from '@ephox/dragster';
 import { Fun, Optional } from '@ephox/katamari';
-import { Bindable, Event, Events } from '@ephox/porkbun';
-import { Attribute, Class, Compare, ContentEditable, Css, DomEvent, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
+import { Attribute, Class, Compare, ContentEditable, Css, DomEvent, SelectorFind, SugarBody, type SugarElement } from '@ephox/sugar';
 
-import { ResizeWire } from '../api/ResizeWire';
+import type { ResizeWire } from '../api/ResizeWire';
 import * as Styles from '../style/Styles';
 import * as CellUtils from '../util/CellUtils';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarMutation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarMutation.ts
@@ -1,8 +1,8 @@
 import { Optional } from '@ephox/katamari';
-import { Bindable, Event, Events } from '@ephox/porkbun';
-import { SugarElement } from '@ephox/sugar';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
+import type { SugarElement } from '@ephox/sugar';
 
-import { DragDistanceEvent, Mutation } from './Mutation';
+import { type DragDistanceEvent, Mutation } from './Mutation';
 
 export interface DragEvent extends DragDistanceEvent {
   readonly target: SugarElement<Element>;

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/BarPositions.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Direction, Height, SugarElement, SugarLocation, Width } from '@ephox/sugar';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
+import { Direction, Height, type SugarElement, SugarLocation, Width } from '@ephox/sugar';
 
 export interface RowInfo {
   readonly row: number;

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Bars.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Bars.ts
@@ -1,7 +1,7 @@
-import { Arr, Optional } from '@ephox/katamari';
-import { Class, Css, Height, Insert, Remove, SelectorFilter, SugarElement, SugarLocation, SugarPosition, Width } from '@ephox/sugar';
+import { Arr, type Optional } from '@ephox/katamari';
+import { Class, Css, Height, Insert, Remove, SelectorFilter, type SugarElement, SugarLocation, type SugarPosition, Width } from '@ephox/sugar';
 
-import { ResizeWire } from '../api/ResizeWire';
+import type { ResizeWire } from '../api/ResizeWire';
 import { Warehouse } from '../api/Warehouse';
 import * as Blocks from '../lookup/Blocks';
 import * as Styles from '../style/Styles';

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/ColumnSizes.ts
@@ -1,12 +1,12 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { SugarElement, SugarNode, Width } from '@ephox/sugar';
+import { type SugarElement, SugarNode, Width } from '@ephox/sugar';
 
-import { TableSize } from '../api/TableSize';
+import type { TableSize } from '../api/TableSize';
 import { Warehouse } from '../api/Warehouse';
 import * as Blocks from '../lookup/Blocks';
 import * as CellUtils from '../util/CellUtils';
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 import * as Util from '../util/Util';
 
 import { height, width } from './BarPositions';

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Mutation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Mutation.ts
@@ -1,4 +1,4 @@
-import { Bindable, Event, Events } from '@ephox/porkbun';
+import { type Bindable, Event, Events } from '@ephox/porkbun';
 
 export interface DragDistanceEvent {
   readonly xDelta: number;

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Recalculations.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Recalculations.ts
@@ -1,8 +1,8 @@
 import { Arr } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import { Warehouse } from '../api/Warehouse';
-import { CellElement } from '../util/TableTypes';
+import type { CellElement } from '../util/TableTypes';
 
 // Returns the sum of elements of measures in the half-open range [start, end)
 // Measures is in pixels, treated as an array of integers or integers in string format.
@@ -77,10 +77,5 @@ const matchRowHeight = (warehouse: Warehouse, heights: number[]): CellHeight<HTM
   });
 };
 
-export {
-  recalculateWidthForCells,
-  recalculateWidthForColumns,
-  recalculateHeightForCells,
-  matchRowHeight,
-  CellWidthSpan
-};
+export type { CellWidthSpan };
+export { recalculateWidthForCells, recalculateWidthForColumns, recalculateHeightForCells, matchRowHeight };

--- a/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/resize/Sizes.ts
@@ -1,5 +1,5 @@
-import { Fun, Optional, Strings } from '@ephox/katamari';
-import { Attribute, Css, Dimension, Height, SugarBody, SugarElement, SugarNode, Traverse, Width } from '@ephox/sugar';
+import { Fun, type Optional, Strings } from '@ephox/katamari';
+import { Attribute, Css, Dimension, Height, SugarBody, type SugarElement, SugarNode, Traverse, Width } from '@ephox/sugar';
 
 import * as TableLookup from '../api/TableLookup';
 import { getSpan } from '../util/CellUtils';

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellBounds.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellBounds.ts
@@ -1,6 +1,6 @@
 import { Fun, Optional } from '@ephox/katamari';
 
-import { Bounds, DetailExt } from '../api/Structs';
+import type { Bounds, DetailExt } from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';
 
 const inSelection = (bounds: Bounds, detail: DetailExt): boolean => {

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellFinder.ts
@@ -1,5 +1,5 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, SugarElement } from '@ephox/sugar';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
+import { Compare, type SugarElement } from '@ephox/sugar';
 
 import { Warehouse } from '../api/Warehouse';
 

--- a/modules/snooker/src/main/ts/ephox/snooker/selection/CellGroup.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/selection/CellGroup.ts
@@ -1,5 +1,5 @@
-import { Optional } from '@ephox/katamari';
-import { Compare, SugarElement } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import { Compare, type SugarElement } from '@ephox/sugar';
 
 import * as Structs from '../api/Structs';
 import { Warehouse } from '../api/Warehouse';

--- a/modules/snooker/src/main/ts/ephox/snooker/util/CellUtils.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/CellUtils.ts
@@ -1,5 +1,5 @@
 import { Fun } from '@ephox/katamari';
-import { Attribute, Css, SugarElement, SugarNode } from '@ephox/sugar';
+import { Attribute, Css, type SugarElement, SugarNode } from '@ephox/sugar';
 
 export const getAttrValue = (cell: SugarElement<Element>, name: string, fallback: number = 0): number =>
   Attribute.getOpt(cell, name).map((value) => parseInt(value, 10)).getOr(fallback);

--- a/modules/snooker/src/main/ts/ephox/snooker/util/ColUtils.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/ColUtils.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import * as Structs from '../api/Structs';
+import type * as Structs from '../api/Structs';
 
 export const uniqueColumns = (details: Structs.DetailExt[]): Structs.DetailExt[] => {
   const uniqueCheck = (rest: Structs.DetailExt[], detail: Structs.DetailExt) => {

--- a/modules/snooker/src/main/ts/ephox/snooker/util/LayerSelector.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/LayerSelector.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun } from '@ephox/katamari';
-import { Selectors, SugarElement, Traverse } from '@ephox/sugar';
+import { Selectors, type SugarElement, Traverse } from '@ephox/sugar';
 
 const firstLayer = <T extends Element>(scope: SugarElement<Node>, selector: string): SugarElement<T>[] => {
   return filterFirstLayer(scope, selector, Fun.always);

--- a/modules/snooker/src/main/ts/ephox/snooker/util/LockedColumnUtils.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/LockedColumnUtils.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
-import { Attribute, SugarElement } from '@ephox/sugar';
+import { Attribute, type SugarElement } from '@ephox/sugar';
 
-import * as Structs from '../api/Structs';
+import type * as Structs from '../api/Structs';
 import * as GridRow from '../model/GridRow';
 
 export const LOCKED_COL_ATTR = 'data-snooker-locked-cols';

--- a/modules/snooker/src/main/ts/ephox/snooker/util/TableTypes.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/util/TableTypes.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 export type RowElement = HTMLTableRowElement | HTMLTableColElement;
 export type CellElement = HTMLTableCellElement | HTMLTableColElement;

--- a/modules/snooker/src/test/ts/atomic/calc/DeltasTest.ts
+++ b/modules/snooker/src/test/ts/atomic/calc/DeltasTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 
 import * as ResizeBehaviour from 'ephox/snooker/api/ResizeBehaviour';
-import { TableSize } from 'ephox/snooker/api/TableSize';
+import type { TableSize } from 'ephox/snooker/api/TableSize';
 import * as Deltas from 'ephox/snooker/calc/Deltas';
 
 UnitTest.test('DeltasTest', () => {

--- a/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentIVTest.ts
@@ -1,8 +1,8 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { Arr, Fun, Num, Result } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, Fun, Num, type Result } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SimpleGenerators } from 'ephox/snooker/api/Generators';
+import type { SimpleGenerators } from 'ephox/snooker/api/Generators';
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as Fitment from 'ephox/snooker/test/Fitment';
 import * as TableMerge from 'ephox/snooker/test/TableMerge';

--- a/modules/snooker/src/test/ts/atomic/model/FitmentTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/FitmentTest.ts
@@ -1,6 +1,6 @@
 import { UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as Fitment from 'ephox/snooker/test/Fitment';

--- a/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TableGridTest.ts
@@ -1,6 +1,6 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import * as Structs from 'ephox/snooker/api/Structs';

--- a/modules/snooker/src/test/ts/atomic/model/TableMergeTest.ts
+++ b/modules/snooker/src/test/ts/atomic/model/TableMergeTest.ts
@@ -1,6 +1,6 @@
 import { UnitTest } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as TableMerge from 'ephox/snooker/test/TableMerge';

--- a/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
+++ b/modules/snooker/src/test/ts/atomic/operate/MergeOperationsTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as MergingOperations from 'ephox/snooker/operate/MergingOperations';

--- a/modules/snooker/src/test/ts/atomic/resize/RedistributeTest.ts
+++ b/modules/snooker/src/test/ts/atomic/resize/RedistributeTest.ts
@@ -1,7 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 
 import * as Redistribution from 'ephox/snooker/resize/Redistribution';
-import { Size } from 'ephox/snooker/resize/Size';
+import type { Size } from 'ephox/snooker/resize/Size';
 
 UnitTest.test('RedistributeTest', () => {
   const toStr = (f: Size) => {

--- a/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
+++ b/modules/snooker/src/test/ts/browser/CloneFormatsTest.ts
@@ -2,7 +2,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { Html, Insert, SugarElement } from '@ephox/sugar';
 
-import { CellData } from 'ephox/snooker/api/Generators';
+import type { CellData } from 'ephox/snooker/api/Generators';
 import * as TableFill from 'ephox/snooker/api/TableFill';
 
 UnitTest.test('CloneFormatsTest', () => {

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Assertions.ts
@@ -4,8 +4,8 @@ import { Arr, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, Hierarchy, Html, Insert, Remove, SelectorFilter, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 
 import * as TableOperations from 'ephox/snooker/api/TableOperations';
-import { TableSection } from 'ephox/snooker/api/TableSection';
-import { OperationCallback, TargetElement, TargetPaste, TargetPasteRows, TargetSelection } from 'ephox/snooker/model/RunOperation';
+import type { TableSection } from 'ephox/snooker/api/TableSection';
+import type { OperationCallback, TargetElement, TargetPaste, TargetPasteRows, TargetSelection } from 'ephox/snooker/model/RunOperation';
 import * as Bridge from 'ephox/snooker/test/Bridge';
 
 interface TargetLocation {

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Bridge.ts
@@ -1,9 +1,9 @@
 import { Arr, Fun, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Attribute, Css, Hierarchy, Insert, Replication, SugarElement, SugarNode, TextContent } from '@ephox/sugar';
 
-import { Generators, SimpleGenerators } from 'ephox/snooker/api/Generators';
+import type { Generators, SimpleGenerators } from 'ephox/snooker/api/Generators';
 import * as Structs from 'ephox/snooker/api/Structs';
-import { TargetMergable } from 'ephox/snooker/model/RunOperation';
+import type { TargetMergable } from 'ephox/snooker/model/RunOperation';
 
 // Mock/Stub out helper functions
 

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/BrowserTestGenerator.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/BrowserTestGenerator.ts
@@ -1,6 +1,6 @@
 import { Html, SugarElement, SugarNode } from '@ephox/sugar';
 
-import { SimpleGenerators } from 'ephox/snooker/api/Generators';
+import type { SimpleGenerators } from 'ephox/snooker/api/Generators';
 
 export default (): SimpleGenerators => {
   let cellCounter = 0;

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/Fitment.ts
@@ -1,7 +1,7 @@
 import { Assert } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 
-import { SimpleGenerators } from 'ephox/snooker/api/Generators';
+import type { SimpleGenerators } from 'ephox/snooker/api/Generators';
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as Fitment from 'ephox/snooker/model/Fitment';
 

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TableMerge.ts
@@ -1,8 +1,8 @@
 import { Assert } from '@ephox/bedrock-client';
-import { Arr, Result } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import { Arr, type Result } from '@ephox/katamari';
+import type { SugarElement } from '@ephox/sugar';
 
-import { SimpleGenerators } from 'ephox/snooker/api/Generators';
+import type { SimpleGenerators } from 'ephox/snooker/api/Generators';
 import * as Structs from 'ephox/snooker/api/Structs';
 import * as TableMerge from 'ephox/snooker/model/TableMerge';
 import * as Fitment from 'ephox/snooker/test/Fitment';

--- a/modules/snooker/src/test/ts/module/ephox/snooker/test/TestGenerator.ts
+++ b/modules/snooker/src/test/ts/module/ephox/snooker/test/TestGenerator.ts
@@ -1,7 +1,7 @@
 import { Fun } from '@ephox/katamari';
-import { SugarElement, TextContent } from '@ephox/sugar';
+import { type SugarElement, TextContent } from '@ephox/sugar';
 
-import { SimpleGenerators } from 'ephox/snooker/api/Generators';
+import type { SimpleGenerators } from 'ephox/snooker/api/Generators';
 
 export default (): SimpleGenerators => {
   let cellCounter = 0;

--- a/modules/sugar/src/main/ts/ephox/sugar/alien/Recurse.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/alien/Recurse.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 /**
  * Applies f repeatedly until it completes (by returning Optional.none()).

--- a/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/Main.ts
@@ -16,7 +16,7 @@ import * as MouseEvents from './events/MouseEvents';
 import * as Ready from './events/Ready';
 import * as Resize from './events/Resize';
 import * as ScrollChange from './events/ScrollChange';
-import { EventArgs, EventFilter, EventHandler, EventUnbinder } from './events/Types';
+import type { EventArgs, EventFilter, EventHandler, EventUnbinder } from './events/Types';
 import * as Viewable from './events/Viewable';
 import * as NodeTypes from './node/NodeTypes';
 import * as SugarBody from './node/SugarBody';
@@ -62,7 +62,7 @@ import * as Traverse from './search/Traverse';
 import * as Awareness from './selection/Awareness';
 import * as CursorPosition from './selection/CursorPosition';
 import * as Edge from './selection/Edge';
-import { RawRect, Rect, StructRect } from './selection/Rect';
+import { type RawRect, Rect, type StructRect } from './selection/Rect';
 import { SimRange } from './selection/SimRange';
 import { SimSelection } from './selection/SimSelection';
 import { Situ } from './selection/Situ';
@@ -79,6 +79,14 @@ import * as Visibility from './view/Visibility';
 import * as Width from './view/Width';
 import * as WindowVisualViewport from './view/WindowVisualViewport';
 
+export type {
+  EventArgs,
+  EventFilter,
+  EventHandler,
+  EventUnbinder,
+  StructRect,
+  RawRect
+};
 export {
   Compare,
   DocumentPosition,
@@ -90,10 +98,6 @@ export {
   Link,
   Remove,
   Replication,
-  EventArgs,
-  EventFilter,
-  EventHandler,
-  EventUnbinder,
   DomEvent,
   MouseEvents,
   Ready,
@@ -161,7 +165,5 @@ export {
   WindowVisualViewport,
   Width,
   SelectionDirection,
-  StructRect,
-  RawRect,
   Rect
 };

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Compare.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Selectors from '../search/Selectors';
 
 const eq = (e1: SugarElement<unknown>, e2: SugarElement<unknown>): boolean =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/DomFuture.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/DomFuture.ts
@@ -1,8 +1,8 @@
 import { Future, LazyValue, Result } from '@ephox/katamari';
 
 import * as DomEvent from '../events/DomEvent';
-import { EventArgs } from '../events/Types';
-import { SugarElement } from '../node/SugarElement';
+import type { EventArgs } from '../events/Types';
+import type { SugarElement } from '../node/SugarElement';
 
 type WorkDone = (res: Result<EventArgs, string>) => void;
 type Worker = (callback: WorkDone) => void;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Hierarchy.ts
@@ -1,6 +1,6 @@
 import { Fun, Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
 
 import * as Compare from './Compare';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Insert.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Insert.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
 
 const before = (marker: SugarElement<Node>, element: SugarElement<Node>): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/InsertAll.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Insert from './Insert';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Remove.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
 
 import * as InsertAll from './InsertAll';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Replication.ts
@@ -1,4 +1,4 @@
-import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
+import type { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 import { SugarElement } from '../node/SugarElement';
 import * as Attribute from '../properties/Attribute';
 import * as Traverse from '../search/Traverse';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/dom/Truncate.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as SugarShadowDom from '../node/SugarShadowDom';
 import * as Html from '../properties/Html';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/DomEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/DomEvent.ts
@@ -1,9 +1,9 @@
 import { Fun } from '@ephox/katamari';
 
 import * as FilteredEvent from '../../impl/FilteredEvent';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
-import { EventHandler, EventUnbinder } from './Types';
+import type { EventHandler, EventUnbinder } from './Types';
 
 const filter = Fun.always; // no filter on plain DomEvents
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvents.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/MouseEvents.ts
@@ -1,7 +1,7 @@
 import * as FilteredEvent from '../../impl/FilteredEvent';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
-import { EventFilter, EventHandler } from './Types';
+import type { EventFilter, EventHandler } from './Types';
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
 const isLeftClick = (raw: MouseEvent) => raw.button === 0;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Resize.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Resize.ts
@@ -8,7 +8,7 @@ import * as Visibility from '../view/Visibility';
 import * as Width from '../view/Width';
 
 import * as DomEvent from './DomEvent';
-import { EventUnbinder } from './Types';
+import type { EventUnbinder } from './Types';
 import * as Viewable from './Viewable';
 
 interface Monitored {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/ScrollChange.ts
@@ -1,9 +1,9 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Scroll from '../view/Scroll';
-import { SugarPosition } from '../view/SugarPosition';
+import type { SugarPosition } from '../view/SugarPosition';
 
 import * as DomEvent from './DomEvent';
-import { EventUnbinder } from './Types';
+import type { EventUnbinder } from './Types';
 
 /* Some browsers (Firefox) fire a scroll event even if the values for scroll don't
  * change. This acts as an intermediary between the scroll event, and the value for scroll

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Types.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Types.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 export interface EventArgs<E = Event, T extends Node | Window = Node> {
   readonly target: SugarElement<T>;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/events/Viewable.ts
@@ -1,6 +1,6 @@
 import { Fun, Throttler } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Traverse from '../search/Traverse';
 import * as Visibility from '../view/Visibility';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarComment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarComment.ts
@@ -1,8 +1,8 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 import { NodeValue } from '../../impl/NodeValue';
 
-import { SugarElement } from './SugarElement';
+import type { SugarElement } from './SugarElement';
 import * as SugarNode from './SugarNode';
 
 const api = NodeValue(SugarNode.isComment, 'comment');

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarComments.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarComments.ts
@@ -1,4 +1,4 @@
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, type Optional } from '@ephox/katamari';
 
 import { SugarElement } from './SugarElement';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElement.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElement.ts
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
 
-import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
+import type { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 
 interface SugarElement<T = any> {
   readonly dom: T;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElementInstances.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarElementInstances.ts
@@ -2,7 +2,7 @@ import { Eq, Pnode, Pprint, Testable } from '@ephox/dispute';
 
 import * as Html from '../properties/Html';
 
-import { SugarElement } from './SugarElement';
+import type { SugarElement } from './SugarElement';
 
 type EqType<A> = Eq.Eq<A>;
 type PprintType<A> = Pprint.Pprint<A>;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarNode.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarNode.ts
@@ -1,9 +1,9 @@
 import { SandHTMLElement } from '@ephox/sand';
 
-import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
+import type { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 
 import * as NodeTypes from './NodeTypes';
-import { SugarElement } from './SugarElement';
+import type { SugarElement } from './SugarElement';
 
 const name = (element: SugarElement<Node>): string => {
   const r = element.dom.nodeName;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
 
-import { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
+import type { HTMLElementFullTagNameMap } from '../../alien/DomTypes';
 import * as Traverse from '../search/Traverse';
 
 import { SugarElement } from './SugarElement';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarText.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarText.ts
@@ -1,8 +1,8 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 import { NodeValue } from '../../impl/NodeValue';
 
-import { SugarElement } from './SugarElement';
+import type { SugarElement } from './SugarElement';
 import * as SugarNode from './SugarNode';
 
 const api = NodeValue(SugarNode.isText, 'text');

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Alignment.ts
@@ -1,6 +1,6 @@
 import { Obj } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Node from '../node/SugarNode';
 
 import * as Css from './Css';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttrList.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttrList.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Attribute from './Attribute';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attribute.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Attribute.ts
@@ -1,6 +1,6 @@
 import { Arr, Obj, Optional, Type } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as SugarNode from '../node/SugarNode';
 
 const rawSet = (dom: Element, key: string, value: string | boolean | number): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/AttributeProperty.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Attribute from './Attribute';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Checked.ts
@@ -1,6 +1,6 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as SelectorFind from '../search/SelectorFind';
 
 const set = (element: SugarElement<HTMLInputElement>, status: boolean): void => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Class.ts
@@ -1,5 +1,5 @@
 import * as ClassList from '../../impl/ClassList';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Attribute from './Attribute';
 import { Toggler } from './Toggler';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Classes.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import * as ClassList from '../../impl/ClassList';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Class from './Class';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/ContentEditable.ts
@@ -1,7 +1,7 @@
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, type Optional } from '@ephox/katamari';
 
 import * as SugarBody from '../node/SugarBody';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as SelectorFind from '../search/SelectorFind';
 
 const closest = (target: SugarElement<Node>): Optional<SugarElement<HTMLElement>> =>

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/CssProperty.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Css from './Css';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Direction.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Css from './Css';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Float.ts
@@ -1,7 +1,7 @@
 import { Optional } from '@ephox/katamari';
 
 import * as Style from '../../impl/Style';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Css from './Css';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/OnNode.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Class from './Class';
 import * as Classes from './Classes';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/TextContent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/TextContent.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 const get = (element: SugarElement<Node>): string | null =>
   element.dom.textContent;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/properties/Value.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/properties/Value.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 type TogglableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | HTMLOptionElement | HTMLButtonElement;
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/ElementAddress.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/ElementAddress.ts
@@ -1,7 +1,7 @@
-import { Arr, Fun, Optional } from '@ephox/katamari';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
 
 import * as Compare from '../dom/Compare';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as PredicateFind from './PredicateFind';
 import * as SelectorFilter from './SelectorFilter';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/Has.ts
@@ -1,7 +1,7 @@
 import { Arr, Fun } from '@ephox/katamari';
 
 import * as Compare from '../dom/Compare';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as PredicateExists from './PredicateExists';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateExists.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as PredicateFind from './PredicateFind';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateFilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/PredicateFilter.ts
@@ -1,7 +1,7 @@
 import { Arr } from '@ephox/katamari';
 
 import * as SugarBody from '../node/SugarBody';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Traverse from './Traverse';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorExists.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as SelectorFind from './SelectorFind';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFilter.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as PredicateFilter from './PredicateFilter';
 import * as Selectors from './Selectors';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/search/SelectorFind.ts
@@ -1,7 +1,7 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 
 import ClosestOrAncestor from '../../impl/ClosestOrAncestor';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as PredicateFind from './PredicateFind';
 import * as Selectors from './Selectors';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Awareness.ts
@@ -1,6 +1,6 @@
 import { Arr, Unicode } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as SugarNode from '../node/SugarNode';
 import * as SugarText from '../node/SugarText';
 import * as Attribute from '../properties/Attribute';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/CursorPosition.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/CursorPosition.ts
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as PredicateFind from '../search/PredicateFind';
 import * as Traverse from '../search/Traverse';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Edge.ts
@@ -1,7 +1,7 @@
-import { Fun, Optional } from '@ephox/katamari';
+import { Fun, type Optional } from '@ephox/katamari';
 
 import * as Compare from '../dom/Compare';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import * as Awareness from './Awareness';
 import * as CursorPosition from './CursorPosition';

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/SimRange.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 export interface SimRange {
   readonly start: SugarElement<Node>;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/Situ.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/Situ.ts
@@ -1,6 +1,6 @@
 import { Adt, Fun } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 export interface Situ {
   fold: <U> (

--- a/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/selection/WindowSelection.ts
@@ -10,10 +10,10 @@ import * as DocumentPosition from '../dom/DocumentPosition';
 import { SugarElement } from '../node/SugarElement';
 import * as SugarFragment from '../node/SugarFragment';
 
-import { RawRect } from './Rect';
+import type { RawRect } from './Rect';
 import { SimRange } from './SimRange';
 import { SimSelection } from './SimSelection';
-import { Situ } from './Situ';
+import type { Situ } from './Situ';
 
 const getNativeSelection = (win: Window) => Optional.from(win.getSelection());
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/tag/OptionTag.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/tag/OptionTag.ts
@@ -1,4 +1,4 @@
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 const setValue = (option: SugarElement<HTMLOptionElement>, value: string, text: string): void => {
   const optionDom = option.dom;

--- a/modules/sugar/src/main/ts/ephox/sugar/api/tag/SelectTag.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/tag/SelectTag.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 const getValueFromIndex = (options: HTMLOptionsCollection, index: number): Optional<string> => {
   return Arr.get(options, index).bind((optionVal) => Optional.from(optionVal.value));

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Height.ts
@@ -1,7 +1,7 @@
 import { Dimension } from '../../impl/Dimension';
 import * as RuntimeSize from '../../impl/RuntimeSize';
 import * as SugarBody from '../node/SugarBody';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
 
 const api = Dimension('height', (element: SugarElement<HTMLElement>) => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/SugarLocation.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/SugarLocation.ts
@@ -1,5 +1,5 @@
 import { inBody } from '../node/SugarBody';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 
 import { SugarPosition } from './SugarPosition';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Visibility.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Visibility.ts
@@ -1,6 +1,6 @@
 import { Fun } from '@ephox/katamari';
 
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
 import { Toggler } from '../properties/Toggler';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/Width.ts
@@ -1,7 +1,7 @@
 import { Dimension } from '../../impl/Dimension';
 import * as RuntimeSize from '../../impl/RuntimeSize';
 import * as SugarBody from '../node/SugarBody';
-import { SugarElement } from '../node/SugarElement';
+import type { SugarElement } from '../node/SugarElement';
 import * as Css from '../properties/Css';
 
 const api = Dimension('width', (element: SugarElement<HTMLElement>) => {

--- a/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/api/view/WindowVisualViewport.ts
@@ -2,7 +2,7 @@ import { Fun, Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 import { fromRawEvent } from '../../impl/FilteredEvent';
-import { EventHandler, EventUnbinder } from '../events/Types';
+import type { EventHandler, EventUnbinder } from '../events/Types';
 import { SugarElement } from '../node/SugarElement';
 
 import * as Scroll from './Scroll';

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/ClassList.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/ClassList.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import { SugarElement } from '../api/node/SugarElement';
+import type { SugarElement } from '../api/node/SugarElement';
 import * as AttrList from '../api/properties/AttrList';
 
 // IE11 Can return undefined for a classList on elements such as math, so we make sure it's not undefined before attempting to use it.

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/ClosestOrAncestor.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/ClosestOrAncestor.ts
@@ -1,6 +1,6 @@
 import { Optional, Type } from '@ephox/katamari';
 
-import { SugarElement } from '../api/node/SugarElement';
+import type { SugarElement } from '../api/node/SugarElement';
 
 type TestFn = (e: SugarElement<Node>) => boolean;
 type ScopeTestFn<T, R extends Node> = (scope: SugarElement<Node>, a: T) => scope is SugarElement<R>;

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Dimension.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Dimension.ts
@@ -1,6 +1,6 @@
 import { Arr, Type } from '@ephox/katamari';
 
-import { SugarElement } from '../api/node/SugarElement';
+import type { SugarElement } from '../api/node/SugarElement';
 import * as Css from '../api/properties/Css';
 
 import * as Style from './Style';

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/FilteredEvent.ts
@@ -1,6 +1,6 @@
 import { Fun } from '@ephox/katamari';
 
-import { EventArgs, EventFilter, EventHandler, EventUnbinder } from '../api/events/Types';
+import type { EventArgs, EventFilter, EventHandler, EventUnbinder } from '../api/events/Types';
 import { SugarElement } from '../api/node/SugarElement';
 import * as SugarShadowDom from '../api/node/SugarShadowDom';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/Monitors.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/Monitors.ts
@@ -1,7 +1,7 @@
 import { Arr, Optional } from '@ephox/katamari';
 
 import * as Compare from '../api/dom/Compare';
-import { SugarElement } from '../api/node/SugarElement';
+import type { SugarElement } from '../api/node/SugarElement';
 
 export interface Polling {
   element: SugarElement<Node>;

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/NodeValue.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/NodeValue.ts
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../api/node/SugarElement';
+import type { SugarElement } from '../api/node/SugarElement';
 
 export interface NodeValue {
   readonly get: (element: SugarElement<Node>) => string;

--- a/modules/sugar/src/main/ts/ephox/sugar/impl/RuntimeSize.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/impl/RuntimeSize.ts
@@ -1,6 +1,6 @@
 import { Strings } from '@ephox/katamari';
 
-import { SugarElement } from '../api/node/SugarElement';
+import type { SugarElement } from '../api/node/SugarElement';
 import * as Css from '../api/properties/Css';
 
 const toNumber = (px: string, fallback: number): number =>

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/core/NativeRange.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/core/NativeRange.ts
@@ -1,8 +1,8 @@
 import { Optional } from '@ephox/katamari';
 
 import { SugarElement } from '../../api/node/SugarElement';
-import { RawRect } from '../../api/selection/Rect';
-import { Situ } from '../../api/selection/Situ';
+import type { RawRect } from '../../api/selection/Rect';
+import type { Situ } from '../../api/selection/Situ';
 
 const selectNode = (win: Window, element: SugarElement<Node>): Range => {
   const rng = win.document.createRange();

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/core/SelectionDirection.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/core/SelectionDirection.ts
@@ -1,7 +1,7 @@
 import { Adt, Fun, Optional, Thunk } from '@ephox/katamari';
 
 import { SugarElement } from '../../api/node/SugarElement';
-import { SimSelection } from '../../api/selection/SimSelection';
+import type { SimSelection } from '../../api/selection/SimSelection';
 
 import * as NativeRange from './NativeRange';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/ContainerPoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/ContainerPoint.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../../api/node/SugarElement';
+import type { SugarElement } from '../../api/node/SugarElement';
 import * as SugarNode from '../../api/node/SugarNode';
 import * as Traverse from '../../api/search/Traverse';
 import * as Geometry from '../alien/Geometry';

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/EdgePoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/EdgePoint.ts
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../../api/node/SugarElement';
+import type { SugarElement } from '../../api/node/SugarElement';
 import * as Traverse from '../../api/search/Traverse';
 import * as CursorPosition from '../../api/selection/CursorPosition';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/TextPoint.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/TextPoint.ts
@@ -1,6 +1,6 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import { SugarElement } from '../../api/node/SugarElement';
+import type { SugarElement } from '../../api/node/SugarElement';
 import * as SugarText from '../../api/node/SugarText';
 import * as Geometry from '../alien/Geometry';
 

--- a/modules/sugar/src/main/ts/ephox/sugar/selection/query/Within.ts
+++ b/modules/sugar/src/main/ts/ephox/sugar/selection/query/Within.ts
@@ -4,7 +4,7 @@ import { SugarElement } from '../../api/node/SugarElement';
 import * as Node from '../../api/node/SugarNode';
 import * as SelectorFilter from '../../api/search/SelectorFilter';
 import * as Selectors from '../../api/search/Selectors';
-import { SimSelection } from '../../api/selection/SimSelection';
+import type { SimSelection } from '../../api/selection/SimSelection';
 import * as NativeRange from '../core/NativeRange';
 import * as SelectionDirection from '../core/SelectionDirection';
 

--- a/modules/sugar/src/test/ts/browser/AttributeTransferTest.ts
+++ b/modules/sugar/src/test/ts/browser/AttributeTransferTest.ts
@@ -1,7 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
 import Div from 'ephox/sugar/test/Div';
 

--- a/modules/sugar/src/test/ts/browser/ContentEditableTest.ts
+++ b/modules/sugar/src/test/ts/browser/ContentEditableTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
 import * as ContentEditable from 'ephox/sugar/api/properties/ContentEditable';
 import Div from 'ephox/sugar/test/Div';

--- a/modules/sugar/src/test/ts/browser/CssPropertyTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssPropertyTest.ts
@@ -1,6 +1,6 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Css from 'ephox/sugar/api/properties/Css';
 import { CssProperty } from 'ephox/sugar/api/properties/CssProperty';
 import EphoxElement from 'ephox/sugar/test/EphoxElement';

--- a/modules/sugar/src/test/ts/browser/CssTransferTest.ts
+++ b/modules/sugar/src/test/ts/browser/CssTransferTest.ts
@@ -1,7 +1,7 @@
 import { Assert, UnitTest } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Css from 'ephox/sugar/api/properties/Css';
 import Div from 'ephox/sugar/test/Div';
 

--- a/modules/sugar/src/test/ts/browser/DirectionTest.ts
+++ b/modules/sugar/src/test/ts/browser/DirectionTest.ts
@@ -3,7 +3,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Attribute from 'ephox/sugar/api/properties/Attribute';
 import * as Direction from 'ephox/sugar/api/properties/Direction';
 import EphoxElement from 'ephox/sugar/test/EphoxElement';

--- a/modules/sugar/src/test/ts/browser/IsRootTest.ts
+++ b/modules/sugar/src/test/ts/browser/IsRootTest.ts
@@ -3,7 +3,7 @@ import { Fun, Optional } from '@ephox/katamari';
 
 import * as Compare from 'ephox/sugar/api/dom/Compare';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as PredicateExists from 'ephox/sugar/api/search/PredicateExists';
 import * as PredicateFilter from 'ephox/sugar/api/search/PredicateFilter';
 import * as PredicateFind from 'ephox/sugar/api/search/PredicateFind';

--- a/modules/sugar/src/test/ts/browser/PredicateTest.ts
+++ b/modules/sugar/src/test/ts/browser/PredicateTest.ts
@@ -2,7 +2,7 @@ import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 
 import * as Remove from 'ephox/sugar/api/dom/Remove';
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as SugarNode from 'ephox/sugar/api/node/SugarNode';
 import * as PredicateExists from 'ephox/sugar/api/search/PredicateExists';
 import * as PredicateFilter from 'ephox/sugar/api/search/PredicateFilter';

--- a/modules/sugar/src/test/ts/browser/PrefilterTest.ts
+++ b/modules/sugar/src/test/ts/browser/PrefilterTest.ts
@@ -3,7 +3,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as Hierarchy from 'ephox/sugar/api/dom/Hierarchy';
 import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Html from 'ephox/sugar/api/properties/Html';
-import { Situ } from 'ephox/sugar/api/selection/Situ';
+import type { Situ } from 'ephox/sugar/api/selection/Situ';
 import * as Prefilter from 'ephox/sugar/selection/quirks/Prefilter';
 
 UnitTest.test('Browser Test: PrefilterTest', () => {

--- a/modules/sugar/src/test/ts/browser/SizeTest.ts
+++ b/modules/sugar/src/test/ts/browser/SizeTest.ts
@@ -3,7 +3,7 @@ import { Assert, UnitTest } from '@ephox/bedrock-client';
 import * as Insert from 'ephox/sugar/api/dom/Insert';
 import * as Remove from 'ephox/sugar/api/dom/Remove';
 import * as SugarBody from 'ephox/sugar/api/node/SugarBody';
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import * as Css from 'ephox/sugar/api/properties/Css';
 import * as Height from 'ephox/sugar/api/view/Height';
 import * as Width from 'ephox/sugar/api/view/Width';

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/Arbitrary.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/Arbitrary.ts
@@ -1,4 +1,4 @@
-import fc, { Arbitrary } from 'fast-check';
+import fc, { type Arbitrary } from 'fast-check';
 
 export const htmlBlockTagName = (): Arbitrary<string> =>
   // note: list is incomplete

--- a/modules/sugar/src/test/ts/module/ephox/sugar/test/Checkers.ts
+++ b/modules/sugar/src/test/ts/module/ephox/sugar/test/Checkers.ts
@@ -1,9 +1,9 @@
 import { Assert } from '@ephox/bedrock-client';
 import { Testable } from '@ephox/dispute';
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 import { KAssert } from '@ephox/katamari-assertions';
 
-import { SugarElement } from 'ephox/sugar/api/node/SugarElement';
+import type { SugarElement } from 'ephox/sugar/api/node/SugarElement';
 import { tElement } from 'ephox/sugar/api/node/SugarElementInstances';
 import * as SugarNode from 'ephox/sugar/api/node/SugarNode';
 


### PR DESCRIPTION
Related Ticket: TINY-12807

Description of Changes:

- Update subset of modules to adhere to import/export type rules

NOTE: The PRs are too big to properly review. The eslint auto-fixer largely did most of the work so should be safe.

yarn build​ works witout issues with a tinymce.d.ts​ still correctly generated

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):