### PR TITLE
TINY-12807: Enforce consisten import and export types (tinymce model/theme)

### DIFF
--- a/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts
@@ -1,4 +1,4 @@
-import { TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 declare let tinymce: TinyMCE;
 

--- a/modules/tinymce/src/models/dom/main/ts/Model.ts
+++ b/modules/tinymce/src/models/dom/main/ts/Model.ts
@@ -1,5 +1,5 @@
-import Editor from 'tinymce/core/api/Editor';
-import ModelManager, { Model } from 'tinymce/core/api/ModelManager';
+import type Editor from 'tinymce/core/api/Editor';
+import ModelManager, { type Model } from 'tinymce/core/api/ModelManager';
 
 import * as Table from './table/Table';
 

--- a/modules/tinymce/src/models/dom/main/ts/table/Table.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/Table.ts
@@ -1,5 +1,5 @@
-import Editor from 'tinymce/core/api/Editor';
-import { Model } from 'tinymce/core/api/ModelManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Model } from 'tinymce/core/api/ModelManager';
 
 import * as Clipboard from './actions/Clipboard';
 import { TableActions } from './actions/TableActions';

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/Clipboard.ts
@@ -1,8 +1,8 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, type Optional } from '@ephox/katamari';
 import { CopySelected, TableFill, TableLookup } from '@ephox/snooker';
 import { Attribute, Css, Insert, InsertAll, Remove, SugarElement, SugarElements, SugarNode, SugarShadowDom } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
 import * as Utils from '../core/TableUtils';
@@ -10,7 +10,7 @@ import * as TableTargets from '../queries/TableTargets';
 import * as Ephemera from '../selection/Ephemera';
 import * as TableSelection from '../selection/TableSelection';
 
-import { TableActions } from './TableActions';
+import type { TableActions } from './TableActions';
 
 const extractSelected = (cells: SugarElement<HTMLTableCellElement>[]): Optional<SugarElement<HTMLTableElement>[]> => {
   // Assume for now that we only have one table (also handles the case where we multi select outside a table)

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/InsertTable.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/InsertTable.ts
@@ -1,8 +1,8 @@
 import { Arr, Fun, Type } from '@ephox/katamari';
 import { TableRender, TableConversions } from '@ephox/snooker';
-import { Attribute, Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Attribute, Html, SelectorFilter, SelectorFind, type SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../api/Events';
 import * as Options from '../api/Options';

--- a/modules/tinymce/src/models/dom/main/ts/table/actions/TableActions.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/actions/TableActions.ts
@@ -1,17 +1,17 @@
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { DomDescent } from '@ephox/phoenix';
 import {
-  CellMutations, ResizeBehaviour, RunOperation, TableFill, TableGridSize, TableSection, TableOperations, TableLookup
+  CellMutations, ResizeBehaviour, type RunOperation, TableFill, TableGridSize, TableSection, TableOperations, TableLookup
 } from '@ephox/snooker';
 import { Attribute, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableEventData } from 'tinymce/core/api/EventTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableEventData } from 'tinymce/core/api/EventTypes';
 
 import * as Events from '../api/Events';
 import * as Options from '../api/Options';
-import { TableCellSelectionHandler } from '../api/TableCellSelectionHandler';
-import { TableResizeHandler } from '../api/TableResizeHandler';
+import type { TableCellSelectionHandler } from '../api/TableCellSelectionHandler';
+import type { TableResizeHandler } from '../api/TableResizeHandler';
 import * as Utils from '../core/TableUtils';
 import * as TableSize from '../queries/TableSize';
 

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Clipboard.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Clipboard.ts
@@ -5,7 +5,7 @@
  */
 
 import { Arr, Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import FakeClipboard from 'tinymce/core/api/FakeClipboard';
 

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Commands.ts
@@ -2,10 +2,10 @@ import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 import { CopyCols, CopyRows, Sizes, TableFill, TableLookup, TableConversions } from '@ephox/snooker';
 import { Insert, Remove, Replication, SelectorFind, Selectors, SugarElement, SugarNode } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as InsertTable from '../actions/InsertTable';
-import { AdvancedPasteTableAction, CombinedTargetsTableAction, TableActionResult, TableActions } from '../actions/TableActions';
+import type { AdvancedPasteTableAction, CombinedTargetsTableAction, TableActionResult, TableActions } from '../actions/TableActions';
 import * as Events from '../api/Events';
 import * as Utils from '../core/TableUtils';
 import * as TableTargets from '../queries/TableTargets';

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Events.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Events.ts
@@ -6,9 +6,9 @@
  Make sure that if making changes to this file, the other files are updated as well
  */
 
-import Editor from 'tinymce/core/api/Editor';
-import { NewTableCellEvent, NewTableRowEvent, TableEventData } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { NewTableCellEvent, NewTableRowEvent, TableEventData } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 // Duplicated in modules/tinymce/src/themes/silver/main/ts/ui/selector/TableSelectorHandles.ts
 // NOTE: This is an internal only event so not publicly exposing the interface in EventTypes.ts

--- a/modules/tinymce/src/models/dom/main/ts/table/api/Options.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/Options.ts
@@ -1,8 +1,8 @@
 import { Arr, Optional, Type } from '@ephox/katamari';
 import { SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 export type TableSizingMode = 'fixed' | 'relative' | 'responsive' | 'auto';
 export type TableColumnResizing = 'preservetable' | 'resizetable';

--- a/modules/tinymce/src/models/dom/main/ts/table/api/QueryCommands.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/QueryCommands.ts
@@ -1,9 +1,9 @@
 import { Obj } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { LookupAction, TableActions } from '../actions/TableActions';
+import type { LookupAction, TableActions } from '../actions/TableActions';
 import * as Utils from '../core/TableUtils';
 import * as TableTargets from '../queries/TableTargets';
 import * as TableSelection from '../selection/TableSelection';

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableCellSelectionHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableCellSelectionHandler.ts
@@ -1,11 +1,11 @@
-import { InputHandlers, Response, SelectionAnnotation, SelectionKeys, Selections, SelectionTypes } from '@ephox/darwin';
+import { InputHandlers, type Response, SelectionAnnotation, SelectionKeys, Selections, SelectionTypes } from '@ephox/darwin';
 import { Arr, Cell, Fun, Obj } from '@ephox/katamari';
 import { DomParent } from '@ephox/robin';
 import { OtherCells, TableFill, TableLookup } from '@ephox/snooker';
-import { Class, Compare, DomEvent, EventArgs, SelectionDirection, SimSelection, SugarElement, SugarNode, Direction } from '@ephox/sugar';
+import { Class, Compare, DomEvent, type EventArgs, SelectionDirection, SimSelection, SugarElement, SugarNode, Direction } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Utils from '../core/TableUtils';
 import { ephemera } from '../selection/Ephemera';
@@ -14,7 +14,7 @@ import * as TableSelection from '../selection/TableSelection';
 
 import * as Events from './Events';
 import * as Options from './Options';
-import { TableResizeHandler } from './TableResizeHandler';
+import type { TableResizeHandler } from './TableResizeHandler';
 
 export interface TableCellSelectionHandler {
   readonly getSelectedCells: () => HTMLTableCellElement[];

--- a/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/api/TableResizeHandler.ts
@@ -1,10 +1,10 @@
 import { Arr, Singleton, Strings, Type } from '@ephox/katamari';
-import { Adjustments, ResizeBehaviour, ResizeWire, Sizes, TableConversions, TableGridSize, TableLookup, TableResize, Warehouse } from '@ephox/snooker';
+import { Adjustments, ResizeBehaviour, type ResizeWire, Sizes, TableConversions, TableGridSize, TableLookup, TableResize, Warehouse } from '@ephox/snooker';
 import { Attribute, Css, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { DisabledStateChangeEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { DisabledStateChangeEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Utils from '../core/TableUtils';
 import * as TableWire from '../core/TableWire';

--- a/modules/tinymce/src/models/dom/main/ts/table/core/TableUtils.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/core/TableUtils.ts
@@ -9,7 +9,7 @@ import { Arr, Optional, Strings } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
 import { Attribute, Compare, ContentEditable, PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const getBody = (editor: Editor): SugarElement<HTMLElement> =>
   SugarElement.fromDom(editor.getBody());

--- a/modules/tinymce/src/models/dom/main/ts/table/core/TableWire.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/core/TableWire.ts
@@ -1,7 +1,7 @@
 import { ResizeWire } from '@ephox/snooker';
 import { SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const get = (editor: Editor, isResizable: (elm: SugarElement<Element>) => boolean): ResizeWire => {
   const editorBody = SugarElement.fromDom(editor.getBody());

--- a/modules/tinymce/src/models/dom/main/ts/table/queries/TableSize.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/queries/TableSize.ts
@@ -1,7 +1,7 @@
 import { TableSize } from '@ephox/snooker';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
 

--- a/modules/tinymce/src/models/dom/main/ts/table/queries/TableTargets.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/queries/TableTargets.ts
@@ -7,8 +7,8 @@
 
 import { CellOpSelection } from '@ephox/darwin';
 import { Optional } from '@ephox/katamari';
-import { RunOperation, SimpleGenerators } from '@ephox/snooker';
-import { SugarElement } from '@ephox/sugar';
+import type { RunOperation, SimpleGenerators } from '@ephox/snooker';
+import type { SugarElement } from '@ephox/sugar';
 
 import { ephemera } from '../selection/Ephemera';
 

--- a/modules/tinymce/src/models/dom/main/ts/table/selection/Ephemera.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/selection/Ephemera.ts
@@ -5,7 +5,7 @@
  Make sure that if making changes to this file, the other files are updated as well
  */
 
-import { Ephemera as DarwinEphemera } from '@ephox/darwin';
+import type { Ephemera as DarwinEphemera } from '@ephox/darwin';
 
 const strSelected = 'data-mce-selected';
 const strSelectedSelector = 'td[' + strSelected + '],th[' + strSelected + ']';

--- a/modules/tinymce/src/models/dom/main/ts/table/selection/TableSelection.ts
+++ b/modules/tinymce/src/models/dom/main/ts/table/selection/TableSelection.ts
@@ -8,9 +8,9 @@
 import { TableSelection } from '@ephox/darwin';
 import { Arr, Fun } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
-import { SelectorFind, Selectors, SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
+import { SelectorFind, Selectors, type SugarElement, SugarElements, SugarNode } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { ephemera } from './Ephemera';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/DragEditorContentsOverTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/DragEditorContentsOverTableTest.ts
@@ -4,7 +4,7 @@ import { SelectorExists, SelectorFind } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.DragEditorContentsOverTableTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/DragResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/DragResizeTest.ts
@@ -1,11 +1,11 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Cell } from '@ephox/katamari';
-import { Attribute, Css, Height, Hierarchy, SelectorFind, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { Attribute, Css, Height, Hierarchy, SelectorFind, SugarBody, type SugarElement, Width } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.DragResizeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/DragSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/DragSelectionTest.ts
@@ -2,7 +2,7 @@ import { Mouse, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.DragSelectionTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/EmptyRowTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/EmptyRowTableTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.EmptyRowTableTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/FakeSelectionTest.ts
@@ -5,9 +5,9 @@ import { Attribute, Focus, Html, Insert, Remove, SelectorFilter, SelectorFind, S
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-import { TableSelectionChangeEvent } from 'tinymce/models/dom/table/api/Events';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type { TableSelectionChangeEvent } from 'tinymce/models/dom/table/api/Events';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/InsertColumnTableSizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/InsertColumnTableSizeTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SelectorFind } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/InsertRowTableResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/InsertRowTableResizeTest.ts
@@ -4,7 +4,7 @@ import { SelectorFind } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/InsertTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/InsertTableTest.ts
@@ -2,7 +2,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/InsertTableWidthsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/InsertTableWidthsTest.ts
@@ -4,7 +4,7 @@ import { Css } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/InvalidColCountTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/InvalidColCountTest.ts
@@ -1,10 +1,10 @@
 import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Optional, Optionals } from '@ephox/katamari';
+import { Arr, type Optional, Optionals } from '@ephox/katamari';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.InvalidColCountTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/ModifyColumnsTableResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/ModifyColumnsTableResizeTest.ts
@@ -3,7 +3,7 @@ import { SelectorFind, Width } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface TableCommandMap {
   readonly mceTableInsertColBefore: number;

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/NestedFakeSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/NestedFakeSelectionTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Attribute } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/NewCellRowEventsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/NewCellRowEventsTest.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/PasteTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/PasteTableTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/mcagar';
 import { SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.PasteTableTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/ResizeTableTest.ts
@@ -7,9 +7,9 @@ import { Class, Css, Height, Html, Insert, InsertAll, Remove, SelectorExists, Se
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { ObjectResizeEvent, TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { ObjectResizeEvent, TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/SwitchTableSectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/SwitchTableSectionTest.ts
@@ -2,7 +2,7 @@ import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.SwitchTableSectionTest', () => {
   const basicContent = `<table>

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TableNoWidthTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TableNoWidthTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.TableNoWidthTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TableSectionApiTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TableSectionApiTest.ts
@@ -5,9 +5,9 @@ import { Selectors } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { NewTableCellEvent, TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { NewTableCellEvent, TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.models.dom.table.TableSectionApiTest', () => {
   const bodyContent = `<table>

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TableSizingModeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TableSizingModeTest.ts
@@ -1,10 +1,10 @@
-import { ApproxStructure, StructAssert } from '@ephox/agar';
+import { ApproxStructure, type StructAssert } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Type } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.TableSizingModeTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/TwoCellsSelectionTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const enum Direction {
   Row,

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/UnmergeCellTableResizeTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/UnmergeCellTableResizeTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 import { TinyContentActions, TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ApplyCellStyleCommandTest.ts
@@ -5,9 +5,9 @@ import { SugarElement, SugarNode } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as TableTestUtils from '../../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/CommandsOnLockedColumnsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/CommandsOnLockedColumnsTest.ts
@@ -1,13 +1,13 @@
-import { ApproxStructure, Cursors } from '@ephox/agar';
+import { ApproxStructure, type Cursors } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarElement, SugarNode } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as TableTestUtils from '../../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertCommandsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertCommandsTest.ts
@@ -2,9 +2,9 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { LegacyUnit, TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.models.dom.table.command.InsertCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertTableCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertTableCommandTest.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertTableCommandWithColGroupsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/InsertTableCommandWithColGroupsTest.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TableTestUtils from '../../../module/table/TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/MergeCellCommandTest.ts
@@ -1,10 +1,10 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Css, Dimension, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Css, Dimension, SelectorFilter, SelectorFind, type SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface PartialTableModifiedEvent {
   readonly type: string;

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/ModifyClassesCommandsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/ModifyClassesCommandsTest.ts
@@ -2,9 +2,9 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.models.dom.table.command.ModifyClassesCommandsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteColumnTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteColumnTest.ts
@@ -3,9 +3,9 @@ import { Arr, Fun } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.models.dom.table.command.TableDeleteColumnTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteCommandTest.ts
@@ -2,7 +2,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.models.dom.table.command.TableDeleteCommandTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteRowTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableDeleteRowTest.ts
@@ -3,9 +3,9 @@ import { Arr, Fun } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TableModifiedEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.models.dom.table.command.TableDeleteRowTest', () => {
   let events: Array<EditorEvent<TableModifiedEvent>> = [];

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableSizingModeCommandTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableSizingModeCommandTest.ts
@@ -1,7 +1,7 @@
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 import { tableSizingModeScenarioTest } from '../../../module/table/TableSizingModeCommandUtil';

--- a/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableSizingModeCommandWithColGroupsTest.ts
+++ b/modules/tinymce/src/models/dom/test/ts/browser/table/command/TableSizingModeCommandWithColGroupsTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { tableSizingModeScenarioTest } from '../../../module/table/TableSizingModeCommandUtil';
 

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableSizingModeCommandUtil.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableSizingModeCommandUtil.ts
@@ -2,8 +2,8 @@ import { Arr } from '@ephox/katamari';
 import { TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import { assertTableStructureWithSizes } from './TableTestUtils';
 

--- a/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
+++ b/modules/tinymce/src/models/dom/test/ts/module/table/TableTestUtils.ts
@@ -5,13 +5,13 @@
  Make sure that if making changes to this file, the other files are updated as well
  */
 
-import { ApproxStructure, Assertions, Cursors, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, type Cursors, Mouse, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { Arr } from '@ephox/katamari';
 import { Attribute, Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface Options {
   readonly headerRows: number;

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ButtonSetupDemo.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
-import { Toolbar } from '@ephox/bridge';
+import type { Toolbar } from '@ephox/bridge';
 import { Arr, Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 export default {
   setup: (ed: Editor): void => {

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/FormatSelectDemo.ts
@@ -1,4 +1,4 @@
-import { TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 declare let tinymce: TinyMCE;
 

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/MenuItemDemo.ts
@@ -1,6 +1,6 @@
 import { Fun } from '@ephox/katamari';
 
-import { TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 import * as MockDemo from './MockDemo';
 

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Fun } from '@ephox/katamari';
 
-import { TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 import ButtonSetupDemo from './ButtonSetupDemo';
 

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/SidebarDemo.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { SugarElement } from '@ephox/sugar';
 
-import { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
 
 // import ButtonSetupDemo from './ButtonSetupDemo';
 declare let tinymce: TinyMCE;

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/ToolbarButtonDemo.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Fun } from '@ephox/katamari';
 
-import { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { Editor, TinyMCE } from 'tinymce/core/api/PublicApi';
 
 import * as MockDemo from './MockDemo';
 

--- a/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
+++ b/modules/tinymce/src/themes/silver/demo/ts/demo/TreeDemo.ts
@@ -1,6 +1,6 @@
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 
-import { TinyMCE } from 'tinymce/core/api/PublicApi';
+import type { TinyMCE } from 'tinymce/core/api/PublicApi';
 
 declare let tinymce: TinyMCE;
 

--- a/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Autocompleter.ts
@@ -1,13 +1,13 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory, Highlighting, InlineView, ItemTypes, SystemEvents } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory, Highlighting, InlineView, type ItemTypes, SystemEvents } from '@ephox/alloy';
+import type { InlineContent } from '@ephox/bridge';
 import { Arr, Cell, Id, Optional, Singleton } from '@ephox/katamari';
 import { Attribute, Css, Replication, SelectorFind, SimRange, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { AutocompleteLookupData } from 'tinymce/core/autocomplete/AutocompleteTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { AutocompleteLookupData } from 'tinymce/core/autocomplete/AutocompleteTypes';
 
-import { AutocompleterEditorEvents, AutocompleterUiApi } from './autocomplete/AutocompleteEditorEvents';
-import { UiFactoryBackstageShared } from './backstage/Backstage';
+import { AutocompleterEditorEvents, type AutocompleterUiApi } from './autocomplete/AutocompleteEditorEvents';
+import type { UiFactoryBackstageShared } from './backstage/Backstage';
 import ItemResponse from './ui/menus/item/ItemResponse';
 import { createPartialMenuWithAlloyItems } from './ui/menus/menu/MenuUtils';
 import { createAutocompleteItems, createInlineMenuFrom, FocusMode } from './ui/menus/menu/SingleMenu';

--- a/modules/tinymce/src/themes/silver/main/ts/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Events.ts
@@ -1,10 +1,10 @@
-import { Attachment, Channels, Gui, SystemEvents } from '@ephox/alloy';
+import { Attachment, Channels, type Gui, SystemEvents } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
-import { Compare, DomEvent, EventArgs, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Compare, DomEvent, type EventArgs, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { AfterProgressStateEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { AfterProgressStateEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as ScrollingContext from './modes/ScrollingContext';
 

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -1,13 +1,13 @@
 import {
-  AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, Behaviour, Boxes, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, SimpleSpec, SystemEvents, VerticalDir
+  type AlloyComponent, AlloyEvents, type AlloyParts, type AlloySpec, Behaviour, type Boxes, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, type SimpleSpec, SystemEvents, VerticalDir
 } from '@ephox/alloy';
 import { Arr, Merger, Obj, Optional, Result, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Compare, Css, SugarBody, SugarElement } from '@ephox/sugar';
+import { Compare, Css, SugarBody, type SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
-import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
+import type { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import * as Events from './api/Events';
@@ -17,22 +17,22 @@ import * as Deprecations from './Deprecations';
 import * as DomEvents from './Events';
 import * as Iframe from './modes/Iframe';
 import * as Inline from './modes/Inline';
-import { LazyUiReferences, ReadyUiReferences, SinkAndMothership } from './modes/UiReferences';
+import { LazyUiReferences, type ReadyUiReferences, type SinkAndMothership } from './modes/UiReferences';
 import * as ContextToolbar from './ui/context/ContextToolbar';
 import * as FormatControls from './ui/core/FormatControls';
 import OuterContainer from './ui/general/OuterContainer';
 import * as StaticHeader from './ui/header/StaticHeader';
 import * as StickyHeader from './ui/header/StickyHeader';
 import * as SilverContextMenu from './ui/menus/contextmenu/SilverContextMenu';
-import { MenuRegistry } from './ui/menus/menubar/Integration';
+import type { MenuRegistry } from './ui/menus/menubar/Integration';
 import * as TableSelectorHandles from './ui/selector/TableSelectorHandles';
 import * as Sidebar from './ui/sidebar/Sidebar';
 import * as EditorSize from './ui/sizing/EditorSize';
 import * as Utils from './ui/sizing/Utils';
 import { renderStatusbar } from './ui/statusbar/Statusbar';
 import * as Throbber from './ui/throbber/Throbber';
-import { RenderToolbarConfig } from './ui/toolbar/Integration';
-import { ViewConfig } from './ui/view/ViewTypes';
+import type { RenderToolbarConfig } from './ui/toolbar/Integration';
+import type { ViewConfig } from './ui/view/ViewTypes';
 import * as UiState from './UiState';
 
 export interface ModeRenderInfo {

--- a/modules/tinymce/src/themes/silver/main/ts/Theme.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Theme.ts
@@ -1,9 +1,9 @@
-import { AlloyComponent, Boxes } from '@ephox/alloy';
+import { type AlloyComponent, Boxes } from '@ephox/alloy';
 import { Fun, Singleton } from '@ephox/katamari';
 import { SelectorFind, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import ThemeManager, { RenderResult, Theme } from 'tinymce/core/api/ThemeManager';
+import type Editor from 'tinymce/core/api/Editor';
+import ThemeManager, { type RenderResult, type Theme } from 'tinymce/core/api/ThemeManager';
 
 import NotificationManagerImpl from './alien/NotificationManagerImpl';
 import * as Options from './api/Options';

--- a/modules/tinymce/src/themes/silver/main/ts/UiState.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/UiState.ts
@@ -1,12 +1,12 @@
-import { Behaviour, Channels, Disabling, Receiving } from '@ephox/alloy';
+import { type Behaviour, Channels, Disabling, Receiving } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { DisabledStateChangeEvent, NodeChangeEvent, SwitchModeEvent } from 'tinymce/core/api/EventTypes';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { DisabledStateChangeEvent, NodeChangeEvent, SwitchModeEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Options from './api/Options';
-import { ReadyUiReferences } from './modes/UiReferences';
+import type { ReadyUiReferences } from './modes/UiReferences';
 
 export const UiStateChannel = 'silver.uistate';
 

--- a/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/alien/NotificationManagerImpl.ts
@@ -1,13 +1,13 @@
-import { AlloyComponent, Behaviour, Boxes, Docking, Gui, GuiFactory, InlineView, Keying, MaxHeight, Replacing } from '@ephox/alloy';
-import { Arr, Optional, Singleton, Type } from '@ephox/katamari';
+import { type AlloyComponent, Behaviour, Boxes, Docking, type Gui, GuiFactory, InlineView, Keying, MaxHeight, Replacing } from '@ephox/alloy';
+import { Arr, Optional, type Singleton, Type } from '@ephox/katamari';
 import { Css, SugarElement, SugarLocation, Traverse, Width } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { NotificationApi, NotificationManagerImpl, NotificationSpec } from 'tinymce/core/api/NotificationManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { NotificationApi, NotificationManagerImpl, NotificationSpec } from 'tinymce/core/api/NotificationManager';
 import Delay from 'tinymce/core/api/util/Delay';
 
 import * as Options from '../api/Options';
-import { UiFactoryBackstage } from '../backstage/Backstage';
+import type { UiFactoryBackstage } from '../backstage/Backstage';
 import * as ScrollingContext from '../modes/ScrollingContext';
 import { Notification } from '../ui/general/Notification';
 

--- a/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
@@ -1,5 +1,5 @@
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 const fireSkinLoaded = (editor: Editor): void => {
   editor.dispatch('SkinLoaded');

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -2,10 +2,10 @@ import { Arr, Fun, Obj, Optional, Optionals, Type } from '@ephox/katamari';
 import { SelectorFind, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import Env from 'tinymce/core/api/Env';
-import { EditorOptions, ToolbarGroup } from 'tinymce/core/api/OptionTypes';
+import type { EditorOptions, ToolbarGroup } from 'tinymce/core/api/OptionTypes';
 
 export type ToolbarGroupOption = ToolbarGroup;
 

--- a/modules/tinymce/src/themes/silver/main/ts/autocomplete/AutocompleteEditorEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/autocomplete/AutocompleteEditorEvents.ts
@@ -1,8 +1,8 @@
-import { AlloyComponent, AlloyTriggers, Highlighting, NativeEvents } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { type AlloyComponent, AlloyTriggers, Highlighting, NativeEvents } from '@ephox/alloy';
+import type { Optional } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 export interface AutocompleterUiApi {
   readonly getMenu: () => Optional<AlloyComponent>;

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Anchors.ts
@@ -1,8 +1,8 @@
-import { AlloyComponent, Bubble, HotspotAnchorSpec, Layout, LayoutInset, MaxHeight, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
+import { type AlloyComponent, Bubble, type HotspotAnchorSpec, Layout, LayoutInset, MaxHeight, type NodeAnchorSpec, type SelectionAnchorSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { Height, SimSelection, SugarElement, SugarShadowDom } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { useFixedContainer } from '../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/Backstage.ts
@@ -1,22 +1,22 @@
-import { AlloyComponent, AlloySpec } from '@ephox/alloy';
-import { Dialog, Menu } from '@ephox/bridge';
-import { Cell, Obj, Optional, Result } from '@ephox/katamari';
+import type { AlloyComponent, AlloySpec } from '@ephox/alloy';
+import type { Dialog, Menu } from '@ephox/bridge';
+import { Cell, Obj, Optional, type Result } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import I18n, { TranslatedString, Untranslated } from 'tinymce/core/api/util/I18n';
+import type Editor from 'tinymce/core/api/Editor';
+import I18n, { type TranslatedString, type Untranslated } from 'tinymce/core/api/util/I18n';
 import * as UiFactory from 'tinymce/themes/silver/ui/general/UiFactory';
 
 import * as Options from '../api/Options';
-import { IconProvider } from '../ui/icons/Icons';
+import type { IconProvider } from '../ui/icons/Icons';
 
-import { UiFactoryBackstageAnchors } from './Anchors';
+import type { UiFactoryBackstageAnchors } from './Anchors';
 import * as Anchors from './Anchors';
-import { ColorInputBackstage, UiFactoryBackstageForColorInput } from './ColorInputBackstage';
-import { DialogBackstage, UiFactoryBackstageForDialog } from './DialogBackstage';
-import { HeaderBackstage, UiFactoryBackstageForHeader } from './HeaderBackstage';
-import { init as initStyleFormatBackstage, UiFactoryBackstageForStyleFormats } from './StyleFormatsBackstage';
-import { TooltipsBackstage, TooltipsProvider } from './TooltipsBackstage';
-import { UiFactoryBackstageForUrlInput, UrlInputBackstage } from './UrlInputBackstage';
+import { ColorInputBackstage, type UiFactoryBackstageForColorInput } from './ColorInputBackstage';
+import { DialogBackstage, type UiFactoryBackstageForDialog } from './DialogBackstage';
+import { HeaderBackstage, type UiFactoryBackstageForHeader } from './HeaderBackstage';
+import { init as initStyleFormatBackstage, type UiFactoryBackstageForStyleFormats } from './StyleFormatsBackstage';
+import { TooltipsBackstage, type TooltipsProvider } from './TooltipsBackstage';
+import { type UiFactoryBackstageForUrlInput, UrlInputBackstage } from './UrlInputBackstage';
 
 export interface UiFactoryBackstageProviders {
   readonly icons: IconProvider;

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/ColorInputBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/ColorInputBackstage.ts
@@ -1,6 +1,6 @@
-import { Menu } from '@ephox/bridge';
+import type { Menu } from '@ephox/bridge';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as ColorSwatch from '../ui/core/color/ColorSwatch';
 import * as Options from '../ui/core/color/Options';

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/DialogBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/DialogBackstage.ts
@@ -1,4 +1,4 @@
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/HeaderBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/HeaderBackstage.ts
@@ -1,6 +1,6 @@
 import { Cell } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/StyleFormatsBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/StyleFormatsBackstage.ts
@@ -1,9 +1,9 @@
 import { Cell, Optional } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
+import type Editor from 'tinymce/core/api/Editor';
+import type { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 
-import { FormatItem } from '../ui/core/complex/BespokeSelect';
+import type { FormatItem } from '../ui/core/complex/BespokeSelect';
 import { getStyleFormats } from '../ui/core/complex/StyleFormat';
 import * as FormatRegister from '../ui/core/complex/utils/FormatRegister';
 

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/TooltipsBackstage.ts
@@ -1,5 +1,5 @@
-import { AlloyComponent, GuiFactory, SimpleSpec, TooltippingTypes } from '@ephox/alloy';
-import { Fun, Result } from '@ephox/katamari';
+import { type AlloyComponent, GuiFactory, type SimpleSpec, type TooltippingTypes } from '@ephox/alloy';
+import { Fun, type Result } from '@ephox/katamari';
 
 interface TooltipConfigSpec {
   readonly tooltipText: string;

--- a/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/backstage/UrlInputBackstage.ts
@@ -1,11 +1,11 @@
 import { Fun, Future, Obj, Optional, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { FilePickerCallback, FilePickerValidationCallback } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { FilePickerCallback, FilePickerValidationCallback } from 'tinymce/core/api/OptionTypes';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
-import { LinkTarget, LinkTargets } from '../ui/core/LinkTargets';
+import { type LinkTarget, LinkTargets } from '../ui/core/LinkTargets';
 
 import { addToHistory, getHistory } from './UrlInputHistory';
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -3,21 +3,21 @@ import { Arr, Cell, Throttler, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Css, DomEvent, SugarElement, SugarPosition, SugarShadowDom } from '@ephox/sugar';
 
-import { EventUtilsEvent } from 'tinymce/core/api/dom/EventUtils';
-import Editor from 'tinymce/core/api/Editor';
-import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
+import type { EventUtilsEvent } from 'tinymce/core/api/dom/EventUtils';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 
 import * as Events from '../api/Events';
 import * as Options from '../api/Options';
-import { UiFactoryBackstage } from '../backstage/Backstage';
-import { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
+import type { UiFactoryBackstage } from '../backstage/Backstage';
+import type { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
 import { identifyMenus } from '../ui/menus/menubar/Integration';
 import { iframe as loadIframeSkin } from '../ui/skin/Loader';
 import * as UiState from '../UiState';
 
 import { setToolbar } from './Toolbars';
-import { ReadyUiReferences } from './UiReferences';
+import type { ReadyUiReferences } from './UiReferences';
 
 const detection = PlatformDetection.detect();
 const isiOS12 = detection.os.isiOS() && detection.os.version.major <= 12;

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Inline.ts
@@ -1,15 +1,15 @@
-import { AlloyComponent, Attachment, Boxes, Disabling, Docking } from '@ephox/alloy';
+import { type AlloyComponent, Attachment, Boxes, Disabling, Docking } from '@ephox/alloy';
 import { Cell, Singleton, Throttler } from '@ephox/katamari';
 import { DomEvent, Scroll, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
-import { EditorUiApi } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
+import type { EditorUiApi } from 'tinymce/core/api/ui/Ui';
 
 import * as Events from '../api/Events';
 import * as Options from '../api/Options';
-import { UiFactoryBackstage } from '../backstage/Backstage';
-import { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
+import type { UiFactoryBackstage } from '../backstage/Backstage';
+import type { ModeRenderInfo, RenderArgs, RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
 import { InlineHeader } from '../ui/header/InlineHeader';
 import { identifyMenus } from '../ui/menus/menubar/Integration';
@@ -17,7 +17,7 @@ import { inline as loadInlineSkin } from '../ui/skin/Loader';
 import * as UiState from '../UiState';
 
 import { setToolbar } from './Toolbars';
-import { ReadyUiReferences } from './UiReferences';
+import type { ReadyUiReferences } from './UiReferences';
 
 const getTargetPosAndBounds = (targetElm: SugarElement, isToolbarTop: boolean) => {
   const bounds = Boxes.box(targetElm);

--- a/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/ScrollingContext.ts
@@ -1,8 +1,8 @@
-import { Bounds, Boxes } from '@ephox/alloy';
+import { type Bounds, Boxes } from '@ephox/alloy';
 import { Arr, Optional, Strings } from '@ephox/katamari';
-import { Css, PredicateFilter, SugarElement, SugarNode, SugarShadowDom } from '@ephox/sugar';
+import { Css, PredicateFilter, type SugarElement, SugarNode, SugarShadowDom } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
@@ -1,13 +1,13 @@
 import { Optional, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstage } from '../backstage/Backstage';
-import { RenderUiConfig } from '../Render';
+import type { UiFactoryBackstage } from '../backstage/Backstage';
+import type { RenderUiConfig } from '../Render';
 import OuterContainer from '../ui/general/OuterContainer';
 import { identifyButtons } from '../ui/toolbar/Integration';
 
-import { ReadyUiReferences } from './UiReferences';
+import type { ReadyUiReferences } from './UiReferences';
 
 // Set toolbar(s) depending on if multiple toolbars is configured or not
 const setToolbar = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage): void => {

--- a/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
@@ -1,5 +1,5 @@
-import { AlloyComponent, Gui } from '@ephox/alloy';
-import { Optional, Singleton } from '@ephox/katamari';
+import type { AlloyComponent, Gui } from '@ephox/alloy';
+import { type Optional, Singleton } from '@ephox/katamari';
 import { Compare } from '@ephox/sugar';
 
 export interface SinkAndMothership {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/ComposingConfigs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/ComposingConfigs.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Composing, MementoRecord } from '@ephox/alloy';
+import { type AlloyComponent, Composing, type MementoRecord } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { Traverse } from '@ephox/sugar';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/DialogTabHeight.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/DialogTabHeight.ts
@@ -1,6 +1,6 @@
-import { AlloyComponent, AlloyEvents, EventFormat, Replacing, SystemEvents, TabbarTypes, TabSection } from '@ephox/alloy';
+import { type AlloyComponent, AlloyEvents, type EventFormat, Replacing, SystemEvents, type TabbarTypes, TabSection } from '@ephox/alloy';
 import { Arr, Singleton } from '@ephox/katamari';
-import { Css, Focus, Height, SelectorFind, SugarElement, SugarShadowDom, Traverse, Width } from '@ephox/sugar';
+import { Css, Focus, Height, SelectorFind, type SugarElement, SugarShadowDom, Traverse, Width } from '@ephox/sugar';
 
 import { formResizeEvent } from '../general/FormEvents';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/FieldLabeller.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/FieldLabeller.ts
@@ -1,7 +1,7 @@
-import { AlloySpec, Behaviour, FormField as AlloyFormField, GuiFactory, RawDomSchema, SketchSpec } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { type AlloySpec, Behaviour, FormField as AlloyFormField, GuiFactory, type RawDomSchema, type SketchSpec } from '@ephox/alloy';
+import type { Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 
 type FormFieldSpec = Parameters<typeof AlloyFormField['sketch']>[0];
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/FlatgridAutodetect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/FlatgridAutodetect.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent } from '@ephox/alloy';
+import type { AlloyComponent } from '@ephox/alloy';
 import { Arr, Optional } from '@ephox/katamari';
 import { SelectorFilter } from '@ephox/sugar';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/RepresentingConfigs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/RepresentingConfigs.ts
@@ -1,7 +1,7 @@
-import { AlloyComponent, MementoRecord, Representing } from '@ephox/alloy';
+import { type AlloyComponent, type MementoRecord, Representing } from '@ephox/alloy';
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
-import { Fun, Optional } from '@ephox/katamari';
-import { Html, SugarElement, Value } from '@ephox/sugar';
+import { Fun, type Optional } from '@ephox/katamari';
+import { Html, type SugarElement, Value } from '@ephox/sugar';
 
 type RepresentingBehaviour = ReturnType<typeof Representing['config']>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/SimpleBehaviours.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/SimpleBehaviours.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour } from '@ephox/alloy';
+import { AddEventsBehaviour, type AlloyEvents, Behaviour } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 // Consider moving to alloy once it takes shape.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/alien/UiUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/alien/UiUtils.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent } from '@ephox/alloy';
+import type { AlloyComponent } from '@ephox/alloy';
 import { Css } from '@ephox/sugar';
 
 const forceInitialSize = (comp: AlloyComponent): void => Css.set(comp.element, 'width', Css.get(comp.element, 'width'));

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/ButtonSlices.ts
@@ -1,6 +1,6 @@
-import { Behaviour, GuiFactory, Replacing, SimpleSpec } from '@ephox/alloy';
+import { Behaviour, GuiFactory, Replacing, type SimpleSpec } from '@ephox/alloy';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Icons from '../icons/Icons';
 import { ToolbarButtonClasses } from '../toolbar/button/ButtonClasses';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/button/MenuButton.ts
@@ -1,11 +1,11 @@
-import { AlloyComponent, AlloyTriggers, Disabling, MementoRecord, SketchSpec, Tabstopping } from '@ephox/alloy';
-import { Dialog, Menu, Toolbar } from '@ephox/bridge';
-import { Arr, Cell, Optional } from '@ephox/katamari';
+import { type AlloyComponent, AlloyTriggers, Disabling, type MementoRecord, type SketchSpec, Tabstopping } from '@ephox/alloy';
+import type { Dialog, Menu, Toolbar } from '@ephox/bridge';
+import { Arr, type Cell, type Optional } from '@ephox/katamari';
 import { Attribute, Class, Focus } from '@ephox/sugar';
 
 import { formActionEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderCommonDropdown, updateMenuIcon, updateMenuText, updateTooltiptext } from '../dropdown/CommonDropdown';
 import ItemResponse from '../menus/item/ItemResponse';
 import * as NestedMenus from '../menus/menu/NestedMenus';
@@ -144,9 +144,5 @@ const getFetch = (items: StoredMenuItem[], getButton: () => MementoRecord, backs
   };
 };
 
-export {
-  renderMenuButton,
-  getFetch,
-  StoredMenuItem,
-  StoredMenuButton
-};
+export type { StoredMenuItem, StoredMenuButton };
+export { renderMenuButton, getFetch };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/ColourEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/ColourEvents.ts
@@ -1,5 +1,5 @@
-import { ColourTypes } from '@ephox/acid';
-import { CustomEvent, SliderTypes } from '@ephox/alloy';
+import type { ColourTypes } from '@ephox/acid';
+import type { CustomEvent, SliderTypes } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 const fieldsUpdate = Id.generate('rgb-hex-update');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/ColourPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/ColourPicker.ts
@@ -1,7 +1,7 @@
-import { ColourTypes, HsvColour, RgbaColour, Transformations } from '@ephox/acid';
+import { type ColourTypes, HsvColour, RgbaColour, Transformations } from '@ephox/acid';
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Composing, Keying, Memento, RawDomSchema,
-  SimulatedEvent, Sketcher, Slider
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, Composing, Keying, Memento, type RawDomSchema,
+  type SimulatedEvent, Sketcher, Slider
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Cell, Fun } from '@ephox/katamari';
@@ -10,7 +10,7 @@ import * as ColourEvents from './ColourEvents';
 import * as HueSlider from './components/HueSlider';
 import * as RgbForm from './components/RgbForm';
 import * as SaturationBrightnessPalette from './components/SaturationBrightnessPalette';
-import { Untranslated } from './I18n';
+import type { Untranslated } from './I18n';
 
 export interface ColourPickerDetail extends Sketcher.SingleSketchDetail {
   readonly dom: RawDomSchema;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/components/HueSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/components/HueSlider.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Focusing, SketchSpec, Slider } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, Behaviour, Focusing, type SketchSpec, Slider } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/components/RgbForm.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/components/RgbForm.ts
@@ -1,8 +1,8 @@
-import { ColourTypes, HexColour, RgbaColour } from '@ephox/acid';
+import { type ColourTypes, HexColour, RgbaColour } from '@ephox/acid';
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, EventFormat, Focusing, Form, FormField, FormTypes, GuiFactory, Input, Invalidating,
-  Memento, Representing, SimpleSpec, SimulatedEvent, Sketcher, SketchSpec,
-  Tabstopping, Tooltipping, TooltippingTypes, UiSketcher
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, type EventFormat, Focusing, Form, FormField, type FormTypes, GuiFactory, Input, Invalidating,
+  Memento, Representing, type SimpleSpec, type SimulatedEvent, Sketcher, type SketchSpec,
+  Tabstopping, Tooltipping, type TooltippingTypes, type UiSketcher
 } from '@ephox/alloy';
 import { Cell, Fun, Future, Id, Merger, Optional, Result } from '@ephox/katamari';
 import { Css } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/components/SaturationBrightnessPalette.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/colorpicker/components/SaturationBrightnessPalette.ts
@@ -1,10 +1,10 @@
-import { ColourTypes, HsvColour, RgbaColour } from '@ephox/acid';
-import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Focusing, Sketcher, SketchSpec, Slider, SliderTypes, UiSketcher } from '@ephox/alloy';
+import { type ColourTypes, HsvColour, RgbaColour } from '@ephox/acid';
+import { type AlloyComponent, AlloyTriggers, Behaviour, Composing, Focusing, Sketcher, type SketchSpec, Slider, type SliderTypes, type UiSketcher } from '@ephox/alloy';
 import { Fun, Optional, Type } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
 import * as ColourEvents from '../ColourEvents';
-import { Untranslated } from '../I18n';
+import type { Untranslated } from '../I18n';
 
 // tslint:disable:no-empty-interface
 export interface SaturationBrightnessPaletteDetail extends Sketcher.SingleSketchDetail {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextForm.ts
@@ -1,10 +1,10 @@
-import { AlloyComponent, AlloySpec, AlloyTriggers, Memento, SketchSpec } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
+import { type AlloyComponent, type AlloySpec, AlloyTriggers, Memento, type SketchSpec } from '@ephox/alloy';
+import type { InlineContent } from '@ephox/bridge';
 import { Arr, Fun, Id, Optional, Singleton } from '@ephox/katamari';
 
-import { ToolbarMode } from '../../api/Options';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { renderToolbar, ToolbarGroup } from '../toolbar/CommonToolbar';
+import type { ToolbarMode } from '../../api/Options';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import { renderToolbar, type ToolbarGroup } from '../toolbar/CommonToolbar';
 
 import { generate } from './ContextFormButtons';
 import * as ContextFormSizeInput from './ContextFormSizeInput';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormApi.ts
@@ -1,13 +1,13 @@
 import {
-  AlloyComponent,
+  type AlloyComponent,
   AlloyTriggers,
   Disabling,
   Representing,
   SystemEvents
 } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
-import { Singleton } from '@ephox/katamari';
-import { Focus, SugarElement, Traverse } from '@ephox/sugar';
+import type { InlineContent } from '@ephox/bridge';
+import type { Singleton } from '@ephox/katamari';
+import { Focus, type SugarElement, Traverse } from '@ephox/sugar';
 
 import { backSlideEvent } from './ContextUi';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormButtons.ts
@@ -1,14 +1,14 @@
 import {
-  AlloyComponent, AlloyEvents,
-  Disabling, Memento, MementoRecord,
-  SimpleOrSketchSpec
+  type AlloyComponent, AlloyEvents,
+  Disabling, Memento, type MementoRecord,
+  type SimpleOrSketchSpec
 } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
-import { InlineContent, Toolbar } from '@ephox/bridge';
-import { Arr, Fun, Optional, Singleton } from '@ephox/katamari';
+import { type InlineContent, Toolbar } from '@ephox/bridge';
+import { Arr, Fun, Optional, type Singleton } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { internalToolbarButtonExecute, InternalToolbarButtonExecuteEvent } from '../toolbar/button/ButtonEvents';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import { internalToolbarButtonExecute, type InternalToolbarButtonExecuteEvent } from '../toolbar/button/ButtonEvents';
 import { renderToolbarButtonWith, renderToolbarToggleButtonWith } from '../toolbar/button/ToolbarButtons';
 
 import { getFormApi } from './ContextFormApi';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormGroup.ts
@@ -1,7 +1,7 @@
-import { AlloySpec, Behaviour, Disabling, FormField, SketchSpec } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { type AlloySpec, Behaviour, Disabling, FormField, type SketchSpec } from '@ephox/alloy';
+import type { Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 
 import * as ContextToolbarFocus from './ContextToolbarFocus';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSizeInput.ts
@@ -1,26 +1,26 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents,
   FormCoupledInputs as AlloyFormCoupledInputs,
   FormField as AlloyFormField,
   Input as AlloyInput,
-  AlloySpec, AlloyTriggers, Behaviour, CustomEvent, Disabling,
+  type AlloySpec, AlloyTriggers, Behaviour, type CustomEvent, Disabling,
   Focusing,
   FocusInsideModes,
   GuiFactory,
   Keying,
-  NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
+  NativeEvents, Representing, type SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
-import { Cell, Fun, Id, Optional, Singleton } from '@ephox/katamari';
-import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
+import type { InlineContent } from '@ephox/bridge';
+import { Cell, Fun, Id, Optional, type Singleton } from '@ephox/katamari';
+import { Focus, SelectorFind, type SugarElement } from '@ephox/sugar';
 
 import { formInputEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { onContextFormControlDetached, onControlAttached } from '../controls/Controls';
 import * as Icons from '../icons/Icons';
-import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
+import { formatSize, makeRatioConverter, noSizeConversion, parseSize, type SizeConversion } from '../sizeinput/SizeInputModel';
 
 import * as ContextFormApi from './ContextFormApi';
 interface RatioEvent extends CustomEvent {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormSlider.ts
@@ -1,8 +1,8 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
-import { Cell, Fun, Optional, Singleton, Strings } from '@ephox/katamari';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, type SketchSpec } from '@ephox/alloy';
+import type { InlineContent } from '@ephox/bridge';
+import { Cell, Fun, Optional, type Singleton, Strings } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { onContextFormControlDetached, onControlAttached } from '../controls/Controls';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextFormTextInput.ts
@@ -1,9 +1,9 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, SketchSpec } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
-import { Cell, Fun, Optional, Singleton } from '@ephox/katamari';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, Disabling, FormField, GuiFactory, Input, Keying, NativeEvents, type SketchSpec } from '@ephox/alloy';
+import type { InlineContent } from '@ephox/bridge';
+import { Cell, Fun, Optional, type Singleton } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { onContextFormControlDetached, onControlAttached } from '../controls/Controls';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbar.ts
@@ -1,20 +1,20 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, AnchorSpec, Behaviour, GuiFactory, InlineView, Keying, Positioning
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, type AnchorSpec, Behaviour, GuiFactory, InlineView, Keying, Positioning
 } from '@ephox/alloy';
-import { InlineContent, Toolbar } from '@ephox/bridge';
+import { InlineContent, type Toolbar } from '@ephox/bridge';
 import { Arr, Fun, Id, Merger, Obj, Optional, Optionals, Singleton, Throttler, Thunk } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Class, Compare, Css, Focus, SugarElement } from '@ephox/sugar';
+import { Class, Compare, Css, Focus, type SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { DisabledStateChangeEvent } from 'tinymce/core/api/EventTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { DisabledStateChangeEvent } from 'tinymce/core/api/EventTypes';
 import Delay from 'tinymce/core/api/util/Delay';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 import VK from 'tinymce/core/api/util/VK';
 
 import * as Events from '../../api/Events';
 import { getToolbarMode, ToolbarMode } from '../../api/Options';
-import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { renderToolbar } from '../toolbar/CommonToolbar';
 import { identifyButtons } from '../toolbar/Integration';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
@@ -1,9 +1,9 @@
-import { AnchorSpec, Bounds, Boxes, Bubble, Layout, LayoutInset, MaxHeight, MaxWidth } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { type AnchorSpec, type Bounds, Boxes, Bubble, Layout, LayoutInset, MaxHeight, MaxWidth } from '@ephox/alloy';
+import type { InlineContent } from '@ephox/bridge';
+import type { Optional } from '@ephox/katamari';
 import { Compare, Css, Height, Scroll, SugarElement, Traverse } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { getSelectionBounds, isVerticalOverlap } from './ContextToolbarBounds';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarBounds.ts
@@ -1,12 +1,12 @@
-import { Bounds, Boxes } from '@ephox/alloy';
-import { InlineContent } from '@ephox/bridge';
+import { type Bounds, Boxes } from '@ephox/alloy';
+import type { InlineContent } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 import { Scroll, SelectorFind, SugarBody, SugarElement, SugarNode, Traverse, WindowVisualViewport } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../../api/Options';
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 // The "threshold" here is the amount of overlap. To make the overlap check
 // be more permissive (return true for 'almost' an overlap), use a negative

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarFocus.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarFocus.ts
@@ -1,5 +1,5 @@
 import {
-  AlloyComponent,
+  type AlloyComponent,
   InlineView,
   Keying
 } from '@ephox/alloy';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarLookup.ts
@@ -1,11 +1,11 @@
-import { InlineContent } from '@ephox/bridge';
+import type { InlineContent } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 import { Compare, SugarElement, SugarNode, TransformFind } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { ContextType } from './ContextToolbar';
-import { ScopedToolbars } from './ContextToolbarScopes';
+import type { ContextType } from './ContextToolbar';
+import type { ScopedToolbars } from './ContextToolbarScopes';
 
 export interface LookupResult {
   readonly toolbars: ContextType[];

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarScopes.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarScopes.ts
@@ -1,8 +1,8 @@
 import { StructureSchema } from '@ephox/boulder';
-import { InlineContent, Toolbar } from '@ephox/bridge';
+import { InlineContent, type Toolbar } from '@ephox/bridge';
 import { Arr, Obj } from '@ephox/katamari';
 
-import { ContextSpecType, ContextType } from './ContextToolbar';
+import type { ContextSpecType, ContextType } from './ContextToolbar';
 
 // Divide the defined toolbars into forms, node scopes, and editor scopes
 export interface ScopedToolbars {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextUi.ts
@@ -1,9 +1,9 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, CustomEvent, GuiFactory, InlineView, Keying, NativeEvents,
-  SketchSpec
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, type CustomEvent, GuiFactory, InlineView, Keying, NativeEvents,
+  type SketchSpec
 } from '@ephox/alloy';
 import { Arr, Cell, Id, Optional, Result } from '@ephox/katamari';
-import { Class, Compare, Css, EventArgs, Focus, SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
+import { Class, Compare, Css, type EventArgs, Focus, type SugarElement, SugarShadowDom, Width } from '@ephox/sugar';
 
 import * as ContextToolbarFocus from './ContextToolbarFocus';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/NavigateBackBespokeButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/NavigateBackBespokeButton.ts
@@ -1,11 +1,11 @@
-import { AlloyEvents, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { AlloyEvents, AlloyTriggers, type SketchSpec } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
 import { Toolbar } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import * as ButtonEvents from '../toolbar/button/ButtonEvents';
 import * as ToolbarButtons from '../toolbar/button/ToolbarButtons';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/controls/Controls.ts
@@ -1,5 +1,5 @@
-import { AlloyComponent, AlloyEvents, EventFormat, Representing } from '@ephox/alloy';
-import { Cell, Singleton, Type } from '@ephox/katamari';
+import { type AlloyComponent, AlloyEvents, type EventFormat, Representing } from '@ephox/alloy';
+import { type Cell, type Singleton, Type } from '@ephox/katamari';
 
 export interface GetApiType<T> {
   readonly getApi: (comp: AlloyComponent) => T;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/AlignmentButtons.ts
@@ -1,6 +1,6 @@
 import { Arr } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { onActionExecCommand, onSetupEditableToggle, onSetupStateToggle } from './ControlUtils';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ChoiceControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ChoiceControls.ts
@@ -1,9 +1,9 @@
 import { Arr, Fun, Optional, Optionals, Singleton, Type } from '@ephox/katamari';
 import { Attribute, Dimension, SugarElement, SugarNode, TransformFind } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { ContentLanguage } from 'tinymce/core/api/OptionTypes';
-import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { ContentLanguage } from 'tinymce/core/api/OptionTypes';
+import type { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import * as Options from '../../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ComplexControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ComplexControls.ts
@@ -1,6 +1,6 @@
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 
 import { createAlignMenu } from './complex/AlignBespoke';
 import { createBlocksMenu } from './complex/BlocksBespoke';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/Context.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/Context.ts
@@ -1,6 +1,6 @@
 import { Fun } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const register = (editor: Editor): void => {
   editor.ui.registry.addContext('editable', () => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ControlUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ControlUtils.ts
@@ -1,9 +1,9 @@
 import { Fun, Singleton } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
-import { FormatterFormatItem } from './complex/BespokeSelect';
+import type { FormatterFormatItem } from './complex/BespokeSelect';
 
 const composeUnbinders = (f: VoidFunction, g: VoidFunction): VoidFunction => () => {
   f();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/FormatControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/FormatControls.ts
@@ -1,6 +1,6 @@
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 
 import * as AlignmentButtons from './AlignmentButtons';
 import * as ChoiceControls from './ChoiceControls';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/IndentOutdent.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/IndentOutdent.ts
@@ -1,5 +1,5 @@
-import Editor from 'tinymce/core/api/Editor';
-import { Toolbar } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import { onActionExecCommand, onSetupEditableToggle, onSetupEvent } from './ControlUtils';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/PasteControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/PasteControls.ts
@@ -1,9 +1,9 @@
 import { Cell } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { PastePlainTextToggleEvent } from 'tinymce/core/api/EventTypes';
-import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { PastePlainTextToggleEvent } from 'tinymce/core/api/EventTypes';
+import type { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Options from '../../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/SimpleControls.ts
@@ -1,4 +1,4 @@
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import { onActionExecCommand, onSetupEditableToggle, onSetupStateToggle } from './ControlUtils';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/UndoRedo.ts
@@ -1,5 +1,5 @@
-import Editor from 'tinymce/core/api/Editor';
-import { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
 
 import { onActionExecCommand, onSetupEvent } from './ControlUtils';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/VisualAid.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/VisualAid.ts
@@ -1,5 +1,5 @@
-import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 
 import { onActionExecCommand, onSetupEvent } from './ControlUtils';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorCache.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorCache.ts
@@ -1,6 +1,6 @@
 import { Arr, Obj, Type } from '@ephox/katamari';
 
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 
 export interface ColorCache {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/ColorSwatch.ts
@@ -2,9 +2,9 @@ import { HexColour, RgbaColour } from '@ephox/acid';
 import { Arr, Cell, Fun, Optional, Optionals, Strings } from '@ephox/katamari';
 import { Css, SugarElement, SugarNode, TransformFind } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog, Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog, Menu, Toolbar } from 'tinymce/core/api/ui/Ui';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Events from '../../../api/Events';
 import { composeUnbinders, onSetupEditableToggle } from '../ControlUtils';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/color/Options.ts
@@ -1,9 +1,9 @@
 import { Transformations } from '@ephox/acid';
 import { Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorOptions } from 'tinymce/core/api/OptionTypes';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorOptions } from 'tinymce/core/api/OptionTypes';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 
 const foregroundId = 'forecolor';
 const backgroundId = 'hilitecolor';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/AlignBespoke.ts
@@ -1,14 +1,14 @@
-import { AlloyComponent, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, type SketchSpec } from '@ephox/alloy';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type Editor from 'tinymce/core/api/Editor';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import * as Events from '../../../api/Events';
 import { updateMenuIcon } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
 
-import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, type FormatterFormatItem, type SelectedFormat, type SelectSpec } from './BespokeSelect';
 import { buildBasicStaticDataset } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeNumberInput.ts
@@ -1,18 +1,18 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing, SystemEvents, Tooltipping } from '@ephox/alloy';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, Behaviour, Button, Disabling, Focusing, FocusInsideModes, Input, Keying, Memento, NativeEvents, Representing, SystemEvents, Tooltipping } from '@ephox/alloy';
 import { Arr, Cell, Fun, Id, Optional, Type } from '@ephox/katamari';
 import { Focus, SugarElement, Traverse } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import VK from 'tinymce/core/api/util/VK';
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import * as Options from '../../../api/Options';
 import { renderIconFromPack } from '../../button/ButtonSlices';
 import { onControlAttached, onControlDetached } from '../../controls/Controls';
-import { updateMenuText, UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
+import { updateMenuText, type UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
 import { onSetupEvent } from '../ControlUtils';
 
-import { NumberInputSpec } from './FontSizeBespoke';
+import type { NumberInputSpec } from './FontSizeBespoke';
 
 interface BespokeSelectApi {
   readonly getComponent: () => AlloyComponent;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BespokeSelect.ts
@@ -1,11 +1,11 @@
-import { AlloyComponent, Disabling, SketchSpec, TieredData, Tooltipping } from '@ephox/alloy';
+import { type AlloyComponent, Disabling, type SketchSpec, type TieredData, Tooltipping } from '@ephox/alloy';
 import { Arr, Cell, Fun, Optional } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { renderCommonDropdown } from '../../dropdown/CommonDropdown';
 import ItemResponse from '../../menus/item/ItemResponse';
@@ -13,8 +13,8 @@ import * as NestedMenus from '../../menus/menu/NestedMenus';
 import { ToolbarButtonClasses } from '../../toolbar/button/ButtonClasses';
 import { composeUnbinders, onSetupEvent } from '../ControlUtils';
 
-import { SelectDataset } from './SelectDatasets';
-import { NestedStyleFormat } from './StyleFormat';
+import type { SelectDataset } from './SelectDatasets';
+import type { NestedStyleFormat } from './StyleFormat';
 import * as FormatRegister from './utils/FormatRegister';
 import * as Tooltip from './utils/Tooltip';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/BlocksBespoke.ts
@@ -1,15 +1,15 @@
-import { AlloyComponent, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, type SketchSpec } from '@ephox/alloy';
 import { Fun, Optional } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
+import type Editor from 'tinymce/core/api/Editor';
+import type { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 
 import * as Events from '../../../api/Events';
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
 
-import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, type SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontFamilyBespoke.ts
@@ -1,15 +1,15 @@
-import { AlloyComponent, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, type SketchSpec } from '@ephox/alloy';
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../../../api/Events';
 import * as Options from '../../../api/Options';
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
 
-import { createMenuItems, createSelectButton, FormatterFormatItem, PreviewSpec, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, type FormatterFormatItem, type PreviewSpec, type SelectedFormat, type SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
 import * as Tooltip from './utils/Tooltip';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -1,19 +1,19 @@
-import { AlloyComponent, AlloySpec, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, type AlloySpec, AlloyTriggers, type SketchSpec } from '@ephox/alloy';
 import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
 import { Dimension } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import * as Options from 'tinymce/themes/silver/api/Options';
 
 import * as Events from '../../../api/Events';
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onSetupEditableToggle } from '../ControlUtils';
 
 import { createBespokeNumberInput } from './BespokeNumberInput';
-import { createMenuItems, createSelectButton, FormatterFormatItem, SelectedFormat, SelectSpec } from './BespokeSelect';
+import { createMenuItems, createSelectButton, type FormatterFormatItem, type SelectedFormat, type SelectSpec } from './BespokeSelect';
 import { buildBasicSettingsDataset, Delimiter } from './SelectDatasets';
-import * as FormatRegister from './utils/FormatRegister';
+import type * as FormatRegister from './utils/FormatRegister';
 import * as Tooltip from './utils/Tooltip';
 
 interface Config {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/SelectDatasets.ts
@@ -1,8 +1,8 @@
 import { Arr } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstageForStyleFormats } from '../../../backstage/StyleFormatsBackstage';
+import type { UiFactoryBackstageForStyleFormats } from '../../../backstage/StyleFormatsBackstage';
 
 export interface BasicSelectItem {
   readonly title: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StyleFormat.ts
@@ -1,7 +1,7 @@
 import { Arr, Obj, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import {
+import type Editor from 'tinymce/core/api/Editor';
+import type {
   AllowedFormat, BlockStyleFormat, FormatReference, InlineStyleFormat, NestedFormatting, SelectorStyleFormat, Separator, StyleFormat
 } from 'tinymce/core/api/fmt/StyleFormat';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/StylesBespoke.ts
@@ -1,18 +1,18 @@
-import { AlloyComponent, AlloyTriggers, SketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, type SketchSpec } from '@ephox/alloy';
 import { Arr, Fun, Optional, Strings } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
+import type Editor from 'tinymce/core/api/Editor';
+import type { BlockFormat, InlineFormat } from 'tinymce/core/api/fmt/Format';
 
 import * as Events from '../../../api/Events';
 import * as Options from '../../../api/Options';
-import { UiFactoryBackstage } from '../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../backstage/Backstage';
 import { updateMenuText } from '../../dropdown/CommonDropdown';
 import { onActionToggleFormat, onSetupEditableToggle } from '../ControlUtils';
 
-import { createMenuItems, createSelectButton, SelectSpec } from './BespokeSelect';
-import { AdvancedSelectDataset, BasicSelectItem, SelectDataset } from './SelectDatasets';
-import { getStyleFormats, isFormatReference, isNestedFormat, StyleFormatType } from './StyleFormat';
+import { createMenuItems, createSelectButton, type SelectSpec } from './BespokeSelect';
+import type { AdvancedSelectDataset, BasicSelectItem, SelectDataset } from './SelectDatasets';
+import { getStyleFormats, isFormatReference, isNestedFormat, type StyleFormatType } from './StyleFormat';
 import { findNearest } from './utils/FormatDetection';
 import * as Tooltip from './utils/Tooltip';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatDetection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatDetection.ts
@@ -1,8 +1,8 @@
 import { Arr, Optional } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { BasicSelectItem } from '../SelectDatasets';
+import type { BasicSelectItem } from '../SelectDatasets';
 
 export const findNearest = (editor: Editor, getStyles: () => BasicSelectItem[]): Optional<BasicSelectItem> => {
   const styles = getStyles();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/FormatRegister.ts
@@ -1,10 +1,10 @@
-import { Arr, Fun, Id, Obj, Optional, Type } from '@ephox/katamari';
+import { Arr, Fun, Id, Obj, type Optional, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { FormatReference, Separator, StyleFormat } from 'tinymce/core/api/fmt/StyleFormat';
+import type Editor from 'tinymce/core/api/Editor';
+import type { FormatReference, Separator, StyleFormat } from 'tinymce/core/api/fmt/StyleFormat';
 
-import { FormatItem, FormatterFormatItem, PreviewSpec, SelectedFormat, SubMenuFormatItem } from '../BespokeSelect';
-import { isFormatReference, isNestedFormat, NestedStyleFormat, StyleFormatType } from '../StyleFormat';
+import type { FormatItem, FormatterFormatItem, PreviewSpec, SelectedFormat, SubMenuFormatItem } from '../BespokeSelect';
+import { isFormatReference, isNestedFormat, type NestedStyleFormat, type StyleFormatType } from '../StyleFormat';
 
 export type IsSelectedForType = (format: string) => (currentValue: Optional<SelectedFormat>) => boolean;
 export type GetPreviewForType = (format: string) => () => Optional<PreviewSpec>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/utils/Tooltip.ts
@@ -1,6 +1,6 @@
 import { Strings } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const makeTooltipText = (editor: Editor, labelWithPlaceholder: string, value: string): string =>
   Strings.isEmpty(value) ? editor.translate(labelWithPlaceholder) : editor.translate([ labelWithPlaceholder, editor.translate(value) ]);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/AlertDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/AlertDialog.ts
@@ -1,9 +1,9 @@
 import { AlloyEvents, Focusing, GuiFactory, Memento, ModalDialog } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderFooterButton } from '../general/Button';
-import { formCancelEvent, FormCancelEvent } from '../general/FormEvents';
+import { formCancelEvent, type FormCancelEvent } from '../general/FormEvents';
 
 import * as Dialogs from './Dialogs';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Bar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Bar.ts
@@ -1,8 +1,8 @@
-import { SimpleSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { SimpleSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 type BarSpec = Omit<Dialog.Bar, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/BodyPanel.ts
@@ -1,8 +1,8 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Form as AlloyForm, Keying, Memento, NativeEvents, SimpleSpec, AlloyComponent } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Form as AlloyForm, Keying, Memento, NativeEvents, type SimpleSpec, type AlloyComponent } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as FormValues from '../general/FormValues';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Collection.ts
@@ -1,17 +1,17 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Bubble, Disabling, EventFormat, FormField as AlloyFormField, Keying,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Bubble, Disabling, type EventFormat, FormField as AlloyFormField, Keying,
   Layout,
-  NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, Tabstopping, Tooltipping
+  NativeEvents, Replacing, Representing, type SimulatedEvent, type SketchSpec, SystemEvents, Tabstopping, Tooltipping
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
-import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Attribute, Class, EventArgs, Focus, Html, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
+import type { Dialog } from '@ephox/bridge';
+import { Arr, Fun, type Optional } from '@ephox/katamari';
+import { Attribute, Class, type EventArgs, Focus, Html, SelectorFilter, SelectorFind, type SugarElement } from '@ephox/sugar';
 
 import Entities from 'tinymce/core/api/html/Entities';
 import I18n from 'tinymce/core/api/util/I18n';
 import { renderFormFieldWith, renderLabel } from 'tinymce/themes/silver/ui/alien/FieldLabeller';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { detectSize } from '../alien/FlatgridAutodetect';
 import { formActionEvent, formResizeEvent } from '../general/FormEvents';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorInput.ts
@@ -1,13 +1,13 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Composing, CustomEvent, Disabling, Focusing, FormField, Input,
-  Invalidating, Layout, Memento, Representing, SimpleSpec, Tabstopping
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, Composing, type CustomEvent, Disabling, Focusing, FormField, Input,
+  Invalidating, Layout, Memento, Representing, type SimpleSpec, Tabstopping
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
-import { Fun, Future, Id, Optional, Result } from '@ephox/katamari';
+import type { Dialog } from '@ephox/bridge';
+import { Fun, Future, Id, type Optional, Result } from '@ephox/katamari';
 import { Css, SugarElement, Traverse } from '@ephox/sugar';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
-import { UiFactoryBackstageForColorInput } from '../../backstage/ColorInputBackstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageForColorInput } from '../../backstage/ColorInputBackstage';
 import * as UiState from '../../UiState';
 import { renderLabel } from '../alien/FieldLabeller';
 import * as ColorCache from '../core/color/ColorCache';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ColorPicker.ts
@@ -1,10 +1,10 @@
-import { AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, SimpleSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { type AlloyComponent, AlloyTriggers, Behaviour, Composing, Form, Memento, NativeEvents, Representing, type SimpleSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Optional, Strings, Type } from '@ephox/katamari';
 
-import { Untranslated } from 'tinymce/core/api/util/I18n';
+import type { Untranslated } from 'tinymce/core/api/util/I18n';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as ColourPicker from '../colorpicker/ColourPicker';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ConfirmDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ConfirmDialog.ts
@@ -1,9 +1,9 @@
 import { AlloyEvents, Focusing, GuiFactory, Memento, ModalDialog } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderFooterButton } from '../general/Button';
-import { formCancelEvent, FormCancelEvent, formSubmitEvent, FormSubmitEvent } from '../general/FormEvents';
+import { formCancelEvent, type FormCancelEvent, formSubmitEvent, type FormSubmitEvent } from '../general/FormEvents';
 
 import * as Dialogs from './Dialogs';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/CustomEditor.ts
@@ -1,5 +1,5 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, Focusing, Memento, SimpleSpec, Tabstopping } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, Focusing, Memento, type SimpleSpec, Tabstopping } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Obj, Optional, Singleton } from '@ephox/katamari';
 
 import Resource from 'tinymce/core/api/Resource';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dialogs.ts
@@ -1,13 +1,13 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, Behaviour, Blocking, Button, Container, DomFactory, Focusing, Keying, ModalDialog,
-  NativeEvents, SketchSpec, SystemEvents, Tabstopping
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloyParts, type AlloySpec, Behaviour, Blocking, Button, Container, DomFactory, Focusing, Keying, ModalDialog,
+  NativeEvents, type SketchSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
-import { Fun, Optional, Result } from '@ephox/katamari';
+import { Fun, Optional, type Result } from '@ephox/katamari';
 import { Class, SugarBody } from '@ephox/sugar';
 
 import Env from 'tinymce/core/api/Env';
 
-import * as Backstage from '../../backstage/Backstage';
+import type * as Backstage from '../../backstage/Backstage';
 import * as HtmlSanitizer from '../core/HtmlSanitizer';
 import * as NavigableObject from '../general/NavigableObject';
 import * as DialogChannels from '../window/DialogChannels';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Dropzone.ts
@@ -1,16 +1,16 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling,
-  FormField as AlloyFormField, GuiFactory, Memento, NativeEvents, Representing, SimpleSpec, SimulatedEvent,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Button, Disabling,
+  FormField as AlloyFormField, GuiFactory, Memento, NativeEvents, Representing, type SimpleSpec, type SimulatedEvent,
   SystemEvents, Tabstopping, Toggling,
-  CustomEvent
+  type CustomEvent
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
-import { Arr, Id, Optional, Strings } from '@ephox/katamari';
-import { EventArgs } from '@ephox/sugar';
+import type { Dialog } from '@ephox/bridge';
+import { Arr, Id, type Optional, Strings } from '@ephox/katamari';
+import type { EventArgs } from '@ephox/sugar';
 
 import Tools from 'tinymce/core/api/util/Tools';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { DisablingConfigs } from '../alien/DisablingConfigs';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Grid.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Grid.ts
@@ -1,8 +1,8 @@
-import { SimpleSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { SimpleSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 type GridSpec = Omit<Dialog.Grid, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -1,10 +1,10 @@
-import { AlloyComponent, Behaviour, Focusing, FormField, Receiving, SketchSpec, Tabstopping } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { type AlloyComponent, Behaviour, Focusing, FormField, Receiving, type SketchSpec, Tabstopping } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Cell, Fun, Optional, Optionals, Throttler, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute, Class, Compare, SugarElement, Traverse } from '@ephox/sugar';
+import { Attribute, Class, Compare, type SugarElement, Traverse } from '@ephox/sugar';
 
-import * as Backstage from '../../backstage/Backstage';
+import type * as Backstage from '../../backstage/Backstage';
 import * as FieldLabeller from '../alien/FieldLabeller';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as NavigableObject from '../general/NavigableObject';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ImagePreview.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ImagePreview.ts
@@ -1,7 +1,7 @@
-import { AlloyComponent, Behaviour, Memento, SimpleSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { type AlloyComponent, Behaviour, Memento, type SimpleSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Cell, Optional, Type } from '@ephox/katamari';
-import { Attribute, Class, Css, Height, Ready, SugarElement, Width } from '@ephox/sugar';
+import { Attribute, Class, Css, Height, Ready, type SugarElement, Width } from '@ephox/sugar';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Label.ts
@@ -1,9 +1,9 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, GuiFactory, Keying, Memento, Replacing, SimpleSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, GuiFactory, Keying, Memento, Replacing, type SimpleSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Id, Optional } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/ListBox.ts
@@ -1,12 +1,12 @@
 import {
-  AlloyComponent, AlloySpec, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, Representing, SimpleSpec, SketchSpec,
+  type AlloyComponent, type AlloySpec, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, Representing, type SimpleSpec, type SketchSpec,
   Tabstopping
 } from '@ephox/alloy';
-import { Dialog, Menu as BridgeMenu } from '@ephox/bridge';
+import type { Dialog, Menu as BridgeMenu } from '@ephox/bridge';
 import { Arr, Fun, Obj, Optional, Optionals } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderLabel } from '../alien/FieldLabeller';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { renderCommonDropdown, updateMenuText } from '../dropdown/CommonDropdown';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Panel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Panel.ts
@@ -1,8 +1,8 @@
-import { SimpleSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { SimpleSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 
 export type PanelSpec = Omit<Dialog.Panel, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SelectBox.ts
@@ -1,11 +1,11 @@
 import {
-  AddEventsBehaviour, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Disabling, FormField as AlloyFormField, HtmlSelect as AlloyHtmlSelect,
-  NativeEvents, SimpleSpec, SketchSpec, Tabstopping
+  AddEventsBehaviour, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, Disabling, FormField as AlloyFormField, HtmlSelect as AlloyHtmlSelect,
+  NativeEvents, type SimpleSpec, type SketchSpec, Tabstopping
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderLabel } from 'tinymce/themes/silver/ui/alien/FieldLabeller';
 import * as Icons from 'tinymce/themes/silver/ui/icons/Icons';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/SizeInput.ts
@@ -1,21 +1,21 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents,
   FormCoupledInputs as AlloyFormCoupledInputs,
   FormField as AlloyFormField,
   Input as AlloyInput,
-  AlloySpec, AlloyTriggers, Behaviour, CustomEvent, Disabling,
+  type AlloySpec, AlloyTriggers, Behaviour, type CustomEvent, Disabling,
   GuiFactory,
-  NativeEvents, Representing, SketchSpec, Tabstopping, Tooltipping
+  NativeEvents, Representing, type SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Id, Unicode } from '@ephox/katamari';
 
 import { formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import * as Icons from '../icons/Icons';
-import { formatSize, makeRatioConverter, noSizeConversion, parseSize, SizeConversion } from '../sizeinput/SizeInputModel';
+import { formatSize, makeRatioConverter, noSizeConversion, parseSize, type SizeConversion } from '../sizeinput/SizeInputModel';
 
 interface RatioEvent extends CustomEvent {
   readonly isField1: boolean;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Slider.ts
@@ -1,8 +1,8 @@
-import { AlloyTriggers, Behaviour, Focusing, GuiFactory, SimpleSpec, Slider } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
-import { Fun, Optional } from '@ephox/katamari';
+import { AlloyTriggers, Behaviour, Focusing, GuiFactory, type SimpleSpec, Slider } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
+import { Fun, type Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { formChangeEvent } from '../general/FormEvents';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TabPanel.ts
@@ -1,15 +1,15 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Composing, Form as AlloyForm, GuiFactory, Keying, Receiving, Representing,
-  SketchSpec, Tabbar as AlloyTabbar, TabbarTypes, TabSection as AlloyTabSection, Tabstopping
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Composing, Form as AlloyForm, GuiFactory, Keying, Receiving, Representing,
+  type SketchSpec, Tabbar as AlloyTabbar, type TabbarTypes, TabSection as AlloyTabSection, Tabstopping
 } from '@ephox/alloy';
 import { Objects } from '@ephox/boulder';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Cell, Fun, Merger, Optional } from '@ephox/katamari';
 
 import { toValidValues } from 'tinymce/themes/silver/ui/general/FormValues';
 import { interpretInForm } from 'tinymce/themes/silver/ui/general/UiFactory';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import * as DialogTabHeight from '../alien/DialogTabHeight';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { formTabChangeEvent } from '../general/FormEvents';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Table.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Table.ts
@@ -1,8 +1,8 @@
-import { Behaviour, Focusing, SimpleSpec, Tabstopping } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { Behaviour, Focusing, type SimpleSpec, Tabstopping } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 
 type TableSpec = Omit<Dialog.Table, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/TextField.ts
@@ -1,11 +1,11 @@
 import {
-  AddEventsBehaviour, AlloyEvents, FormField as AlloyFormField, Input as AlloyInput, AlloyTriggers, Behaviour, Disabling, Invalidating, Keying, NativeEvents, Representing, SketchSpec, SystemEvents, Tabstopping
+  AddEventsBehaviour, AlloyEvents, FormField as AlloyFormField, Input as AlloyInput, AlloyTriggers, Behaviour, Disabling, Invalidating, Keying, NativeEvents, Representing, type SketchSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Fun, Future, Optional, Result } from '@ephox/katamari';
 import { Traverse } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { renderFormFieldWith, renderLabel } from '../alien/FieldLabeller';
 import { formChangeEvent, formSubmitEvent } from '../general/FormEvents';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/Tree.ts
@@ -1,29 +1,29 @@
 import {
   AddEventsBehaviour,
   Button as AlloyButton,
-  AlloyComponent,
+  type AlloyComponent,
   AlloyEvents,
   AlloyTriggers,
   Behaviour,
-  CustomEvent,
-  EventFormat,
+  type CustomEvent,
+  type EventFormat,
   Focusing,
   GuiFactory,
   Keying,
   NativeEvents,
   Receiving,
   Replacing,
-  SimpleSpec,
+  type SimpleSpec,
   Sliding,
   Tabstopping,
   Toggling,
   Tooltipping
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Cell, Fun, Id, Optional } from '@ephox/katamari';
-import { EventArgs, SelectorFind } from '@ephox/sugar';
+import { type EventArgs, SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderMenuButton } from '../button/MenuButton';
 import * as Icons from '../icons/Icons';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/UrlInput.ts
@@ -1,13 +1,13 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Composing, CustomEvent, Disabling, FormField as AlloyFormField,
-  Invalidating, Memento, NativeEvents, Representing, SketchSpec, SimpleSpec, SystemEvents, Tabstopping, Typeahead as AlloyTypeahead
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, Composing, type CustomEvent, Disabling, FormField as AlloyFormField,
+  Invalidating, Memento, NativeEvents, Representing, type SketchSpec, type SimpleSpec, SystemEvents, Tabstopping, Typeahead as AlloyTypeahead
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Fun, Future, FutureResult, Id, Optional, Result } from '@ephox/katamari';
 import { Attribute, Traverse, Value } from '@ephox/sugar';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
-import { UiFactoryBackstageForUrlInput } from '../../backstage/UrlInputBackstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstageForUrlInput } from '../../backstage/UrlInputBackstage';
 import * as UiState from '../../UiState';
 import { renderFormFieldDom, renderLabel } from '../alien/FieldLabeller';
 import { renderButton } from '../general/Button';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/WindowManager.ts
@@ -1,17 +1,17 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Boxes, Channels, Docking, GuiFactory, HotspotAnchorSpec, InlineView, Keying,
-  MakeshiftAnchorSpec, ModalDialog, NodeAnchorSpec, SelectionAnchorSpec, SystemEvents
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Boxes, Channels, Docking, GuiFactory, type HotspotAnchorSpec, InlineView, Keying,
+  type MakeshiftAnchorSpec, ModalDialog, type NodeAnchorSpec, type SelectionAnchorSpec, SystemEvents
 } from '@ephox/alloy';
-import { StructureProcessor, StructureSchema } from '@ephox/boulder';
-import { Dialog, DialogManager } from '@ephox/bridge';
+import { type StructureProcessor, StructureSchema } from '@ephox/boulder';
+import { type Dialog, DialogManager } from '@ephox/bridge';
 import { Optional, Singleton, Type } from '@ephox/katamari';
 import { SelectorExists, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { WindowManagerImpl, WindowParams } from 'tinymce/core/api/WindowManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { WindowManagerImpl, WindowParams } from 'tinymce/core/api/WindowManager';
 
 import * as Options from '../../api/Options';
-import { UiFactoryBackstagePair } from '../../backstage/Backstage';
+import type { UiFactoryBackstagePair } from '../../backstage/Backstage';
 import * as ScrollingContext from '../../modes/ScrollingContext';
 import { formCancelEvent } from '../general/FormEvents';
 import { renderDialog } from '../window/SilverDialog';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dropdown/CommonDropdown.ts
@@ -1,27 +1,27 @@
 import {
-  AddEventsBehaviour, AlloyComponent,
+  AddEventsBehaviour, type AlloyComponent,
   Dropdown as AlloyDropdown,
-  AlloyEvents, AlloyTriggers, Behaviour, CustomEvent,
+  AlloyEvents, AlloyTriggers, Behaviour, type CustomEvent,
   Focusing, GuiFactory, Highlighting,
-  Keying, MaxHeight, Memento, NativeEvents, Replacing, Representing, SimulatedEvent, SketchSpec, SystemEvents, TieredData, Tooltipping, Unselecting
+  Keying, MaxHeight, Memento, NativeEvents, Replacing, Representing, type SimulatedEvent, type SketchSpec, SystemEvents, type TieredData, Tooltipping, Unselecting
 } from '@ephox/alloy';
-import { Toolbar } from '@ephox/bridge';
+import type { Toolbar } from '@ephox/bridge';
 import { Arr, Cell, Fun, Future, Id, Merger, Optional, Optionals, Type } from '@ephox/katamari';
-import { Attribute, EventArgs, SugarElement } from '@ephox/sugar';
+import { Attribute, type EventArgs, type SugarElement } from '@ephox/sugar';
 
 import { toolbarButtonEventOrder } from 'tinymce/themes/silver/ui/toolbar/button/ButtonEvents';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 import * as UiUtils from '../alien/UiUtils';
 import { renderLabel, renderReplaceableIconFromPack } from '../button/ButtonSlices';
-import { onControlAttached, onControlDetached, OnDestroy } from '../controls/Controls';
+import { onControlAttached, onControlDetached, type OnDestroy } from '../controls/Controls';
 import * as Icons from '../icons/Icons';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
 import * as MenuParts from '../menus/menu/MenuParts';
 import { focusSearchField, handleRedirectToMenuItem, handleRefetchTrigger, updateAriaOnDehighlight, updateAriaOnHighlight } from '../menus/menu/searchable/SearchableMenu';
-import { RedirectMenuItemInteractionEvent, redirectMenuItemInteractionEvent, RefetchTriggerEvent, refetchTriggerEvent } from '../menus/menu/searchable/SearchableMenuEvents';
+import { type RedirectMenuItemInteractionEvent, redirectMenuItemInteractionEvent, type RefetchTriggerEvent, refetchTriggerEvent } from '../menus/menu/searchable/SearchableMenuEvents';
 
 export const updateMenuText = Id.generate('update-menu-text');
 export const updateMenuIcon = Id.generate('update-menu-icon');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/AlertBanner.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/AlertBanner.ts
@@ -1,9 +1,9 @@
-import { AlloyTriggers, Behaviour, Button, Container, SketchSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { AlloyTriggers, Behaviour, Button, Container, type SketchSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 
 import { formActionEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Icons from '../icons/Icons';
 
 type AlertBannerSpec = Omit<Dialog.AlertBanner, 'type'>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Button.ts
@@ -1,23 +1,23 @@
 import {
   AddEventsBehaviour,
   Button as AlloyButton,
-  AlloyComponent, AlloyEvents,
+  type AlloyComponent, AlloyEvents,
   FormField as AlloyFormField,
-  AlloySpec, AlloyTriggers, Behaviour,
+  type AlloySpec, AlloyTriggers, Behaviour,
   GuiFactory, Memento,
-  RawDomSchema, Replacing, SimpleOrSketchSpec, SketchSpec, Tabstopping, Tooltipping
+  type RawDomSchema, Replacing, type SimpleOrSketchSpec, type SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
-import { Dialog, Toolbar } from '@ephox/bridge';
+import type { Dialog, Toolbar } from '@ephox/bridge';
 import { Fun, Merger, Optional, Type } from '@ephox/katamari';
 
-import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 import { renderFormField } from '../alien/FieldLabeller';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import { renderIconFromPack, renderReplaceableIconFromPack } from '../button/ButtonSlices';
-import { getFetch, renderMenuButton, StoredMenuButton } from '../button/MenuButton';
+import { getFetch, renderMenuButton, type StoredMenuButton } from '../button/MenuButton';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
 import { ToolbarButtonClasses, ViewButtonClasses } from '../toolbar/button/ButtonClasses';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Checkbox.ts
@@ -1,12 +1,12 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, GuiFactory, Keying, Memento,
-  NativeEvents, SimpleSpec, Tabstopping, Unselecting
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Disabling, Focusing, FormField as AlloyFormField, GuiFactory, Keying, Memento,
+  NativeEvents, type SimpleSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 import { Checked, Class, Traverse } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/FormEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/FormEvents.ts
@@ -1,4 +1,4 @@
-import { CustomEvent } from '@ephox/alloy';
+import type { CustomEvent } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 export interface FormChangeEvent<T> extends CustomEvent {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/FormValues.ts
@@ -1,4 +1,4 @@
-import { Obj, Optional, Result } from '@ephox/katamari';
+import { Obj, type Optional, Result } from '@ephox/katamari';
 
 const toValidValues = <T>(values: Record<string, Optional<T>>): Result<Record<string, T>, string[]> => {
   const errors: string[] = [];

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/HtmlPanel.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/HtmlPanel.ts
@@ -1,9 +1,9 @@
-import { AlloyComponent, Behaviour, Bubble, Container as AlloyContainer, Focusing, Layout, SketchSpec, Tabstopping, Tooltipping, AddEventsBehaviour, AlloyEvents } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { type AlloyComponent, Behaviour, Bubble, Container as AlloyContainer, Focusing, Layout, type SketchSpec, Tabstopping, Tooltipping, AddEventsBehaviour, AlloyEvents } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
 import { Attribute, Focus, SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 
 type HtmlPanelSpec = Omit<Dialog.HtmlPanel, 'type'>;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/NavigableObject.ts
@@ -1,6 +1,6 @@
-import { AlloyComponent, AlloySpec, AlloyTriggers, Behaviour, Focusing, NativeEvents, SimpleSpec, Tabstopping } from '@ephox/alloy';
-import { Fun, Id, Optional } from '@ephox/katamari';
-import { Class, SelectorExists, SugarElement } from '@ephox/sugar';
+import { type AlloyComponent, type AlloySpec, AlloyTriggers, Behaviour, Focusing, NativeEvents, type SimpleSpec, Tabstopping } from '@ephox/alloy';
+import { Fun, Id, type Optional } from '@ephox/katamari';
+import { Class, SelectorExists, type SugarElement } from '@ephox/sugar';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/Notification.ts
@@ -1,13 +1,13 @@
 import {
-  AlloyComponent, AlloySpec, Behaviour, Button, DomFactory, Focusing, GuiFactory, Keying, Memento, Replacing, Sketcher,
+  type AlloyComponent, type AlloySpec, Behaviour, Button, DomFactory, Focusing, GuiFactory, Keying, Memento, Replacing, Sketcher,
   Tabstopping,
   Tooltipping,
-  UiSketcher
+  type UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
 import { Arr, Id, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as HtmlSanitizer from '../core/HtmlSanitizer';
 import * as Icons from '../icons/Icons';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -1,21 +1,21 @@
 import {
-  AlloyComponent, AlloySpec, Behaviour, Composite, CustomList, Keying, RawDomSchema, Sketcher, SketchSpec, Toolbar, UiSketcher
+  type AlloyComponent, type AlloySpec, Behaviour, Composite, CustomList, Keying, type RawDomSchema, Sketcher, type SketchSpec, Toolbar, type UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
-import { Arr, Id, Optional, Optionals, Result } from '@ephox/katamari';
-import { Attribute, Css, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Arr, Id, Optional, Optionals, type Result } from '@ephox/katamari';
+import { Attribute, Css, SelectorFind, type SugarElement } from '@ephox/sugar';
 
 import { ToolbarMode } from '../../api/Options';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
-import { HeaderSpec, renderHeader } from '../header/CommonHeader';
-import SilverMenubar, { MenubarItemSpec, SilverMenubarSpec } from '../menus/menubar/SilverMenubar';
-import { PromotionSpec, renderPromotion } from '../promotion/Promotion';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import { type HeaderSpec, renderHeader } from '../header/CommonHeader';
+import SilverMenubar, { type MenubarItemSpec, type SilverMenubarSpec } from '../menus/menubar/SilverMenubar';
+import { type PromotionSpec, renderPromotion } from '../promotion/Promotion';
 import * as Sidebar from '../sidebar/Sidebar';
 import * as Throbber from '../throbber/Throbber';
 import {
-  MoreDrawerData, MoreDrawerToolbarSpec, renderFloatingMoreToolbar, renderSlidingMoreToolbar, renderToolbar, renderToolbarGroup, ToolbarGroup
+  type MoreDrawerData, type MoreDrawerToolbarSpec, renderFloatingMoreToolbar, renderSlidingMoreToolbar, renderToolbar, renderToolbarGroup, type ToolbarGroup
 } from '../toolbar/CommonToolbar';
-import * as ViewTypes from '../view/ViewTypes';
+import type * as ViewTypes from '../view/ViewTypes';
 import ViewWrapper from '../view/ViewWrapper';
 
 export interface OuterContainerSketchSpec extends Sketcher.CompositeSketchSpec {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/PanelButton.ts
@@ -1,10 +1,10 @@
 import {
-  AlloyComponent, AlloySpec, Behaviour, Dropdown as AlloyDropdown, Layouts, RawDomSchema, SketchSpec, Tabstopping, Unselecting
+  type AlloyComponent, type AlloySpec, Behaviour, Dropdown as AlloyDropdown, type Layouts, type RawDomSchema, type SketchSpec, Tabstopping, Unselecting
 } from '@ephox/alloy';
-import { Menu, Toolbar } from '@ephox/bridge';
+import type { Menu, Toolbar } from '@ephox/bridge';
 import { Fun, Future, Id, Merger, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 import ItemResponse from '../menus/item/ItemResponse';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/UiFactory.ts
@@ -1,8 +1,8 @@
-import { AlloyComponent, AlloyParts, AlloySpec, FormTypes, SimpleOrSketchSpec } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge/';
+import type { AlloyComponent, AlloyParts, AlloySpec, FormTypes, SimpleOrSketchSpec } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge/';
 import { Fun, Merger, Obj, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderBar } from '../dialog/Bar';
 import { renderCollection } from '../dialog/Collection';
 import { renderColorInput } from '../dialog/ColorInput';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/CommonHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/CommonHeader.ts
@@ -1,8 +1,8 @@
-import { AlloySpec, Behaviour, SimpleSpec } from '@ephox/alloy';
+import { type AlloySpec, Behaviour, type SimpleSpec } from '@ephox/alloy';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 import * as StaticHeader from './StaticHeader';
 import * as StickyHeader from './StickyHeader';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/InlineHeader.ts
@@ -1,13 +1,13 @@
-import { AlloyComponent, Boxes, Channels, Docking, OffsetOrigin, VerticalDir } from '@ephox/alloy';
-import { Arr, Cell, Fun, Optional, Optionals, Singleton } from '@ephox/katamari';
-import { Attribute, Compare, Css, Height, Scroll, SugarBody, SugarElement, SugarLocation, SugarPosition, Traverse, Width, WindowVisualViewport } from '@ephox/sugar';
+import { type AlloyComponent, Boxes, Channels, Docking, OffsetOrigin, VerticalDir } from '@ephox/alloy';
+import { Arr, Cell, Fun, Optional, Optionals, type Singleton } from '@ephox/katamari';
+import { Attribute, Compare, Css, Height, Scroll, SugarBody, type SugarElement, SugarLocation, type SugarPosition, Traverse, Width, WindowVisualViewport } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../../api/Options';
-import { UiFactoryBackstage } from '../../backstage/Backstage';
-import { ReadyUiReferences } from '../../modes/UiReferences';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { ReadyUiReferences } from '../../modes/UiReferences';
 import OuterContainer from '../general/OuterContainer';
 import * as EditorSize from '../sizing/EditorSize';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/header/StickyHeader.ts
@@ -1,12 +1,12 @@
-import { AlloyComponent, Behaviour, Boxes, Channels, Docking, DockingTypes, Focusing, Receiving } from '@ephox/alloy';
-import { Arr, Optional, Result, Singleton } from '@ephox/katamari';
+import { type AlloyComponent, type Behaviour, Boxes, Channels, Docking, type DockingTypes, Focusing, Receiving } from '@ephox/alloy';
+import { Arr, Optional, type Result, Singleton } from '@ephox/katamari';
 import { Class, Classes, Compare, Css, Focus, Height, Scroll, SugarElement, SugarLocation, Traverse, Visibility, Width } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { ScrollIntoViewEvent } from 'tinymce/core/api/EventTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { ScrollIntoViewEvent } from 'tinymce/core/api/EventTypes';
 
 import * as Options from '../../api/Options';
-import { UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageShared } from '../../backstage/Backstage';
 import * as EditorChannels from '../../Channels';
 import * as ScrollingContext from '../../modes/ScrollingContext';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/icons/Icons.ts
@@ -1,4 +1,4 @@
-import { AddEventsBehaviour, AlloyEvents, Behaviour, SimpleSpec } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, Behaviour, type SimpleSpec } from '@ephox/alloy';
 import { Arr, Obj, Optional, Strings } from '@ephox/katamari';
 import { Attribute, SelectorFind } from '@ephox/sugar';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/image/Images.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/image/Images.ts
@@ -1,5 +1,5 @@
-import { AddEventsBehaviour, AlloyEvents, AlloySpec, Behaviour, SimpleSpec } from '@ephox/alloy';
-import { Optional } from '@ephox/katamari';
+import { AddEventsBehaviour, AlloyEvents, type AlloySpec, Behaviour, type SimpleSpec } from '@ephox/alloy';
+import type { Optional } from '@ephox/katamari';
 import { Class, Insert, Ready, Remove, SelectorFind, SugarElement } from '@ephox/sugar';
 
 export type ImageProvider = () => Record<string, string>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Coords.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Coords.ts
@@ -1,9 +1,9 @@
-import { AnchorSpec, MakeshiftAnchorSpec, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
+import type { AnchorSpec, MakeshiftAnchorSpec, NodeAnchorSpec, SelectionAnchorSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 export type AnchorType = 'node' | 'selection' | 'point';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/Options.ts
@@ -1,7 +1,7 @@
 import { Arr, Obj, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorOptions } from 'tinymce/core/api/OptionTypes';
 
 const patchPipeConfig = (config: string[] | string): string[] =>
   Type.isString(config) ? config.split(/[ ,]/) : config;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/SilverContextMenu.ts
@@ -1,14 +1,14 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, GuiFactory, InlineView, Sandboxing, SystemEvents } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
-import { Arr, Fun, Obj, Result, Strings, Type } from '@ephox/katamari';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, GuiFactory, InlineView, Sandboxing, SystemEvents } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
+import { Arr, Fun, Obj, type Result, Strings, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SelectorExists, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
-import { AnchorType } from './Coords';
+import type { AnchorType } from './Coords';
 import * as Options from './Options';
 import * as DesktopContextMenu from './platform/DesktopContextMenu';
 import * as MobileContextMenu from './platform/MobileContextMenu';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/DesktopContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/DesktopContextMenu.ts
@@ -1,15 +1,15 @@
-import { AlloyComponent, InlineView } from '@ephox/alloy';
+import { type AlloyComponent, InlineView } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-import { UiFactoryBackstage } from '../../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../../backstage/Backstage';
 import ItemResponse from '../../item/ItemResponse';
 import * as MenuParts from '../../menu/MenuParts';
 import * as NestedMenus from '../../menu/NestedMenus';
-import { SingleMenuItemSpec } from '../../menu/SingleMenuTypes';
-import { AnchorType, getAnchorSpec } from '../Coords';
+import type { SingleMenuItemSpec } from '../../menu/SingleMenuTypes';
+import { type AnchorType, getAnchorSpec } from '../Coords';
 
 export const initAndShow = (
   editor: Editor,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/contextmenu/platform/MobileContextMenu.ts
@@ -1,19 +1,19 @@
-import { AlloyComponent, Bubble, InlineView, Layout, LayoutInset, MaxHeight, MaxWidth, TieredMenuTypes } from '@ephox/alloy';
+import { type AlloyComponent, Bubble, InlineView, Layout, LayoutInset, MaxHeight, MaxWidth, TieredMenuTypes } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SimSelection, WindowSelection } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import Delay from 'tinymce/core/api/util/Delay';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
-import { UiFactoryBackstage } from '../../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../../backstage/Backstage';
 import { hideContextToolbarEvent } from '../../../context/ContextEditorEvents';
 import { getContextToolbarBounds } from '../../../context/ContextToolbarBounds';
 import ItemResponse from '../../item/ItemResponse';
 import * as MenuParts from '../../menu/MenuParts';
 import * as NestedMenus from '../../menu/NestedMenus';
-import { SingleMenuItemSpec } from '../../menu/SingleMenuTypes';
+import type { SingleMenuItemSpec } from '../../menu/SingleMenuTypes';
 import * as Coords from '../Coords';
 
 type MenuItems = string | Array<string | SingleMenuItemSpec>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemClasses.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemClasses.ts
@@ -1,4 +1,4 @@
-import { Toolbar } from '@ephox/bridge';
+import type { Toolbar } from '@ephox/bridge';
 import { Obj } from '@ephox/katamari';
 
 const navClass = 'tox-menu-nav__js';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/ItemEvents.ts
@@ -1,6 +1,6 @@
-import { AlloyEvents, AlloyTriggers, EventFormat, SystemEvents } from '@ephox/alloy';
+import { AlloyEvents, AlloyTriggers, type EventFormat, SystemEvents } from '@ephox/alloy';
 
-import { GetApiType, runWithApi } from '../../controls/Controls';
+import { type GetApiType, runWithApi } from '../../controls/Controls';
 
 import ItemResponse from './ItemResponse';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/AutocompleteMenuItem.ts
@@ -1,13 +1,13 @@
-import { Behaviour, GuiFactory, ItemTypes, MaxHeight, Tooltipping } from '@ephox/alloy';
-import { InlineContent, Toolbar } from '@ephox/bridge';
+import { type Behaviour, GuiFactory, type ItemTypes, MaxHeight, Tooltipping } from '@ephox/alloy';
+import type { InlineContent, Toolbar } from '@ephox/bridge';
 import { Fun, Obj, Optional, Regex } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import I18n from 'tinymce/core/api/util/I18n';
-import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { buildData, renderCommonItem } from 'tinymce/themes/silver/ui/menus/item/build/CommonMenuItem';
-import ItemResponse from 'tinymce/themes/silver/ui/menus/item/ItemResponse';
+import type ItemResponse from 'tinymce/themes/silver/ui/menus/item/ItemResponse';
 import { renderItemStructure } from 'tinymce/themes/silver/ui/menus/item/structure/ItemStructure';
 
 type ItemValueHandler = (itemValue: string, itemMeta: Record<string, any>) => void;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CardMenuItem.ts
@@ -1,13 +1,13 @@
-import { AlloyComponent, AlloySpec, Behaviour, Disabling, ItemTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { type AlloyComponent, type AlloySpec, type Behaviour, Disabling, type ItemTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 import { SelectorFilter } from '@ephox/sugar';
 
-import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderItemDomStructure } from 'tinymce/themes/silver/ui/menus/item/structure/ItemStructure';
 
 import * as ItemClasses from '../ItemClasses';
-import ItemResponse from '../ItemResponse';
+import type ItemResponse from '../ItemResponse';
 import { renderContainer, renderHtml, renderImage } from '../structure/ItemSlices';
 
 import { replaceText } from './AutocompleteMenuItem';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ChoiceItem.ts
@@ -1,11 +1,11 @@
-import { AlloyComponent, Disabling, ItemTypes, Toggling, Tooltipping } from '@ephox/alloy';
-import { Menu, Toolbar } from '@ephox/bridge';
+import { type AlloyComponent, Disabling, type ItemTypes, Toggling, Tooltipping } from '@ephox/alloy';
+import type { Menu, Toolbar } from '@ephox/bridge';
 import { Fun, Merger, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
 import * as ItemClasses from '../ItemClasses';
-import ItemResponse from '../ItemResponse';
+import type ItemResponse from '../ItemResponse';
 import { renderCheckmark } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ColorSwatchItem.ts
@@ -1,8 +1,8 @@
-import { ItemTypes, ItemWidget, Menu as AlloyMenu, MenuTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { type ItemTypes, ItemWidget, Menu as AlloyMenu, type MenuTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Fun, Id } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 import { createPartialChoiceMenu } from '../../menu/MenuChoice';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/CommonMenuItem.ts
@@ -1,16 +1,16 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, Behaviour, Button, Focusing, ItemTypes, NativeEvents, Replacing
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, Behaviour, Button, Focusing, type ItemTypes, NativeEvents, Replacing
 } from '@ephox/alloy';
-import { Cell, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Cell, Fun, type Optional, Optionals } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { DisablingConfigs } from 'tinymce/themes/silver/ui/alien/DisablingConfigs';
-import { onControlAttached, onControlDetached, OnDestroy } from 'tinymce/themes/silver/ui/controls/Controls';
+import { onControlAttached, onControlDetached, type OnDestroy } from 'tinymce/themes/silver/ui/controls/Controls';
 import * as UiState from 'tinymce/themes/silver/UiState';
 
 import { menuItemEventOrder, onMenuItemExecute } from '../ItemEvents';
-import ItemResponse from '../ItemResponse';
-import { ItemStructure } from '../structure/ItemStructure';
+import type ItemResponse from '../ItemResponse';
+import type { ItemStructure } from '../structure/ItemStructure';
 
 export interface ItemDataInput {
   readonly value: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/FancyMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/FancyMenuItem.ts
@@ -1,8 +1,8 @@
-import { ItemTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
-import { Obj, Optional } from '@ephox/katamari';
+import type { ItemTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
+import { Obj, type Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../../backstage/Backstage';
 
 import { renderColorSwatchItem } from './ColorSwatchItem';
 import { renderImageSelector } from './ImageSelector';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ImageItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ImageItem.ts
@@ -1,11 +1,11 @@
-import { AlloyComponent, Disabling, ItemTypes, Toggling, Tooltipping } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { type AlloyComponent, Disabling, type ItemTypes, Toggling, Tooltipping } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Fun, Merger, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
 import * as ItemClasses from '../ItemClasses';
-import ItemResponse from '../ItemResponse';
+import type ItemResponse from '../ItemResponse';
 import { renderCheckmark } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ImageSelector.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ImageSelector.ts
@@ -1,8 +1,8 @@
-import { Menu as AlloyMenu, ItemTypes, ItemWidget, MenuTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { Menu as AlloyMenu, type ItemTypes, ItemWidget, type MenuTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Fun, Id } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { createPartialChoiceMenu } from '../../menu/MenuChoice';
 import { deriveMenuMovement } from '../../menu/MenuMovement';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/InsertTableMenuItem.ts
@@ -1,11 +1,11 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, CustomEvent, Focusing, GuiFactory, ItemTypes, ItemWidget,
-  Keying, Memento, NativeEvents, NativeSimulatedEvent, PremadeSpec, Replacing, SystemEvents, Toggling
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, type CustomEvent, Focusing, GuiFactory, type ItemTypes, ItemWidget,
+  Keying, Memento, NativeEvents, type NativeSimulatedEvent, type PremadeSpec, Replacing, SystemEvents, Toggling
 } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import type { Menu } from '@ephox/bridge';
 import { Arr, Id } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../../../backstage/Backstage';
 
 const cellOverEvent = Id.generate('cell-over');
 const cellExecuteEvent = Id.generate('cell-execute');

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NestedMenuItem.ts
@@ -1,11 +1,11 @@
-import { AlloyComponent, Disabling, ItemTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { type AlloyComponent, Disabling, type ItemTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 import { Attribute, SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
-import ItemResponse from '../ItemResponse';
+import type ItemResponse from '../ItemResponse';
 import { renderDownwardsCaret, renderSubmenuCaret } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/NormalMenuItem.ts
@@ -1,10 +1,10 @@
-import { AlloyComponent, Disabling, ItemTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { type AlloyComponent, Disabling, type ItemTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
-import ItemResponse from '../ItemResponse';
+import type ItemResponse from '../ItemResponse';
 import { renderItemStructure } from '../structure/ItemStructure';
 
 import { buildData, renderCommonItem } from './CommonMenuItem';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/SeparatorItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/SeparatorItem.ts
@@ -1,5 +1,5 @@
-import { GuiFactory, ItemTypes } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { GuiFactory, type ItemTypes } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 
 import * as ItemClasses from '../ItemClasses';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/build/ToggleMenuItem.ts
@@ -1,11 +1,11 @@
-import { AlloyComponent, Disabling, ItemTypes, Toggling } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
+import { type AlloyComponent, Disabling, type ItemTypes, Toggling } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
 import { Merger, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
 import * as ItemClasses from '../ItemClasses';
-import ItemResponse from '../ItemResponse';
+import type ItemResponse from '../ItemResponse';
 import { renderCheckmark } from '../structure/ItemSlices';
 import { renderItemStructure } from '../structure/ItemStructure';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemSlices.ts
@@ -1,6 +1,6 @@
-import { AlloySpec, GuiFactory, SimpleSpec } from '@ephox/alloy';
-import { Menu } from '@ephox/bridge';
-import { Optional } from '@ephox/katamari';
+import { type AlloySpec, GuiFactory, type SimpleSpec } from '@ephox/alloy';
+import type { Menu } from '@ephox/bridge';
+import type { Optional } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/item/structure/ItemStructure.ts
@@ -1,10 +1,10 @@
-import { AlloySpec, GuiFactory, RawDomSchema, SimpleSpec } from '@ephox/alloy';
-import { Toolbar } from '@ephox/bridge';
+import { type AlloySpec, GuiFactory, type RawDomSchema, type SimpleSpec } from '@ephox/alloy';
+import type { Toolbar } from '@ephox/bridge';
 import { Fun, Id, Obj, Optional, Type } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
 import * as Icons from '../../../icons/Icons';
 import * as Images from '../../../image/Images';
 import * as ItemClasses from '../ItemClasses';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuChoice.ts
@@ -1,15 +1,15 @@
-import { ItemTypes } from '@ephox/alloy';
-import { Menu as BridgeMenu, Toolbar } from '@ephox/bridge';
+import type { ItemTypes } from '@ephox/alloy';
+import { Menu as BridgeMenu, type Toolbar } from '@ephox/bridge';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
 
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { renderChoiceItem } from '../item/build/ChoiceItem';
 import { renderImgItem } from '../item/build/ImageItem';
-import ItemResponse from '../item/ItemResponse';
+import type ItemResponse from '../item/ItemResponse';
 
 import * as MenuUtils from './MenuUtils';
-import { SingleMenuItemSpec } from './SingleMenuTypes';
+import type { SingleMenuItemSpec } from './SingleMenuTypes';
 
 type PartialMenuSpec = MenuUtils.PartialMenuSpec;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuClasses.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuClasses.ts
@@ -1,4 +1,4 @@
-import { Toolbar } from '@ephox/bridge';
+import type { Toolbar } from '@ephox/bridge';
 
 interface MenuClasses {
   readonly backgroundMenu: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuConversion.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuConversion.ts
@@ -1,7 +1,7 @@
-import { Menu } from '@ephox/bridge';
+import type { Menu } from '@ephox/bridge';
 import { Arr, Id, Merger, Obj, Type } from '@ephox/katamari';
 
-import { SingleMenuItemSpec } from './SingleMenuTypes';
+import type { SingleMenuItemSpec } from './SingleMenuTypes';
 
 interface ExpandedMenu {
   readonly menus: Record<string, SingleMenuItemSpec[]>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuMovement.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuMovement.ts
@@ -1,5 +1,5 @@
-import { KeyingConfigSpec, MenuTypes } from '@ephox/alloy';
-import { Toolbar } from '@ephox/bridge';
+import type { KeyingConfigSpec, MenuTypes } from '@ephox/alloy';
+import type { Toolbar } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuParts.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuParts.ts
@@ -1,5 +1,5 @@
-import { Menu as AlloyMenu, RawDomSchema, TieredMenuTypes } from '@ephox/alloy';
-import { Toolbar } from '@ephox/bridge';
+import { Menu as AlloyMenu, type RawDomSchema, type TieredMenuTypes } from '@ephox/alloy';
+import type { Toolbar } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
 import { classForPreset } from '../item/ItemClasses';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuStructures.ts
@@ -1,9 +1,9 @@
-import { Menu as AlloyMenu, AlloySpec, ItemTypes, RawDomSchema, SimpleSpec } from '@ephox/alloy';
+import { Menu as AlloyMenu, type AlloySpec, type ItemTypes, type RawDomSchema, type SimpleSpec } from '@ephox/alloy';
 import { Arr, Fun, Id, Obj } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
 
-import { SearchMenuWithFieldMode } from './searchable/SearchableMenu';
+import type { SearchMenuWithFieldMode } from './searchable/SearchableMenu';
 import { renderMenuSearcher } from './searchable/SearchableMenuField';
 import { augmentWithAria, searchResultsClass } from './searchable/SearchableMenus';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuUtils.ts
@@ -1,12 +1,12 @@
-import { ItemTypes, MenuTypes } from '@ephox/alloy';
+import type { ItemTypes, MenuTypes } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
-import { InlineContent, Menu, Toolbar } from '@ephox/bridge';
+import type { InlineContent, Menu, Toolbar } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 
 import { components as menuComponents, dom as menuDom } from './MenuParts';
-import { forCollection, forCollectionWithSearchField, forCollectionWithSearchResults, forHorizontalCollection, forImageSelector, forSwatch, forToolbar, StructureSpec } from './MenuStructures';
-import { SearchMenuWithFieldMode, SearchMenuWithResultsMode } from './searchable/SearchableMenu';
-import { SingleMenuItemSpec } from './SingleMenuTypes';
+import { forCollection, forCollectionWithSearchField, forCollectionWithSearchResults, forHorizontalCollection, forImageSelector, forSwatch, forToolbar, type StructureSpec } from './MenuStructures';
+import type { SearchMenuWithFieldMode, SearchMenuWithResultsMode } from './searchable/SearchableMenu';
+import type { SingleMenuItemSpec } from './SingleMenuTypes';
 
 export interface PartialMenuSpec {
   readonly value: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuWidgets.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/MenuWidgets.ts
@@ -1,4 +1,4 @@
-import { AlloySpec, Behaviour, ItemWidget, Keying, Memento, Menu, MenuTypes, SimpleOrSketchSpec } from '@ephox/alloy';
+import { type AlloySpec, Behaviour, ItemWidget, Keying, Memento, Menu, type MenuTypes, type SimpleOrSketchSpec } from '@ephox/alloy';
 import { Id, Optional } from '@ephox/katamari';
 
 import { dom as menuDom } from './MenuParts';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/NestedMenus.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/NestedMenus.ts
@@ -1,15 +1,15 @@
-import { TieredData, TieredMenu } from '@ephox/alloy';
+import { type TieredData, TieredMenu } from '@ephox/alloy';
 import { Objects } from '@ephox/boulder';
 import { Id, Merger, Obj, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
-import ItemResponse from '../item/ItemResponse';
+import type ItemResponse from '../item/ItemResponse';
 
 import { expand } from './MenuConversion';
-import { MenuSearchMode } from './searchable/SearchableMenu';
+import type { MenuSearchMode } from './searchable/SearchableMenu';
 import { createPartialMenu } from './SingleMenu';
-import { SingleMenuItemSpec } from './SingleMenuTypes';
+import type { SingleMenuItemSpec } from './SingleMenuTypes';
 
 export interface NestedMenusSettings {
   readonly isHorizontalMenu: boolean;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenu.ts
@@ -1,20 +1,20 @@
-import { AlloyEvents, InlineViewTypes, ItemTypes, Keying, TieredMenu, TieredMenuTypes } from '@ephox/alloy';
-import { InlineContent, Menu as BridgeMenu, Toolbar } from '@ephox/bridge';
+import { AlloyEvents, type InlineViewTypes, type ItemTypes, Keying, TieredMenu, type TieredMenuTypes } from '@ephox/alloy';
+import { InlineContent, Menu as BridgeMenu, type Toolbar } from '@ephox/bridge';
 import { Arr, Obj, Optional, Optionals } from '@ephox/katamari';
 
-import { UiFactoryBackstage, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstage, UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { detectSize } from '../../alien/FlatgridAutodetect';
 import { SimpleBehaviours } from '../../alien/SimpleBehaviours';
 import { tooltipBehaviour } from '../item/build/AutocompleteMenuItem';
-import ItemResponse from '../item/ItemResponse';
+import type ItemResponse from '../item/ItemResponse';
 import * as MenuItems from '../item/MenuItems';
 
 import { deriveMenuMovement } from './MenuMovement';
 import { markers as getMenuMarkers } from './MenuParts';
 import * as MenuUtils from './MenuUtils';
-import { identifyMenuLayout, MenuSearchMode } from './searchable/SearchableMenu';
-import { SingleMenuItemSpec } from './SingleMenuTypes';
+import { identifyMenuLayout, type MenuSearchMode } from './searchable/SearchableMenu';
+import type { SingleMenuItemSpec } from './SingleMenuTypes';
 
 type PartialMenuSpec = MenuUtils.PartialMenuSpec;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenuTypes.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/SingleMenuTypes.ts
@@ -1,4 +1,4 @@
-import { Menu } from '@ephox/bridge';
+import type { Menu } from '@ephox/bridge';
 
 export type SingleMenuItemSpec = Menu.MenuItemSpec | Menu.NestedMenuItemSpec | Menu.ToggleMenuItemSpec | Menu.SeparatorMenuItemSpec |
 Menu.ChoiceMenuItemSpec | Menu.FancyMenuItemSpec | Menu.ImageMenuItemSpec | Menu.ResetImageItemSpec;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenu.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenu.ts
@@ -1,10 +1,10 @@
-import { AlloyComponent, AlloyTriggers, Coupling, Dropdown, Focusing, Highlighting, Representing, Sandboxing, SimulatedEvent } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, Coupling, Dropdown, Focusing, Highlighting, Representing, Sandboxing, type SimulatedEvent } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
-import { Attribute, Class, SelectorFind, SugarElement } from '@ephox/sugar';
+import { Attribute, Class, SelectorFind, type SugarElement } from '@ephox/sugar';
 
-import { MenuLayoutType } from '../MenuUtils';
+import type { MenuLayoutType } from '../MenuUtils';
 
-import { RedirectMenuItemInteractionEvent } from './SearchableMenuEvents';
+import type { RedirectMenuItemInteractionEvent } from './SearchableMenuEvents';
 import { findWithinMenu, findWithinSandbox, restoreState, saveState, setActiveDescendant } from './SearchableMenuField';
 import { searchResultsClass } from './SearchableMenus';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenuEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenuEvents.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, EventFormat } from '@ephox/alloy';
+import type { CustomEvent, EventFormat } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 // We also could have put the SearcherState in here, but that makes refetch

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenuField.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenuField.ts
@@ -1,11 +1,11 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Input, Keying, NativeEvents, NativeSimulatedEvent, Representing } from '@ephox/alloy';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, Input, Keying, NativeEvents, type NativeSimulatedEvent, Representing } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
-import { Attribute, EventArgs, SelectorFind } from '@ephox/sugar';
+import { Attribute, type EventArgs, SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../../../backstage/Backstage';
 import { selectableClass as usualItemClass } from '../../item/ItemClasses';
 
-import { redirectMenuItemInteractionEvent, RedirectMenuItemInteractionEventData, refetchTriggerEvent } from './SearchableMenuEvents';
+import { redirectMenuItemInteractionEvent, type RedirectMenuItemInteractionEventData, refetchTriggerEvent } from './SearchableMenuEvents';
 
 export interface MenuSearcherSpec {
   readonly placeholder: Optional<string>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenus.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menu/searchable/SearchableMenus.ts
@@ -1,4 +1,4 @@
-import { ItemTypes } from '@ephox/alloy';
+import type { ItemTypes } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
 export const searchResultsClass = 'tox-collection--results__js';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -1,11 +1,11 @@
 import { Arr, Obj, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 
 import * as Options from '../../../api/Options';
 
-import { MenubarItemSpec } from './SilverMenubar';
+import type { MenubarItemSpec } from './SilverMenubar';
 
 interface MenuSpec {
   readonly title: string;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/SilverMenubar.ts
@@ -1,15 +1,15 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Dropdown, Focusing, Keying, NativeEvents, RawDomSchema, Replacing, Sketcher,
-  SystemEvents, Tabstopping, UiSketcher
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, Dropdown, Focusing, Keying, NativeEvents, type RawDomSchema, Replacing, Sketcher,
+  SystemEvents, Tabstopping, type UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { Toolbar } from '@ephox/bridge';
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Compare, EventArgs, SelectorFind } from '@ephox/sugar';
+import { Compare, type EventArgs, SelectorFind } from '@ephox/sugar';
 
-import { Menu } from 'tinymce/core/api/ui/Ui';
-import { TranslatedString } from 'tinymce/core/api/util/I18n';
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
+import type { TranslatedString } from 'tinymce/core/api/util/I18n';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
 
 import { renderMenuButton } from '../../button/MenuButton';
 import { MenuButtonClasses } from '../../toolbar/button/ButtonClasses';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/promotion/Promotion.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/promotion/Promotion.ts
@@ -1,4 +1,4 @@
-import { AlloySpec, SimpleSpec } from '@ephox/alloy';
+import type { AlloySpec, SimpleSpec } from '@ephox/alloy';
 
 const promotionMessage = '💝 Get all features';
 const promotionLink = 'https://www.tiny.cloud/tinymce-upgrade-to-cloud/?utm_campaign=self_hosted_upgrade_promo&utm_source=tiny&utm_medium=referral';
@@ -31,4 +31,5 @@ const renderPromotion = (spec: PromotionSpec): AlloySpec => {
   };
 };
 
-export { renderPromotion, PromotionSpec };
+export type { PromotionSpec };
+export { renderPromotion };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/selector/TableSelectorHandles.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/selector/TableSelectorHandles.ts
@@ -1,12 +1,12 @@
 import {
-  AlloyComponent, Attachment, Behaviour, Boxes, Button, DragCoord, Dragging, DraggingTypes, GuiFactory, Memento, Unselecting
+  type AlloyComponent, Attachment, Behaviour, Boxes, Button, DragCoord, Dragging, type DraggingTypes, GuiFactory, Memento, Unselecting
 } from '@ephox/alloy';
 import { Arr, Cell, Optional, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Compare, Css, SugarElement, SugarPosition, Traverse } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 interface SnapExtra {
   readonly td: SugarElement<HTMLTableCellElement>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -1,15 +1,15 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec, AlloyTriggers, Behaviour, Composing, CustomEvent, Focusing, Replacing, SketchSpec,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec, AlloyTriggers, Behaviour, Composing, type CustomEvent, Focusing, Replacing, type SketchSpec,
   Sliding,
   SlotContainer,
-  SlotContainerTypes, SystemEvents, Tabstopping
+  type SlotContainerTypes, SystemEvents, Tabstopping
 } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
 import { Sidebar as BridgeSidebar } from '@ephox/bridge';
 import { Arr, Cell, Fun, Id, Obj, Optional, Optionals, Type } from '@ephox/katamari';
-import { Attribute, Css, SugarElement, Width } from '@ephox/sugar';
+import { Attribute, Css, type SugarElement, Width } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/EditorSize.ts
@@ -1,7 +1,7 @@
-import { Optional } from '@ephox/katamari';
+import type { Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Options from '../../api/Options';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Resize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Resize.ts
@@ -1,7 +1,7 @@
 import { Obj, Type } from '@ephox/katamari';
-import { Css, Height, SugarElement, SugarPosition, Width } from '@ephox/sugar';
+import { Css, Height, SugarElement, type SugarPosition, Width } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../../api/Events';
 import * as Options from '../../api/Options';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Utils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sizing/Utils.ts
@@ -1,5 +1,5 @@
 import { Optional, Type } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 const parseToInt = (val: string | number): Optional<number> => {
   // if size is a number or '_px', will return the number

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/Loader.ts
@@ -2,9 +2,9 @@ import { Fun, Optional, Optionals, Type } from '@ephox/katamari';
 import { SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import DOMUtils from 'tinymce/core/api/dom/DOMUtils';
-import StyleSheetLoader from 'tinymce/core/api/dom/StyleSheetLoader';
-import Editor from 'tinymce/core/api/Editor';
-import { TinyMCE } from 'tinymce/core/api/Tinymce';
+import type StyleSheetLoader from 'tinymce/core/api/dom/StyleSheetLoader';
+import type Editor from 'tinymce/core/api/Editor';
+import type { TinyMCE } from 'tinymce/core/api/Tinymce';
 
 declare let tinymce: TinyMCE;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/skin/SkinLoaded.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/skin/SkinLoaded.ts
@@ -1,4 +1,4 @@
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../../api/Events';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ElementPath.ts
@@ -1,10 +1,10 @@
-import { AddEventsBehaviour, AlloyEvents, AlloySpec, AriaDescribe, Behaviour, Button, Disabling, GuiFactory, Keying, Replacing, SimpleSpec, Tabstopping, Tooltipping } from '@ephox/alloy';
+import { AddEventsBehaviour, AlloyEvents, type AlloySpec, AriaDescribe, Behaviour, Button, Disabling, GuiFactory, Keying, Replacing, type SimpleSpec, Tabstopping, Tooltipping } from '@ephox/alloy';
 import { Arr } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Events from '../../api/Events';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/ResizeHandle.ts
@@ -1,12 +1,12 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, Dragging, Focusing, Keying, SimpleSpec, SystemEvents, Tabstopping, Tooltipping } from '@ephox/alloy';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, Dragging, Focusing, Keying, type SimpleSpec, SystemEvents, Tabstopping, Tooltipping } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { Attribute, SugarPosition } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import * as Options from '../../api/Options';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Icons from '../icons/Icons';
 import * as Resize from '../sizing/Resize';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/Statusbar.ts
@@ -1,11 +1,11 @@
-import { Behaviour, Focusing, GuiFactory, SimpleSpec } from '@ephox/alloy';
+import { Behaviour, Focusing, GuiFactory, type SimpleSpec } from '@ephox/alloy';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import { Logo } from 'tinymce/themes/silver/resources/StatusbarLogo';
 
 import * as Options from '../../api/Options';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as ConvertShortcut from '../alien/ConvertShortcut';
 
 import * as ElementPath from './ElementPath';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/statusbar/WordCount.ts
@@ -1,10 +1,10 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, Behaviour, Button, GuiFactory, Replacing, Representing, SimpleSpec, SystemEvents, Tabstopping
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, Behaviour, Button, GuiFactory, Replacing, Representing, type SimpleSpec, SystemEvents, Tabstopping
 } from '@ephox/alloy';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as UiState from '../../UiState';
 import { DisablingConfigs } from '../alien/DisablingConfigs';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/throbber/Throbber.ts
@@ -1,15 +1,15 @@
-import { AlloyComponent, AlloySpec, Behaviour, Blocking, Composing, DomFactory, Replacing, SketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, type AlloySpec, Behaviour, Blocking, Composing, DomFactory, Replacing, type SketchSpec } from '@ephox/alloy';
 import { Arr, Cell, Optional, Singleton, Type } from '@ephox/katamari';
 import { Attribute, Class, Css, Focus, SugarElement, SugarNode } from '@ephox/sugar';
 
-import { EventUtilsEvent } from 'tinymce/core/api/dom/EventUtils';
-import Editor from 'tinymce/core/api/Editor';
-import { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
+import type { EventUtilsEvent } from 'tinymce/core/api/dom/EventUtils';
+import type Editor from 'tinymce/core/api/Editor';
+import type { ExecCommandEvent } from 'tinymce/core/api/EventTypes';
 import Delay from 'tinymce/core/api/util/Delay';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as Events from '../../api/Events';
-import { UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../backstage/Backstage';
 
 const getBusySpec = (providerBackstage: UiFactoryBackstageProviders) => (_root: AlloyComponent, _behaviours: Behaviour.AlloyBehaviourRecord): AlloySpec => ({
   dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/CommonToolbar.ts
@@ -1,19 +1,19 @@
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloySpec,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloySpec,
   SplitFloatingToolbar as AlloySplitFloatingToolbar,
   SplitSlidingToolbar as AlloySplitSlidingToolbar,
   Toolbar as AlloyToolbar, ToolbarGroup as AlloyToolbarGroup,
   Behaviour, Boxes,
   Focusing,
   GuiFactory,
-  Keying, SketchSpec,
+  Keying, type SketchSpec,
   Tabstopping
 } from '@ephox/alloy';
-import { Arr, Optional, Result } from '@ephox/katamari';
+import { Arr, Optional, type Result } from '@ephox/katamari';
 import { Traverse } from '@ephox/sugar';
 
 import { ToolbarMode } from '../../api/Options';
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as Channels from '../../Channels';
 import * as UiState from '../../UiState';
 import { DisablingConfigs } from '../alien/DisablingConfigs';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/Integration.ts
@@ -1,13 +1,13 @@
-import { AlloySpec, VerticalDir } from '@ephox/alloy';
+import { type AlloySpec, VerticalDir } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
 import { Toolbar } from '@ephox/bridge';
-import { Arr, Obj, Optional, Optionals, Result, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional, Optionals, type Result, Type } from '@ephox/katamari';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { getToolbarMode, ToolbarGroupOption, ToolbarMode } from '../../api/Options';
-import { UiFactoryBackstage } from '../../backstage/Backstage';
-import { ToolbarConfig } from '../../Render';
+import { getToolbarMode, type ToolbarGroupOption, ToolbarMode } from '../../api/Options';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { ToolbarConfig } from '../../Render';
 import { renderMenuButton } from '../button/MenuButton';
 import { createNavigateBackButton } from '../context/NavigateBackBespokeButton';
 import { createAlignButton } from '../core/complex/AlignBespoke';
@@ -18,7 +18,7 @@ import { createStylesButton } from '../core/complex/StylesBespoke';
 
 import { ToolbarButtonClasses } from './button/ButtonClasses';
 import { renderFloatingToolbarButton, renderSplitButton, renderToolbarButton, renderToolbarToggleButton } from './button/ToolbarButtons';
-import { ToolbarGroup } from './CommonToolbar';
+import type { ToolbarGroup } from './CommonToolbar';
 
 export type ToolbarButton = Toolbar.ToolbarButtonSpec | Toolbar.ToolbarMenuButtonSpec | Toolbar.ToolbarToggleButtonSpec | Toolbar.ToolbarSplitButtonSpec;
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ButtonEvents.ts
@@ -1,7 +1,7 @@
-import { AlloyEvents, AlloyTriggers, CustomEvent, EventFormat, NativeEvents, SystemEvents } from '@ephox/alloy';
+import { AlloyEvents, AlloyTriggers, type CustomEvent, type EventFormat, NativeEvents, SystemEvents } from '@ephox/alloy';
 import { Id } from '@ephox/katamari';
 
-import { GetApiType, runWithApi } from '../../controls/Controls';
+import { type GetApiType, runWithApi } from '../../controls/Controls';
 
 export interface OnMenuItemExecuteType<T> extends GetApiType<T> {
   readonly onAction: (itemApi: T) => void;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/toolbar/button/ToolbarButtons.ts
@@ -1,8 +1,8 @@
 import {
   AddEventsBehaviour,
-  AlloyComponent,
+  type AlloyComponent,
   AlloyEvents,
-  AlloySpec,
+  type AlloySpec,
   AlloyTriggers,
   Behaviour,
   Button as AlloyButton,
@@ -15,20 +15,20 @@ import {
   Memento,
   NativeEvents,
   Replacing,
-  SketchSpec,
+  type SketchSpec,
   SystemEvents,
-  TieredData,
-  TieredMenuTypes,
+  type TieredData,
+  type TieredMenuTypes,
   Toggling,
   Tooltipping,
   Unselecting
 } from '@ephox/alloy';
-import { Toolbar } from '@ephox/bridge';
+import type { Toolbar } from '@ephox/bridge';
 import { Arr, Cell, Fun, Future, Id, Merger, Optional, Type } from '@ephox/katamari';
-import { Attribute, Class, EventArgs, SelectorFind, Traverse } from '@ephox/sugar';
+import { Attribute, Class, type EventArgs, SelectorFind, Traverse } from '@ephox/sugar';
 
-import { ToolbarGroupOption } from '../../../api/Options';
-import { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../../backstage/Backstage';
+import type { ToolbarGroupOption } from '../../../api/Options';
+import type { UiFactoryBackstage, UiFactoryBackstageProviders, UiFactoryBackstageShared } from '../../../backstage/Backstage';
 import * as ConvertShortcut from '../../../ui/alien/ConvertShortcut';
 import * as UiState from '../../../UiState';
 import { DisablingConfigs } from '../../alien/DisablingConfigs';
@@ -36,8 +36,8 @@ import { detectSize } from '../../alien/FlatgridAutodetect';
 import { SimpleBehaviours } from '../../alien/SimpleBehaviours';
 import * as UiUtils from '../../alien/UiUtils';
 import { renderLabel, renderReplaceableIconFromPack } from '../../button/ButtonSlices';
-import { onControlAttached, onControlDetached, OnDestroy } from '../../controls/Controls';
-import { updateMenuIcon, UpdateMenuIconEvent, updateMenuText, UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
+import { onControlAttached, onControlDetached, type OnDestroy } from '../../controls/Controls';
+import { updateMenuIcon, type UpdateMenuIconEvent, updateMenuText, type UpdateMenuTextEvent } from '../../dropdown/CommonDropdown';
 import * as Icons from '../../icons/Icons';
 import { componentRenderPipeline } from '../../menus/item/build/CommonMenuItem';
 import { classForPreset } from '../../menus/item/ItemClasses';
@@ -46,8 +46,8 @@ import { createPartialChoiceMenu } from '../../menus/menu/MenuChoice';
 import { deriveMenuMovement } from '../../menus/menu/MenuMovement';
 import * as MenuParts from '../../menus/menu/MenuParts';
 import { createTieredDataFrom } from '../../menus/menu/SingleMenu';
-import { SingleMenuItemSpec } from '../../menus/menu/SingleMenuTypes';
-import { renderToolbarGroup, ToolbarGroup } from '../CommonToolbar';
+import type { SingleMenuItemSpec } from '../../menus/menu/SingleMenuTypes';
+import { renderToolbarGroup, type ToolbarGroup } from '../CommonToolbar';
 
 import { ToolbarButtonClasses } from './ButtonClasses';
 import { commonButtonDisplayEvent, onToolbarButtonExecute, toolbarButtonEventOrder } from './ButtonEvents';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/urlinput/Completions.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/urlinput/Completions.ts
@@ -1,9 +1,9 @@
-import { Menu as BridgeMenu } from '@ephox/bridge';
+import type { Menu as BridgeMenu } from '@ephox/bridge';
 import { Arr, Fun, Optional, Strings } from '@ephox/katamari';
 
-import { LinkInformation } from '../../backstage/UrlInputBackstage';
-import { LinkTarget, LinkTargetType } from '../core/LinkTargets';
-import { SingleMenuItemSpec } from '../menus/menu/SingleMenuTypes';
+import type { LinkInformation } from '../../backstage/UrlInputBackstage';
+import type { LinkTarget, LinkTargetType } from '../core/LinkTargets';
+import type { SingleMenuItemSpec } from '../menus/menu/SingleMenuTypes';
 
 const separator: BridgeMenu.SeparatorMenuItemSpec = {
   type: 'separator'

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/View.ts
@@ -1,13 +1,13 @@
 import {
-  AlloyComponent, AlloySpec, Behaviour, Composite, Container, Focusing, FocusInsideModes, Keying, PartType, RawDomSchema, SimpleSpec,
-  Sketcher, Tabstopping, UiSketcher
+  type AlloyComponent, type AlloySpec, Behaviour, Composite, Container, Focusing, FocusInsideModes, Keying, PartType, type RawDomSchema, type SimpleSpec,
+  Sketcher, Tabstopping, type UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema } from '@ephox/boulder';
-import { View as BridgeView } from '@ephox/bridge';
-import { Arr, Optional } from '@ephox/katamari';
+import type { View as BridgeView } from '@ephox/bridge';
+import { Arr, type Optional } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 
 import { renderButton } from './ViewButtons';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewButtons.ts
@@ -1,14 +1,14 @@
-import { AlloyComponent, Behaviour, Button as AlloyButton, GuiFactory, Memento, Replacing, SimpleOrSketchSpec } from '@ephox/alloy';
+import { type AlloyComponent, type Behaviour, Button as AlloyButton, GuiFactory, Memento, Replacing, type SimpleOrSketchSpec } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { Attribute, Class, Focus } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { renderReplaceableIconFromPack } from '../button/ButtonSlices';
-import { calculateClassesFromButtonType, IconButtonWrapper, renderCommonSpec } from '../general/Button';
+import { calculateClassesFromButtonType, type IconButtonWrapper, renderCommonSpec } from '../general/Button';
 import { componentRenderPipeline } from '../menus/item/build/CommonMenuItem';
 import { ViewButtonClasses } from '../toolbar/button/ButtonClasses';
 
-import { ViewButtonWithoutGroup } from './View';
+import type { ViewButtonWithoutGroup } from './View';
 
 type Behaviours = Behaviour.NamedConfiguredBehaviour<any, any, any>[];
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewTypes.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewTypes.ts
@@ -1,3 +1,3 @@
-import { View as BridgeView } from '@ephox/bridge';
+import type { View as BridgeView } from '@ephox/bridge';
 
 export type ViewConfig = Record<string, BridgeView.ViewSpec>;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewWrapper.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/view/ViewWrapper.ts
@@ -1,17 +1,17 @@
 import {
-  AlloyComponent, AlloyEvents, Behaviour, Composing,
-  Replacing, Sketcher, SlotContainer, SlotContainerTypes, UiSketcher
+  type AlloyComponent, AlloyEvents, Behaviour, Composing,
+  Replacing, Sketcher, SlotContainer, type SlotContainerTypes, type UiSketcher
 } from '@ephox/alloy';
 import { FieldSchema, StructureSchema } from '@ephox/boulder';
 import { View as BridgeView } from '@ephox/bridge';
-import { Arr, Fun, Obj, Optional } from '@ephox/katamari';
+import { Arr, Fun, Obj, type Optional } from '@ephox/katamari';
 import { Attribute, Css } from '@ephox/sugar';
 
-import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { SimpleBehaviours } from '../alien/SimpleBehaviours';
 
 import View from './View';
-import { ViewConfig } from './ViewTypes';
+import type { ViewConfig } from './ViewTypes';
 
 interface SilverViewWrapperSpec extends Sketcher.SingleSketchSpec {
   readonly backstage: UiFactoryBackstage;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialog.ts
@@ -1,8 +1,8 @@
-import { AlloyComponent, Composing, ModalDialog, Reflecting } from '@ephox/alloy';
-import { Dialog, DialogManager } from '@ephox/bridge';
+import { type AlloyComponent, Composing, ModalDialog, Reflecting } from '@ephox/alloy';
+import type { Dialog, DialogManager } from '@ephox/bridge';
 import { Cell, Fun, Id, Optional, Optionals } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 
 import { dialogChannel } from './DialogChannels';
 import { renderModalBody } from './SilverDialogBody';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogBody.ts
@@ -1,8 +1,8 @@
-import { AlloyComponent, AlloyParts, Behaviour, Focusing, Keying, ModalDialog, Reflecting, SimpleSpec, Tabstopping } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { type AlloyComponent, type AlloyParts, Behaviour, Focusing, Keying, ModalDialog, Reflecting, type SimpleSpec, Tabstopping } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Fun, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { renderBodyPanel } from '../dialog/BodyPanel';
 import { renderTabPanel } from '../dialog/TabPanel';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogCommon.ts
@@ -1,18 +1,18 @@
 import {
-  AlloyComponent, AlloyEvents, AlloyParts, AlloySpec, AlloyTriggers, Behaviour, DomFactory, GuiFactory, ModalDialog, Receiving, Reflecting,
+  type AlloyComponent, type AlloyEvents, type AlloyParts, type AlloySpec, AlloyTriggers, type Behaviour, DomFactory, GuiFactory, ModalDialog, Receiving, Reflecting,
   SystemEvents
 } from '@ephox/alloy';
-import { Dialog, DialogManager } from '@ephox/bridge';
+import type { Dialog, DialogManager } from '@ephox/bridge';
 import { Arr, Cell, Obj, Optional } from '@ephox/katamari';
 import { Class, Classes, Height, SelectorFind, SugarElement } from '@ephox/sugar';
 
-import { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstage, UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
-import { StoredMenuButton, StoredMenuItem } from '../button/MenuButton';
+import type { StoredMenuButton, StoredMenuItem } from '../button/MenuButton';
 import * as Dialogs from '../dialog/Dialogs';
-import { FormBlockEvent, formCancelEvent } from '../general/FormEvents';
+import { type FormBlockEvent, formCancelEvent } from '../general/FormEvents';
 
-import { ExtraListeners } from './SilverDialogEvents';
+import type { ExtraListeners } from './SilverDialogEvents';
 import { renderModalHeader } from './SilverDialogHeader';
 
 export interface SharedWindowExtra {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogEvents.ts
@@ -1,13 +1,13 @@
-import { AlloyComponent, AlloyEvents, AlloyTriggers, CustomEvent, Keying, NativeEvents, Reflecting, Representing } from '@ephox/alloy';
-import { Dialog, DialogManager } from '@ephox/bridge';
-import { Result } from '@ephox/katamari';
-import { Attribute, Compare, Focus, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { type AlloyComponent, AlloyEvents, AlloyTriggers, type CustomEvent, Keying, NativeEvents, Reflecting, Representing } from '@ephox/alloy';
+import type { Dialog, DialogManager } from '@ephox/bridge';
+import type { Result } from '@ephox/katamari';
+import { Attribute, Compare, Focus, type SugarElement, SugarShadowDom } from '@ephox/sugar';
 
 import {
-  formActionEvent, FormActionEvent, formBlockEvent, FormBlockEvent, FormCancelEvent, formCancelEvent, FormChangeEvent, formChangeEvent,
-  FormCloseEvent,
+  formActionEvent, type FormActionEvent, formBlockEvent, type FormBlockEvent, type FormCancelEvent, formCancelEvent, type FormChangeEvent, formChangeEvent,
+  type FormCloseEvent,
   formCloseEvent,
-  FormSubmitEvent, formSubmitEvent, formTabChangeEvent, FormTabChangeEvent, formUnblockEvent, FormUnblockEvent
+  type FormSubmitEvent, formSubmitEvent, formTabChangeEvent, type FormTabChangeEvent, formUnblockEvent, type FormUnblockEvent
 } from '../general/FormEvents';
 import * as NavigableObject from '../general/NavigableObject';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogFooter.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogFooter.ts
@@ -1,10 +1,10 @@
 import {
-  AlloyComponent, AlloyParts, Behaviour, Container, DomFactory, Memento, MementoRecord, ModalDialog, Reflecting, SimpleSpec, SketchSpec
+  type AlloyComponent, type AlloyParts, Behaviour, Container, DomFactory, Memento, type MementoRecord, ModalDialog, Reflecting, type SimpleSpec, type SketchSpec
 } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import type { Dialog } from '@ephox/bridge';
 import { Arr, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 import { renderFooterButton } from '../general/Button';
 
 import { footerChannel } from './DialogChannels';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogHeader.ts
@@ -1,10 +1,10 @@
 import {
-  AlloySpec, AlloyTriggers, Behaviour, Button, Channels, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, SketchSpec, Tabstopping, Tooltipping
+  type AlloySpec, AlloyTriggers, Behaviour, Button, Channels, Container, DomFactory, Dragging, GuiFactory, ModalDialog, Reflecting, type SketchSpec, Tabstopping, Tooltipping
 } from '@ephox/alloy';
 import { Optional } from '@ephox/katamari';
 import { SelectorFind } from '@ephox/sugar';
 
-import { UiFactoryBackstageProviders } from '../../backstage/Backstage';
+import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { formCancelEvent } from '../general/FormEvents';
 import * as Icons from '../icons/Icons';
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverDialogInstanceApi.ts
@@ -1,13 +1,13 @@
-import { AlloyComponent, AlloyTriggers, Composing, Disabling, Focusing, Form, Reflecting, Representing, TabSection } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, Composing, Disabling, Focusing, Form, Reflecting, Representing, TabSection } from '@ephox/alloy';
 import { StructureSchema } from '@ephox/boulder';
-import { Dialog, DialogManager } from '@ephox/bridge';
-import { Cell, Merger, Obj, Optional, Type } from '@ephox/katamari';
+import type { Dialog, DialogManager } from '@ephox/bridge';
+import { type Cell, Merger, Obj, Optional, Type } from '@ephox/katamari';
 
 import { formBlockEvent, formCloseEvent, formUnblockEvent } from '../general/FormEvents';
 
 import { bodyChannel, dialogChannel, footerChannel, titleChannel } from './DialogChannels';
 import * as SilverDialogCommon from './SilverDialogCommon';
-import { FooterState } from './SilverDialogFooter';
+import type { FooterState } from './SilverDialogFooter';
 
 const getCompByName = (access: DialogAccess, name: string): Optional<AlloyComponent> => {
   // TODO: Add API to alloy to find the inner most component of a Composing chain.

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverInlineDialog.ts
@@ -1,14 +1,14 @@
 // DUPE with SilverDialog. Cleaning up.
 import {
-  AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, GuiFactory, Keying, Memento, NativeEvents,
+  AddEventsBehaviour, type AlloyComponent, AlloyEvents, AlloyTriggers, Behaviour, Blocking, Composing, Focusing, GuiFactory, Keying, Memento, NativeEvents,
   Receiving, Reflecting, Replacing, SystemEvents
 } from '@ephox/alloy';
-import { Dialog, DialogManager } from '@ephox/bridge';
+import type { Dialog, DialogManager } from '@ephox/bridge';
 import { Cell, Fun, Id, Optional, Optionals } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { Attribute, Height, SugarNode } from '@ephox/sugar';
 
-import * as Backstage from '../../backstage/Backstage';
+import type * as Backstage from '../../backstage/Backstage';
 import * as RepresentingConfigs from '../alien/RepresentingConfigs';
 import * as FormEvents from '../general/FormEvents';
 import * as NavigableObject from '../general/NavigableObject';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialog.ts
@@ -1,12 +1,12 @@
-import { AddEventsBehaviour, AlloyComponent, AlloyEvents, AlloyParts, Receiving, Reflecting } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { AddEventsBehaviour, type AlloyComponent, AlloyEvents, type AlloyParts, Receiving, Reflecting } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Id, Obj, Optional, Singleton, Type } from '@ephox/katamari';
-import { DomEvent, EventUnbinder, SelectorFind, SugarElement } from '@ephox/sugar';
+import { DomEvent, type EventUnbinder, SelectorFind, SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import URI from 'tinymce/core/api/util/URI';
 
-import { UiFactoryBackstage } from '../../backstage/Backstage';
+import type { UiFactoryBackstage } from '../../backstage/Backstage';
 
 import { bodySendMessageChannel, dialogChannel } from './DialogChannels';
 import { renderIframeBody } from './SilverDialogBody';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialogInstanceApi.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/window/SilverUrlDialogInstanceApi.ts
@@ -1,5 +1,5 @@
-import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
-import { Dialog } from '@ephox/bridge';
+import { type AlloyComponent, AlloyTriggers } from '@ephox/alloy';
+import type { Dialog } from '@ephox/bridge';
 import { Type } from '@ephox/katamari';
 
 import { formBlockEvent, formCloseEvent, formUnblockEvent } from '../general/FormEvents';

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConvertTest.ts
@@ -3,7 +3,7 @@ import { Arr, Optional, Optionals } from '@ephox/katamari';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 
-import { convertUnit, nuSize, Size, SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
+import { convertUnit, nuSize, type Size, type SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 import { convertibleUnits, largeSensible, units } from './SizeInputShared';
 

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConverterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputConverterTest.ts
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import * as fc from 'fast-check';
 
 import {
-  makeRatioConverter, noSizeConversion, nuSize, ratioSizeConversion, Size, SizeConversion, SizeUnit
+  makeRatioConverter, noSizeConversion, nuSize, ratioSizeConversion, type Size, type SizeConversion, type SizeUnit
 } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 import { largeSensible, units } from './SizeInputShared';

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputParsingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputParsingTest.ts
@@ -3,7 +3,7 @@ import { Arr, Result } from '@ephox/katamari';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 
-import { nuSize, parseSize, Size, SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
+import { nuSize, parseSize, type Size, type SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 import { largeSensible, units } from './SizeInputShared';
 

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputShared.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/components/sizeinput/SizeInputShared.ts
@@ -1,4 +1,4 @@
-import { SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
+import type { SizeUnit } from 'tinymce/themes/silver/ui/sizeinput/SizeInputModel';
 
 export const units: SizeUnit[] = [ '', 'cm', 'mm', 'in', 'px', 'pt', 'pc', 'em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', '%' ];
 export const convertibleUnits: SizeUnit[] = [ '', 'cm', 'mm', 'in', 'px', 'pt', 'pc' ];

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/context/ContextMenuTriggerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/context/ContextMenuTriggerTest.ts
@@ -2,7 +2,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { isTriggeredByKeyboard } from 'tinymce/themes/silver/ui/menus/contextmenu/SilverContextMenu';
 
 describe('atomic.tinymce.themes.silver.context.ContextMenuTriggerTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/menus/MenuConversionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/menus/MenuConversionTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 import * as MenuConversion from 'tinymce/themes/silver/ui/menus/menu/MenuConversion';
 
 describe('atomic.tinymce.themes.silver.menus.MenuConversionTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/atomic/sizing/ResizeTest.ts
@@ -3,7 +3,7 @@ import { Optional } from '@ephox/katamari';
 import { SugarPosition } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { getDimensions, ResizeTypes } from 'tinymce/themes/silver/ui/sizing/Resize';
 import * as Utils from 'tinymce/themes/silver/ui/sizing/Utils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/DefaultHeightTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/DefaultHeightTest.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.DefaultHeightTest', () => {
   const baseSettings = {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/DisableTest.ts
@@ -5,7 +5,7 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.DisableTest', () => {
   const pAssertUiDisabled = async (editor: Editor, disabled: boolean) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/EventsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/EventsTest.ts
@@ -3,7 +3,7 @@ import { before, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 
 describe('browser.tinymce.themes.silver.editor.EventsTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/MenuGroupHeadingTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.MenuGroupHeadingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/NotificationManagerImplTest.ts
@@ -5,8 +5,8 @@ import { Css, Focus, Height, Remove, Scroll, SugarBody, SugarDocument, SugarElem
 import { TinyContentActions, TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { NotificationApi } from 'tinymce/core/api/NotificationManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { NotificationApi } from 'tinymce/core/api/NotificationManager';
 
 import * as PageScroll from '../../module/PageScroll';
 import { resizeToPos } from '../../module/UiUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ResourceLoadingCssTest.ts
@@ -3,7 +3,7 @@ import { McEditor, TinyDom } from '@ephox/mcagar';
 import { Css } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { tinymce } from 'tinymce/core/api/Tinymce';
 
 describe('browser.tinymce.themes.silver.editor.ResourceLoadingCssTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShadowDomInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShadowDomInlineTest.ts
@@ -2,7 +2,7 @@ import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import * as Options from 'tinymce/themes/silver/api/Options';
 
 describe('browser.tinymce.themes.silver.editor.ShadowDomInlineTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ShowHideTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as UiUtils from '../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogButtonContextTest.ts
@@ -4,8 +4,8 @@ import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 describe('browser.tinymce.themes.silver.editor.SilverDialogButtonContextTest', () => {
   const assertButtonEnabled = (menuItemLabel: string) => UiFinder.notExists(SugarBody.body(), `[aria-label="${menuItemLabel}"][aria-disabled="true"]`);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCancelTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverDialogCancelTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogCloseTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverDialogCloseTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogPopupsTest.ts
@@ -1,11 +1,11 @@
 import { FocusTools, Keys, UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it, TestLabel } from '@ephox/bedrock-client';
-import { Result } from '@ephox/katamari';
+import { before, describe, it, type TestLabel } from '@ephox/bedrock-client';
+import type { Result } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { SelectorExists, SugarBody, SugarDocument, SugarElement, WindowSelection } from '@ephox/sugar';
+import { SelectorExists, SugarBody, SugarDocument, type SugarElement, WindowSelection } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.DialogPopupsTest', () => {
   before(function () {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverDialogTreeTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.DialogTreeTest', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorDirectionalityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorDirectionalityTest.ts
@@ -1,10 +1,10 @@
-import { ApproxStructure, Assertions, StructAssert } from '@ephox/agar';
+import { ApproxStructure, Assertions, type StructAssert } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 describe('browser.tinymce.themes.silver.editor.SilverEditorDirectionalityTest', () => {
   before(() => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverEditorTest.ts
@@ -7,7 +7,7 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverEditorTest', () => {
   const os = PlatformDetection.detect().os;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerPriorityTest.ts
@@ -3,7 +3,7 @@ import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerPriorityTest', () => {
   const toolbar: SugarElement<HTMLDivElement> = SugarElement.fromHtml('<div style="margin: 50px 0;"></div>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
@@ -3,7 +3,7 @@ import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTargetNotInlineTest', () => {
   const toolbar: SugarElement<HTMLDivElement> = SugarElement.fromHtml('<div style="margin: 50px 0;"></div>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetTest.ts
@@ -3,7 +3,7 @@ import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTargetTest', () => {
   const toolbar: SugarElement<HTMLDivElement> = SugarElement.fromHtml('<div style="margin: 50px 0;"></div>');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTest.ts
@@ -3,7 +3,7 @@ import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as UiUtils from '../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorTest.ts
@@ -7,7 +7,7 @@ import { Css, SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as UiUtils from '../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverInlineEditorWidthTest.ts
@@ -1,12 +1,12 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Type } from '@ephox/katamari';
-import { Css, Scroll, SugarBody, SugarElement } from '@ephox/sugar';
+import { Css, Scroll, SugarBody, type SugarElement } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import { ToolbarMode } from 'tinymce/themes/silver/api/Options';
 
 import { pOpenMore } from '../../module/MenuUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverPopupSinkBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverPopupSinkBoundsTest.ts
@@ -1,12 +1,12 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Menu } from '@ephox/bridge';
+import type { Menu } from '@ephox/bridge';
 import { Arr, Fun } from '@ephox/katamari';
 import { Class, Css, Insert, Remove, SugarBody, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface Scenario {
   readonly label: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverPromotionElementTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverPromotionElementTest.ts
@@ -4,7 +4,7 @@ import { SugarElement } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverPromotionElementTest', () => {
   context('editor without menubar', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverRenderTest.ts
@@ -1,11 +1,11 @@
 import { UiFinder } from '@ephox/agar';
 import { after, describe, it } from '@ephox/bedrock-client';
-import { Optional } from '@ephox/katamari';
-import { SugarElement, SugarShadowDom } from '@ephox/sugar';
+import type { Optional } from '@ephox/katamari';
+import { type SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import PluginManager from 'tinymce/core/api/PluginManager';
 
 interface RenderState {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverUiModeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverUiModeTest.ts
@@ -5,7 +5,7 @@ import { Class, Insert, Remove, SelectorFind, Selectors, SugarBody, SugarElement
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.SilverUiModeTest', () => {
   const sharedSettings = {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarBottomTest.ts
@@ -6,8 +6,8 @@ import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 interface Scenario {
   readonly options: RawEditorOptions;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToolbarPersistTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Focus, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.ToolbarPersistTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/ToxWrappingTest.ts
@@ -3,7 +3,7 @@ import { Class, Traverse } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.ToxWrappingTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteAriaTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteAriaTest.ts
@@ -1,11 +1,11 @@
 import { Keys, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Attribute, SelectorFilter, SugarBody, SugarElement } from '@ephox/sugar';
+import { Attribute, SelectorFilter, SugarBody, type SugarElement } from '@ephox/sugar';
 import { TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Assets from '../../../module/Assets';
 import * as AutocompleterUtils from '../../../module/AutocompleterUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteCancelTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Keys, Mouse, StructAssert, Waiter } from '@ephox/agar';
+import { ApproxStructure, Keys, Mouse, type StructAssert, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { pWaitForAutocompleteToClose } from '../../../module/AutocompleterUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteReloadTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteReloadTest.ts
@@ -2,8 +2,8 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj } from '@ephox/katamari';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { InlineContent } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { InlineContent } from 'tinymce/core/api/ui/Ui';
 
 import { pAssertAutocompleterStructure, pWaitForAutocompleteToOpen } from '../../../module/AutocompleterUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/autocomplete/AutocompleteTest.ts
@@ -4,11 +4,11 @@ import { Arr, Throttler, Type } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { getGreenImageDataUrl } from '../../../module/Assets';
 import {
-  AutocompleterStructure, pAssertAutocompleterStructure, pWaitForAutocompleteToClose, pWaitForAutocompleteToOpen
+  type AutocompleterStructure, pAssertAutocompleterStructure, pWaitForAutocompleteToClose, pWaitForAutocompleteToOpen
 } from '../../../module/AutocompleterUtils';
 
 interface TriggerDetails {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageCheckContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageCheckContextTest.ts
@@ -5,7 +5,7 @@ import { Classes, SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import * as Backstage from 'tinymce/themes/silver/backstage/Backstage';
 
 describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
@@ -1,11 +1,11 @@
 import { Assertions, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
-import { AlloyComponent, Attachment, Behaviour, Gui, GuiFactory, Positioning, Representing } from '@ephox/alloy';
+import { type AlloyComponent, Attachment, Behaviour, Gui, GuiFactory, Positioning, Representing } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Fun, Optional, Result } from '@ephox/katamari';
 import { Classes, SugarBody, Traverse } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import * as Backstage from 'tinymce/themes/silver/backstage/Backstage';
 import * as Options from 'tinymce/themes/silver/ui/core/color/Options';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/BespokeSelectAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/BespokeSelectAriaLabelTest.ts
@@ -1,11 +1,11 @@
 import { UiFinder } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { Attribute, SugarBody, SugarElement } from '@ephox/sugar';
+import { Attribute, SugarBody, type SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import * as MenuUtils from '../../../module/MenuUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/SilverBespokeButtonsTest.ts
@@ -5,8 +5,8 @@ import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 import * as MenuUtils from '../../../module/MenuUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/bespoke/StyleSelectFormatNamesTest.ts
@@ -5,7 +5,7 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as MenuUtils from '../../../module/MenuUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/GroupToolbarButtonTest.ts
@@ -1,12 +1,12 @@
-import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, type StructAssert, UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SelectorFilter, SugarBody, TextContent } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 import { extractOnlyOne } from '../../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/UpdateToolbarButtonTextAndIconTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/buttons/UpdateToolbarButtonTextAndIconTest.ts
@@ -4,10 +4,10 @@ import { Css, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyHooks, TinyUi, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
-import { Menu } from 'tinymce/core/api/ui/Ui';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { NodeChangeEvent } from 'tinymce/core/api/EventTypes';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.themes.silver.editor.buttons.UpdateToolbarButtonTextAndIconTest', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorAriaLabelTest.ts
@@ -4,7 +4,7 @@ import { Arr, Fun, Strings } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorCacheTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorCacheTest.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { assert } from 'chai';
 
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 import * as ColorCache from 'tinymce/themes/silver/ui/core/color/ColorCache';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorPickerSanityTest.ts
@@ -1,11 +1,11 @@
 import { FocusTools, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Optional } from '@ephox/katamari';
-import { Attribute, SelectorFilter, SugarDocument, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Arr, type Optional } from '@ephox/katamari';
+import { Attribute, SelectorFilter, SugarDocument, type SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 describe('browser.tinymce.themes.silver.editor.color.ColorPickerSanityTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ColorSettingsTest.ts
@@ -3,7 +3,7 @@ import { Arr } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 import * as Options from 'tinymce/themes/silver/ui/core/color/Options';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/GetCurrentColorTest.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import * as ColorSwatch from 'tinymce/themes/silver/ui/core/color/ColorSwatch';
 
 describe('browser.tinymce.themes.silver.editor.color.GetCurrentColorTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ImageSelectorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/ImageSelectorTest.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TooltipUtils from '../../../module/TooltipUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/NoneditableRootTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.color.NoneditableRootTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorCommandsTest.ts
@@ -3,7 +3,7 @@ import { Cell } from '@ephox/katamari';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorCommandsTest', () => {
   const selectors = {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorFormattingTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Unicode } from '@ephox/katamari';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.color.TextColorFormattingTest', () => {
   const selectors = {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/color/TextColorSanityTest.ts
@@ -4,7 +4,7 @@ import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarShadowDom } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 import * as ColorCache from 'tinymce/themes/silver/ui/core/color/ColorCache';
 import { getColorCols } from 'tinymce/themes/silver/ui/core/color/Options';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormAsSubtoolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormAsSubtoolbarTest.ts
@@ -1,10 +1,10 @@
 import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.ContextFormAsSubtoolbarTest', () => {
   Arr.each([ true, false ], (inline) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTest.ts
@@ -1,12 +1,12 @@
-import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, type StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun, Obj } from '@ephox/katamari';
 import { Attribute, SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.themes.silver.editor.ContextFormTest', () => {
   const store = TestStore();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextFormTextInputTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.ContextFormTextInputTest', () => {
   const store = TestStore();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSizeInputFormTest.ts
@@ -1,11 +1,11 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, type StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.ContextSizeInputFormTest', () => {
   const store = TestStore();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextform/ContextSliderFormTest.ts
@@ -1,11 +1,11 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, type StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { Attribute, SugarBody, SugarDocument, Value } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.ContextSliderFormTest', () => {
   const store = TestStore();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuPositionTest.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 
 import { assertContentMenuPosition, pOpenContextMenu } from '../../../module/ContextMenuUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuSettingsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/ContextMenuSettingsTest.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 
 import Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import * as Options from 'tinymce/themes/silver/ui/menus/contextmenu/Options';
 
 describe('browser.tinymce.themes.silver.editor.contextmenu.ContextMenuSettingsTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/CustomContextMenuTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.contextmenu.CustomContextMenuTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/DesktopContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/DesktopContextMenuTest.ts
@@ -4,7 +4,7 @@ import { Arr } from '@ephox/katamari';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contextmenu/MobileContextMenuTest.ts
@@ -5,7 +5,7 @@ import { PlatformDetection } from '@ephox/sand';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import ImagePlugin from 'tinymce/plugins/image/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarBoundsTest.ts
@@ -1,12 +1,12 @@
-import { Bounds, Boxes } from '@ephox/alloy';
+import { type Bounds, Boxes } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { InlineContent } from '@ephox/bridge';
+import type { InlineContent } from '@ephox/bridge';
 import { Css, Scroll, SelectorFind, SugarBody } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import { getContextToolbarBounds, isVerticalOverlap } from 'tinymce/themes/silver/ui/context/ContextToolbarBounds';
 
 import TestBackstage from '../../../module/TestBackstage';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarDistractionFreePositionTest.ts
@@ -5,7 +5,7 @@ import { Css, Scroll, SugarBody, SugarLocation } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface Scenario {
   readonly content: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarIframePositionTest.ts
@@ -5,7 +5,7 @@ import { Css, Scroll, SugarBody } from '@ephox/sugar';
 import { TinyContentActions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 
 import { getGreenImageDataUrl } from '../../../module/Assets';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarInlinePositionTest.ts
@@ -5,7 +5,7 @@ import { Css, Scroll, SugarBody, SugarLocation } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface Scenario {
   readonly content: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPositionPriorityTest.ts
@@ -1,9 +1,9 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { InlineContent } from '@ephox/bridge';
+import type { InlineContent } from '@ephox/bridge';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { assert } from 'chai';
 
-import { ContextType } from 'tinymce/themes/silver/ui/context/ContextToolbar';
+import type { ContextType } from 'tinymce/themes/silver/ui/context/ContextToolbar';
 import { filterByPositionForAncestorNode, filterByPositionForStartNode } from 'tinymce/themes/silver/ui/context/ContextToolbarLookup';
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLookupPositionPriorityTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupPrioritisationTest.ts
@@ -1,10 +1,10 @@
 import { describe, it } from '@ephox/bedrock-client';
-import { InlineContent } from '@ephox/bridge';
+import type { InlineContent } from '@ephox/bridge';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { ContextType } from 'tinymce/themes/silver/ui/context/ContextToolbar';
+import type { ContextType } from 'tinymce/themes/silver/ui/context/ContextToolbar';
 import { matchStartNode } from 'tinymce/themes/silver/ui/context/ContextToolbarLookup';
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLookupPrioritisationTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLookupTest.ts
@@ -5,7 +5,7 @@ import { Focus, SelectorFind, SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 // TODO TINY-10480: Investigate flaky tests
 describe.skip('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLookupTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarTest.ts
@@ -4,7 +4,7 @@ import { Css, SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarTest', () => {
   const store = TestStore();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/RemoveContextToolbarOnFocusoutTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { Focus, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { McEditor, TinySelections } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 // TODO TINY-10480: Investigate flaky tests
 describe.skip('browser.tinymce.themes.silver.editor.contexttoolbar.RemoveContextToolbarOnFocusoutTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/AlignmentButtonsTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { extractOnlyOne } from '../../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ChoiceControlsTest.ts
@@ -6,7 +6,7 @@ import { Attribute, SugarBody } from '@ephox/sugar';
 import { McEditor, TinyAssertions, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface ToolbarOrMenuSpec {
   readonly name: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ContentLanguageHiddenTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/ContentLanguageHiddenTest.ts
@@ -2,7 +2,7 @@ import { UiFinder } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.core.ContentLanguageHiddenTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/PasteControlsTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.core.PasteControlsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/SimpleControlsTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.core.SimpleControlsTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/core/UndoRedoTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.core.UndoRedoTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/HeaderLocationTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.header.HeaderLocationTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/InlineHeaderTest.ts
@@ -4,7 +4,7 @@ import { Css, Insert, Remove, Scroll, SelectorFind, SugarBody, SugarElement, Sug
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.header.InlineHeaderTest', () => {
   context('horizontal ', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/PromotionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/PromotionTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SelectorFind } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.header.PromotionTest', () => {
   const promotionSelector = '.tox-promotion';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderInitialPlacementTest.ts
@@ -2,7 +2,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { McEditor } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { ToolbarLocation } from 'tinymce/themes/silver/api/Options';
 
 import * as StickyUtils from '../../../module/StickyHeaderUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderScrollIntoViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/header/StickyHeaderScrollIntoViewTest.ts
@@ -1,10 +1,10 @@
 import { Cursors, Waiter } from '@ephox/agar';
 import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { Scroll, SugarLocation, SugarPosition } from '@ephox/sugar';
+import { Scroll, SugarLocation, type SugarPosition } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import * as ScrollIntoView from 'tinymce/core/dom/ScrollIntoView';
 
 // TODO TINY-10480: Investigate flaky tests

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenuItemContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenuItemContextTest.ts
@@ -5,7 +5,7 @@ import { Attribute, SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.EditorMenuItemContextTest', () => {
   const assertMenuEnabled = (menu: string) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarButtonContextTest.ts
@@ -4,7 +4,7 @@ import { Attribute, SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarButtonContextTest', () => {
   const assertMenuEnabled = (menu: string) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarOptionsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarOptionsTest.ts
@@ -1,11 +1,11 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { countNumber, extractOnlyOne } from '../../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/menubar/EditorMenubarRenderTest.ts
@@ -4,7 +4,7 @@ import { Css } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.menubar.EditorMenubarRenderTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/scrolling/EditorInScrollingContainerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/scrolling/EditorInScrollingContainerTest.ts
@@ -5,7 +5,7 @@ import { Class, Css, Html, Insert, InsertAll, Remove, SelectorFind, SugarBody, S
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface TestUi {
   readonly className: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/GridSinkSizingTest.ts
@@ -4,7 +4,7 @@ import { Insert, Remove, SugarBody, SugarElement, SugarHead, TextContent, Width 
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.sizing.GridSinkSizingTest', () => {
   let style: SugarElement<HTMLStyleElement>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeNotInRootTest.ts
@@ -4,7 +4,7 @@ import { Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 // TODO TINY-10480: Investigate flaky tests
 describe.skip('browser.tinymce.themes.silver.editor.sizing.ResizeNotInRootTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/sizing/ResizeTest.ts
@@ -4,7 +4,7 @@ import { Css, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { resizeToPos } from '../../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarOptionsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/EditorToolbarOptionsTest.ts
@@ -1,11 +1,11 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { countNumber, extractOnlyOne } from '../../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarDrawerFloatingPositionTest.ts
@@ -5,8 +5,8 @@ import { Css, SugarBody, SugarLocation } from '@ephox/sugar';
 import { McEditor, TinyContentActions, TinyDom, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 import { pAssertFloatingToolbarPosition, pOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/InlineToolbarPositionTest.ts
@@ -6,7 +6,7 @@ import { Class, Css, Insert, Remove, SelectorFind, SugarBody, SugarDocument, Sug
 import { TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as PageScroll from '../../../module/PageScroll';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleInlineToolbarVisibilityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleInlineToolbarVisibilityTest.ts
@@ -2,7 +2,7 @@ import { Assert, describe, it } from '@ephox/bedrock-client';
 import { Css } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 // TODO TINY-10480: Investigate flaky tests
 describe.skip('browser.tinymce.themes.silver.editor.toolbar.MultipleInlineToolbarVisibilityTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleSplitButtonPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/MultipleSplitButtonPositionTest.ts
@@ -5,7 +5,7 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.MultipleSplitButtonPositionTest', () => {
   context('Multiple split buttons positioning', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/NumberInputTest.ts
@@ -1,12 +1,12 @@
 import { FocusTools, Keys, Mouse, UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional, Strings } from '@ephox/katamari';
-import { SugarBody, SugarElement, SugarShadowDom, Value } from '@ephox/sugar';
+import { SugarBody, type SugarElement, SugarShadowDom, Value } from '@ephox/sugar';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
 
 describe('browser.tinymce.themes.silver.throbber.NumberInputTest', () => {
   const setInputSelection = (toolbarInput: Optional<HTMLInputElement>, index: number) => toolbarInput.each((input) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ReadonlyToolbarResizeTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Css, SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import AdvListPlugin from 'tinymce/plugins/advlist/Plugin';
 import ListsPlugin from 'tinymce/plugins/lists/Plugin';
 import { ToolbarMode } from 'tinymce/themes/silver/api/Options';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitButtonPopupPositionWithFullscreenTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitButtonPopupPositionWithFullscreenTest.ts
@@ -3,7 +3,7 @@ import { Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.SplitButtonPopupPositionWithFullscreenTest', () => {
   context('in scrollable container', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/SplitFloatingToolbarKeyboardNavigationTest.ts
@@ -4,7 +4,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/mcagar';
 import { Attribute, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.SplitFloatingToolbarKeyboardNavigationTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/TabStoppingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/TabStoppingTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.TabStoppingTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -4,7 +4,7 @@ import { Arr, Fun, Type } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Assets from '../../../module/Assets';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerFloatingPositionTest.ts
@@ -4,7 +4,7 @@ import { PlatformDetection } from '@ephox/sand';
 import { Css, Insert, Remove, Scroll, SugarBody, SugarElement, SugarLocation } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import { pAssertFloatingToolbarHeight, pOpenFloatingToolbarAndAssertPosition } from '../../../module/ToolbarUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarDrawerToggleTest.ts
@@ -5,8 +5,8 @@ import { SugarDocument } from '@ephox/sugar';
 import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions, ToolbarMode } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions, ToolbarMode } from 'tinymce/core/api/OptionTypes';
 
 import * as UiUtils from '../../../module/UiUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarFocusTest.ts
@@ -3,8 +3,8 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
 import { McEditor, TinyContentActions, TinyDom, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarFocusTest', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarOverflowContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarOverflowContextTest.ts
@@ -4,8 +4,8 @@ import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { ToolbarMode } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { ToolbarMode } from 'tinymce/core/api/OptionTypes';
 
 import * as Assets from '../../../module/Assets';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/AutocompleterTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/AutocompleterTooltipTest.ts
@@ -4,7 +4,7 @@ import { Arr, Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyContentActions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as Assets from '../../../module/Assets';
 import * as AutocompleterUtils from '../../../module/AutocompleterUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/CollectionTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/CollectionTooltipTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import CharmapPlugin from 'tinymce/plugins/charmap/Plugin';
 import EmoticonsPlugin from 'tinymce/plugins/emoticons/Plugin';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/DynamicTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/DynamicTooltipTest.ts
@@ -1,10 +1,10 @@
 import { UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipShortcutTest.ts
@@ -3,7 +3,7 @@ import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import SavePlugin from 'tinymce/plugins/save/Plugin';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/tooltip/TooltipTest.ts
@@ -1,11 +1,11 @@
 import { Keys, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { SugarElement, TextContent } from '@ephox/sugar';
+import { type SugarElement, TextContent } from '@ephox/sugar';
 import { TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface EditorWithTestApis extends Editor {
   testSplitButtonApi?: () => Optional<any>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/icons/IconsTest.ts
@@ -1,11 +1,11 @@
-import { SimpleOrSketchSpec } from '@ephox/alloy';
+import type { SimpleOrSketchSpec } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { getAll as getAllOxide } from '@tinymce/oxide-icons-default';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 import * as Icons from 'tinymce/themes/silver/ui/icons/Icons';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarRoleAttributeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarRoleAttributeTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const enum SidebarStateRoleAttr {
   Grown = 'region',

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarShowOptionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarShowOptionTest.ts
@@ -1,10 +1,10 @@
 import { TestStore, UiFinder } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
-import { Sidebar } from '@ephox/bridge';
+import type { Sidebar } from '@ephox/bridge';
 import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { McEditor, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 interface EventLog {
   readonly name: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -4,8 +4,8 @@ import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Sidebar } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Sidebar } from 'tinymce/core/api/ui/Ui';
 
 interface EventLog {
   readonly name: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideBlockedDialogTest.ts
@@ -3,8 +3,8 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 describe('browser.tinymce.themes.silver.skin.OxideBlockedDialogTest', () => {
   let testDialogApi: Dialog.DialogInstanceApi<{}>;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideCollectionComponentTest.ts
@@ -1,11 +1,11 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, type StructAssert, UiFinder } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Optional, Optionals } from '@ephox/katamari';
-import { Attribute, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { Attribute, SugarBody, SugarDocument, type SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as GuiSetup from '../../module/GuiSetup';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -1,11 +1,11 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, type StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
 
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideFontFormatMenuTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as GuiSetup from '../../module/GuiSetup';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideGridCollectionMenuTest.ts
@@ -4,8 +4,8 @@ import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 
 import * as GuiSetup from '../../module/GuiSetup';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideListCollectionMenuTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as GuiSetup from '../../module/GuiSetup';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideTablePickerMenuTest.ts
@@ -1,11 +1,11 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Menu } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Menu } from 'tinymce/core/api/ui/Ui';
 
 const tableCellsApprox = (s: ApproxStructure.StructApi, str: ApproxStructure.StringApi, arr: ApproxStructure.ArrayApi, selectedRows: number, selectedCols: number) => {
   const cells: StructAssert[] = [];

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideToolbarCollectionMenuTest.ts
@@ -4,7 +4,7 @@ import { Arr } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.skin.OxideToolbarCollectionMenuTest', () => {
   const store = TestStore();

--- a/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
+import type Editor from 'tinymce/core/api/Editor';
+import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 import WordcountPlugin from 'tinymce/plugins/wordcount/Plugin';
 
 describe('browser.tinymce.themes.silver.statusbar.StatusbarTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberEditorTest.ts
@@ -5,7 +5,7 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberEditorTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberFocusTest.ts
@@ -4,7 +4,7 @@ import { Focus, Insert, Remove, SelectorFind, SugarBody, SugarDocument, SugarEle
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 // TODO TINY-10480: Investigate flaky tests
 describe.skip('browser.tinymce.themes.silver.throbber.ThrobberFocusTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberPopupTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { Class, Focus, Insert, Remove, SugarBody, SugarElement, SugarNode } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberPopupTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/throbber/ThrobberTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.throbber.ThrobberTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsContextTest.ts
@@ -5,7 +5,7 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.view.ViewButtonsContextTest', () => {
   afterEach(() => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewButtonsTest.ts
@@ -5,7 +5,7 @@ import { Class, SugarDocument } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { ViewButtonClasses } from 'tinymce/themes/silver/ui/toolbar/button/ButtonClasses';
 
 describe('browser.tinymce.themes.silver.view.ViewButtonsTest', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/view/ViewTest.ts
@@ -1,12 +1,12 @@
-import { ApproxStructure, Assertions, FocusTools, Keys, StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, Keys, type StructAssert, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
 import { Attribute, Css, Html, Scroll, SugarBody, SugarShadowDom } from '@ephox/sugar';
 import { TinyApis, TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { View } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { View } from 'tinymce/core/api/ui/Ui';
 
 describe('browser.tinymce.themes.silver.view.ViewTest', () => {
   context('Iframe mode', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogApiAccessTest.ts
@@ -5,8 +5,8 @@ import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as DialogUtils from '../../module/DialogUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogAriaLabelTest.ts
@@ -2,12 +2,12 @@ import { UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute, SugarBody, SugarDocument, SugarElement, TextContent } from '@ephox/sugar';
+import { Attribute, SugarBody, SugarDocument, type SugarElement, TextContent } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as DialogUtils from '../../module/DialogUtils';
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBeforeEditorRenderedTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBeforeEditorRenderedTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.window.SilverDialogBeforeEditorRenderedTest', () => {
   const hook = TinyHooks.bddSetupLight<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogBlockTest.ts
@@ -5,8 +5,8 @@ import { Attribute, Height, SelectorFind, SugarBody, SugarDocument, SugarElement
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import * as DialogUtils from '../../module/DialogUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogFooterTest.ts
@@ -3,8 +3,8 @@ import { describe, context, it, afterEach, beforeEach } from '@ephox/bedrock-cli
 import { Singleton } from '@ephox/katamari';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 type ButtonName = 'buttons-undefined' | 'buttons-empty' | 'buttons-nonempty';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogPositioningTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogPositioningTest.ts
@@ -1,13 +1,13 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowParams } from 'tinymce/core/api/WindowManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowParams } from 'tinymce/core/api/WindowManager';
 
 import * as DialogUtils from '../../module/DialogUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverDialogSliderApiTest.ts
@@ -5,8 +5,8 @@ import { SugarDocument } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as DialogUtils from '../../module/DialogUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPersistenceTest.ts
@@ -4,8 +4,8 @@ import { Arr } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as DialogUtils from '../../module/DialogUtils';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogPositionTest.ts
@@ -6,8 +6,8 @@ import { Class, Css, Height, Insert, Remove, Scroll, SugarBody, SugarElement, Tr
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
 
 import * as DialogUtils from '../../module/DialogUtils';
 import * as PageScroll from '../../module/PageScroll';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/window/SilverInlineDialogTest.ts
@@ -5,9 +5,9 @@ import { SugarBody, SugarDocument, Css } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowParams } from 'tinymce/core/api/WindowManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowParams } from 'tinymce/core/api/WindowManager';
 
 import * as DialogUtils from '../../module/DialogUtils';
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/BasicCheckboxTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Keyboard, Keys, UiFinder } from '@ephox/agar';
-import { AlloyComponent, Disabling, Form, GuiFactory, Representing } from '@ephox/alloy';
+import { type AlloyComponent, Disabling, Form, GuiFactory, Representing } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { assert } from 'chai';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/checkbox/CheckboxFormChangeTest.ts
@@ -1,10 +1,10 @@
-import { FocusTools, Keyboard, Keys, TestStore } from '@ephox/agar';
+import { FocusTools, Keyboard, Keys, type TestStore } from '@ephox/agar';
 import { AddEventsBehaviour, AlloyEvents, Behaviour, GuiFactory } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 
 import { renderCheckbox } from 'tinymce/themes/silver/ui/general/Checkbox';
-import { FormChangeEvent, formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
+import { type FormChangeEvent, formChangeEvent } from 'tinymce/themes/silver/ui/general/FormEvents';
 
 import * as GuiSetup from '../../../module/GuiSetup';
 import TestProviders from '../../../module/TestProviders';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorinput/ColorInputTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinder, Waiter } from '@ephox/agar';
-import { AlloyComponent, AlloyTriggers, Container, GuiFactory, Invalidating, NativeEvents, Representing } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, Container, GuiFactory, Invalidating, NativeEvents, Representing } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 import { SelectorFind, SugarDocument, Traverse } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/colorpicker/ColorPickerTest.ts
@@ -1,9 +1,9 @@
 import { HsvColour } from '@ephox/acid';
 import { UiControls, UiFinder, Waiter } from '@ephox/agar';
-import { AlloyComponent, GuiFactory } from '@ephox/alloy';
+import { type AlloyComponent, GuiFactory } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { renderColorPicker } from 'tinymce/themes/silver/ui/dialog/ColorPicker';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/customeditor/BasicCustomEditorTest.ts
@@ -5,7 +5,7 @@ import { Cell, Fun, Global, Optional } from '@ephox/katamari';
 import { Class, SugarElement } from '@ephox/sugar';
 
 import Resource from 'tinymce/core/api/Resource';
-import { TinyMCE } from 'tinymce/core/api/Tinymce';
+import type { TinyMCE } from 'tinymce/core/api/Tinymce';
 import { renderCustomEditor } from 'tinymce/themes/silver/ui/dialog/CustomEditor';
 
 import * as GuiSetup from '../../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/grid/BasicGridTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/grid/BasicGridTest.ts
@@ -3,7 +3,7 @@ import { GuiFactory } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 
-import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderGrid } from 'tinymce/themes/silver/ui/dialog/Grid';
 
 import * as GuiSetup from '../../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/htmlpanel/HtmlPanelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/htmlpanel/HtmlPanelTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions } from '@ephox/agar';
 import { GuiFactory } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Singleton } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { renderHtmlPanel } from 'tinymce/themes/silver/ui/general/HtmlPanel';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/iframe/IframeTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Waiter } from '@ephox/agar';
-import { AlloyComponent, Composing, Container, GuiFactory, Representing } from '@ephox/alloy';
+import { type AlloyComponent, Composing, Container, GuiFactory, Representing } from '@ephox/alloy';
 import { describe, context, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
 import { assert } from 'chai';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/imagepreview/BasicImagePreviewTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/imagepreview/BasicImagePreviewTest.ts
@@ -1,11 +1,11 @@
 import { ApproxStructure, Assertions, UiFinder } from '@ephox/agar';
-import { AlloyComponent, GuiFactory, Memento, Representing } from '@ephox/alloy';
+import { type AlloyComponent, GuiFactory, Memento, Representing } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { Ready } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { ImagePreviewDataSpec, renderImagePreview } from 'tinymce/themes/silver/ui/dialog/ImagePreview';
+import { type ImagePreviewDataSpec, renderImagePreview } from 'tinymce/themes/silver/ui/dialog/ImagePreview';
 
 import * as GuiSetup from '../../../module/GuiSetup';
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/label/LabelTest.ts
@@ -1,9 +1,9 @@
 import { ApproxStructure, Assertions } from '@ephox/agar';
-import { AlloyComponent, GuiFactory, Memento } from '@ephox/alloy';
+import { type AlloyComponent, GuiFactory, Memento } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
 
-import { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageShared } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderLabel } from 'tinymce/themes/silver/ui/dialog/Label';
 
 import * as GuiSetup from '../../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/listbox/ListBoxTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, UiFinder } from '@ephox/agar';
-import { AlloyComponent, Disabling, GuiFactory, Representing } from '@ephox/alloy';
+import { type AlloyComponent, Disabling, GuiFactory, Representing } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 import { Attribute } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/sizeinput/SizeInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/sizeinput/SizeInputTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, FocusTools, Mouse, UiFinder } from '@ephox/agar';
-import { AlloyComponent, GuiFactory, NativeEvents, Representing } from '@ephox/alloy';
+import { type AlloyComponent, GuiFactory, NativeEvents, Representing } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/tree/TreeTest.ts
@@ -1,5 +1,5 @@
 import { ApproxStructure, Assertions, FocusTools, Keys, Mouse, UiFinder } from '@ephox/agar';
-import { AlloyComponent, AlloyTriggers, GuiFactory, NativeEvents } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers, GuiFactory, NativeEvents } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { StructureSchema } from '@ephox/boulder';
 import { Dialog } from '@ephox/bridge';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/components/urlinput/UrlInputTest.ts
@@ -1,12 +1,12 @@
-import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, TestStore, UiControls, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, Keyboard, Keys, Mouse, type TestStore, UiControls, UiFinder, Waiter } from '@ephox/agar';
 import { Container, Disabling, Focusing, GuiFactory, Representing } from '@ephox/alloy';
 import { beforeEach, describe, it } from '@ephox/bedrock-client';
 import { Future, Optional } from '@ephox/katamari';
 import { Attribute, SelectorFind, SugarDocument, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
-import { LinkTargetType } from 'tinymce/themes/silver/ui/core/LinkTargets';
+import type { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
+import type { LinkTargetType } from 'tinymce/themes/silver/ui/core/LinkTargets';
 import { renderUrlInput } from 'tinymce/themes/silver/ui/dialog/UrlInput';
 
 import * as GuiSetup from '../../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/ScrollingContextTest.ts
@@ -1,5 +1,5 @@
 import { Cursors } from '@ephox/agar';
-import { Boxes } from '@ephox/alloy';
+import type { Boxes } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { Css, Insert, InsertAll, Remove, SugarBody, SugarElement } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/modes/UiReferencesTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/modes/UiReferencesTest.ts
@@ -4,7 +4,7 @@ import { Arr } from '@ephox/katamari';
 import { Class, Classes } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { LazyUiReferences, SinkAndMothership } from 'tinymce/themes/silver/modes/UiReferences';
+import { LazyUiReferences, type SinkAndMothership } from 'tinymce/themes/silver/modes/UiReferences';
 
 describe('headless.modes.UiReferencesTest', () => {
   context('getUiMotherships', () => {

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/SearchableMenuButtonTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, FocusTools, Keyboard, Keys, Mouse, UiFinde
 import { AlloyTriggers, GuiFactory, NativeEvents } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
-import { Attribute, SugarDocument, SugarElement } from '@ephox/sugar';
+import { Attribute, SugarDocument, type SugarElement } from '@ephox/sugar';
 
 import { renderMenuButton } from 'tinymce/themes/silver/ui/button/MenuButton';
 

--- a/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/toolbar/ToolbarButtonsTest.ts
@@ -1,7 +1,7 @@
 import { ApproxStructure, Assertions, Mouse, Waiter } from '@ephox/agar';
-import { AlloyComponent, GuiFactory } from '@ephox/alloy';
+import { type AlloyComponent, GuiFactory } from '@ephox/alloy';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { Menu, Toolbar } from '@ephox/bridge';
+import type { Menu, Toolbar } from '@ephox/bridge';
 import { Cell, Fun, Optional } from '@ephox/katamari';
 import { Attribute, Class, SelectorFind } from '@ephox/sugar';
 import { assert } from 'chai';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/CustomDialogTest.ts
@@ -1,10 +1,10 @@
 import { FocusTools, Keyboard, Keys, Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { Checked, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { Checked, SugarBody, SugarDocument, type SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogEventTest.ts
@@ -1,13 +1,13 @@
-import { Mouse, TestStore, UiFinder, Waiter } from '@ephox/agar';
-import { AlloyComponent, Behaviour, GuiFactory, ModalDialog, Positioning, TooltippingTypes } from '@ephox/alloy';
+import { Mouse, type TestStore, UiFinder, Waiter } from '@ephox/agar';
+import { type AlloyComponent, Behaviour, GuiFactory, ModalDialog, Positioning, type TooltippingTypes } from '@ephox/alloy';
 import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { ValueType } from '@ephox/boulder';
-import { DialogManager } from '@ephox/bridge';
+import type { DialogManager } from '@ephox/bridge';
 import { Fun, Optional, Result } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 
 import I18n from 'tinymce/core/api/util/I18n';
-import { UiFactoryBackstage, UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstage, UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 import { renderDialog } from 'tinymce/themes/silver/ui/window/SilverDialog';
 
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogForLabelTest.ts
@@ -3,7 +3,7 @@ import { before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogReuseTest.ts
@@ -1,12 +1,12 @@
-import { ApproxStructure, Assertions, FocusTools, StructAssert, TestStore, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, type StructAssert, TestStore, UiFinder } from '@ephox/agar';
 import { afterEach, before, describe, it } from '@ephox/bedrock-client';
-import { Dialog as BridgeSpec } from '@ephox/bridge';
+import type { Dialog as BridgeSpec } from '@ephox/bridge';
 import { Optional } from '@ephox/katamari';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverDialogTest.ts
@@ -3,8 +3,8 @@ import { before, describe, it } from '@ephox/bedrock-client';
 import { SugarBody, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverUrlDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/SilverUrlDialogTest.ts
@@ -2,8 +2,8 @@ import { ApproxStructure, Assertions, Mouse, TestStore, UiFinder, Waiter } from 
 import { before, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/TabbedDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/TabbedDialogTest.ts
@@ -1,9 +1,9 @@
-import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, type StructAssert, UiFinder } from '@ephox/agar';
 import { before, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
 
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerAlertTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerAlertTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { SelectorFind, SugarBody, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerConfirmTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerConfirmTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { SelectorFind, SugarBody, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerRedialTest.ts
@@ -3,8 +3,8 @@ import { before, describe, it } from '@ephox/bedrock-client';
 import { SugarBody, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/headless/window/WindowManagerTest.ts
@@ -1,11 +1,11 @@
-import { ApproxStructure, Assertions, Mouse, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, Mouse, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Fun } from '@ephox/katamari';
-import { SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { SelectorFind, SugarBody, type SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowManagerImpl, WindowParams } from 'tinymce/core/api/WindowManager';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowManagerImpl, WindowParams } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as TestExtras from '../../module/TestExtras';

--- a/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/AutocompleterUtils.ts
@@ -1,6 +1,6 @@
-import { ApproxStructure, Assertions, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { Arr, Type } from '@ephox/katamari';
-import { SugarBody, SugarElement } from '@ephox/sugar';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
 
 interface TitleWithTextItem {
   readonly title: string;
@@ -140,14 +140,5 @@ const pAssertAutocompleterStructure = async (structure: AutocompleterStructure):
   );
 };
 
-export {
-  AutocompleterGridStructure,
-  AutocompleterListStructure,
-  AutocompleterStructure,
-  pAssertAutocompleterStructure,
-  structWithTitleAndIcon,
-  structWithTitleAndIconAndText,
-  structWithTitleAndText,
-  pWaitForAutocompleteToClose,
-  pWaitForAutocompleteToOpen
-};
+export type { AutocompleterGridStructure, AutocompleterListStructure, AutocompleterStructure };
+export { pAssertAutocompleterStructure, structWithTitleAndIcon, structWithTitleAndIconAndText, structWithTitleAndText, pWaitForAutocompleteToClose, pWaitForAutocompleteToOpen };

--- a/modules/tinymce/src/themes/silver/test/ts/module/CommonMailMergeFetch.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/CommonMailMergeFetch.ts
@@ -1,5 +1,5 @@
-import { TestStore } from '@ephox/agar';
-import { Menu, Toolbar } from '@ephox/bridge';
+import type { TestStore } from '@ephox/agar';
+import type { Menu, Toolbar } from '@ephox/bridge';
 import { Arr } from '@ephox/katamari';
 
 export const fetchMailMergeData = (settings: { collapseSearchResults: boolean }, store: TestStore): Toolbar.ToolbarMenuButtonSpec['fetch'] => (callback, fetchContext) => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/CommonMenuTestStructures.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/CommonMenuTestStructures.ts
@@ -1,7 +1,7 @@
 // This is just a set of basic menu structures for quickly creating ApproxStructures.
 
-import { ApproxStructure, StructAssert } from '@ephox/agar';
-import { Optional } from '@ephox/katamari';
+import { ApproxStructure, type StructAssert } from '@ephox/agar';
+import type { Optional } from '@ephox/katamari';
 
 const structMenuWith = (state: { selected: boolean }, children: StructAssert[]): StructAssert => ApproxStructure.build(
   (s, str, arr) => s.element('div', {

--- a/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ContextMenuUtils.ts
@@ -3,7 +3,7 @@ import { Css, SugarBody } from '@ephox/sugar';
 import { TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const pOpenContextMenu = async (editor: Editor, selector: string): Promise<void> => {
   await TinyUiActions.pTriggerContextMenu(editor, selector, '.tox-silver-sink .tox-menu.tox-collection [role="menuitem"]');

--- a/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DialogUtils.ts
@@ -1,10 +1,10 @@
-import { TestStore, UiFinder } from '@ephox/agar';
+import { type TestStore, UiFinder } from '@ephox/agar';
 import { SugarBody } from '@ephox/sugar';
 import { TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowParams } from 'tinymce/core/api/WindowManager';
+import type Editor from 'tinymce/core/api/Editor';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowParams } from 'tinymce/core/api/WindowManager';
 
 const open = <T extends Dialog.DialogData>(editor: Editor, spec: Dialog.DialogSpec<T>, params: WindowParams): Dialog.DialogInstanceApi<T> =>
   editor.windowManager.open(spec, params);

--- a/modules/tinymce/src/themes/silver/test/ts/module/DomUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/DomUtils.ts
@@ -1,5 +1,5 @@
 import { FocusTools, UiFinder } from '@ephox/agar';
-import { AlloyComponent, AlloyTriggers } from '@ephox/alloy';
+import { type AlloyComponent, AlloyTriggers } from '@ephox/alloy';
 import { Traverse, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/GuiSetup.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/GuiSetup.ts
@@ -1,7 +1,7 @@
 import { Assertions, Pipeline, Step, TestLogs, TestStore } from '@ephox/agar';
-import { AlloyComponent, Attachment, Gui } from '@ephox/alloy';
+import { type AlloyComponent, Attachment, Gui } from '@ephox/alloy';
 import { Fun, Global, Merger, Obj, Optional, Type } from '@ephox/katamari';
-import { DomEvent, EventUnbinder, Html, Insert, Remove, SugarBody, SugarDocument, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
+import { DomEvent, type EventUnbinder, Html, Insert, Remove, SugarBody, SugarDocument, SugarElement, SugarShadowDom, Traverse } from '@ephox/sugar';
 
 type RootNode = SugarShadowDom.RootNode;
 type ContentContainer<T extends RootNode> = T extends ShadowRoot ? ShadowRoot : HTMLElement;

--- a/modules/tinymce/src/themes/silver/test/ts/module/PageScroll.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/PageScroll.ts
@@ -3,7 +3,7 @@ import { Fun } from '@ephox/katamari';
 import { Insert, Remove, SugarElement } from '@ephox/sugar';
 import { TinyDom } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const createScrollDiv = (height: number) =>
   SugarElement.fromHtml<HTMLElement>(`<div style="height: ${height}px;" tabindex="0" class="scroll-div"></div>`);

--- a/modules/tinymce/src/themes/silver/test/ts/module/RepresentingUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/RepresentingUtils.ts
@@ -1,4 +1,4 @@
-import { AlloyComponent, Composing, Representing } from '@ephox/alloy';
+import { type AlloyComponent, Composing, Representing } from '@ephox/alloy';
 import { assert } from 'chai';
 
 const assertComposedValue = (component: AlloyComponent, expected: any): void => {

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderStep.ts
@@ -5,7 +5,7 @@ import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import FullscreenPlugin from 'tinymce/plugins/fullscreen/Plugin';
 import { ToolbarLocation, ToolbarMode } from 'tinymce/themes/silver/api/Options';
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/StickyHeaderUtils.ts
@@ -1,6 +1,6 @@
-import { ApproxStructure, Assertions, Keyboard, Keys, StructAssert, UiFinder, Waiter } from '@ephox/agar';
+import { ApproxStructure, Assertions, Keyboard, Keys, type StructAssert, UiFinder, Waiter } from '@ephox/agar';
 import { Arr, Fun } from '@ephox/katamari';
-import { Css, Focus, Scroll, SugarBody, SugarDocument, SugarElement } from '@ephox/sugar';
+import { Css, Focus, Scroll, SugarBody, SugarDocument, type SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import { ToolbarLocation } from 'tinymce/themes/silver/api/Options';

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestBackstage.ts
@@ -1,9 +1,9 @@
-import { AlloyComponent, GuiFactory, HotspotAnchorSpec, TooltippingTypes } from '@ephox/alloy';
+import { type AlloyComponent, GuiFactory, type HotspotAnchorSpec, type TooltippingTypes } from '@ephox/alloy';
 import { Cell, Fun, Future, Optional, Result } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 
-import { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
-import { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
+import type { UiFactoryBackstage } from 'tinymce/themes/silver/backstage/Backstage';
+import type { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
 
 import TestProviders from './TestProviders';
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestExtras.ts
@@ -1,10 +1,10 @@
 import { Attachment, Behaviour, DomFactory, Gui, GuiFactory, Positioning } from '@ephox/alloy';
 import { after, afterEach, before } from '@ephox/bedrock-client';
 import { Fun, Optional } from '@ephox/katamari';
-import { Class, SugarBody, SugarElement } from '@ephox/sugar';
+import { Class, SugarBody, type SugarElement } from '@ephox/sugar';
 
-import Editor from 'tinymce/core/api/Editor';
-import { UiFactoryBackstagePair } from 'tinymce/themes/silver/backstage/Backstage';
+import type Editor from 'tinymce/core/api/Editor';
+import type { UiFactoryBackstagePair } from 'tinymce/themes/silver/backstage/Backstage';
 
 import TestBackstage from './TestBackstage';
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TestProviders.ts
@@ -1,8 +1,8 @@
-import { TooltippingTypes } from '@ephox/alloy';
+import type { TooltippingTypes } from '@ephox/alloy';
 import { Fun } from '@ephox/katamari';
 
 import I18n from 'tinymce/core/api/util/I18n';
-import { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
+import type { UiFactoryBackstageProviders } from 'tinymce/themes/silver/backstage/Backstage';
 
 const defaultOptions: Record<string, any> = {
   images_file_types: 'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp'

--- a/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/ToolbarUtils.ts
@@ -1,10 +1,10 @@
 import { Waiter } from '@ephox/agar';
 import { Type } from '@ephox/katamari';
-import { Height, SugarElement, SugarLocation, Width } from '@ephox/sugar';
+import { Height, type SugarElement, SugarLocation, Width } from '@ephox/sugar';
 import { TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import { ToolbarMode } from 'tinymce/themes/silver/api/Options';
 
 import { pCloseMore, pOpenMore } from './MenuUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/TooltipUtils.ts
@@ -1,9 +1,9 @@
 import { FocusTools, Mouse, UiFinder, Waiter } from '@ephox/agar';
-import { SelectorFilter, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { SelectorFilter, SugarBody, type SugarElement, TextContent } from '@ephox/sugar';
 import { TinyUiActions } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const tooltipSelector = '.tox-silver-sink .tox-tooltip__body';
 

--- a/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/module/UiUtils.ts
@@ -1,9 +1,9 @@
 import { Mouse, UiFinder, Waiter } from '@ephox/agar';
 import { Arr } from '@ephox/katamari';
-import { Scroll, SugarBody, SugarElement } from '@ephox/sugar';
+import { Scroll, SugarBody, type SugarElement } from '@ephox/sugar';
 import { TinyDom } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 const countNumber = (container: SugarElement<Node>, selector: string): number => {
   const ts = UiFinder.findAllIn(container, selector);

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/components/urlinput/UrlInputTest.ts
@@ -5,7 +5,7 @@ import { Future, Optional } from '@ephox/katamari';
 import { SelectorFind, SugarDocument, Value } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
+import type { ApiUrlData } from 'tinymce/themes/silver/backstage/UrlInputBackstage';
 import { renderUrlInput } from 'tinymce/themes/silver/ui/dialog/UrlInput';
 
 import * as GuiSetup from '../../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/DialogFocusTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/DialogFocusTest.ts
@@ -4,7 +4,7 @@ import { Fun } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { SugarDocument } from '@ephox/sugar';
 
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/IFrameDialogTest.ts
@@ -5,8 +5,8 @@ import { PlatformDetection } from '@ephox/sand';
 import { Focus, SelectorFind, SugarDocument } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import { Dialog } from 'tinymce/core/api/ui/Ui';
-import { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
+import type { Dialog } from 'tinymce/core/api/ui/Ui';
+import type { WindowManagerImpl } from 'tinymce/core/api/WindowManager';
 import * as WindowManager from 'tinymce/themes/silver/ui/dialog/WindowManager';
 
 import * as GuiSetup from '../../module/GuiSetup';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/SizeInputSpaceTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/dialogs/SizeInputSpaceTest.ts
@@ -2,7 +2,7 @@ import { ApproxStructure, Assertions, FocusTools, RealKeys, UiFinder } from '@ep
 import { GuiFactory } from '@ephox/alloy';
 import { describe, it } from '@ephox/bedrock-client';
 import { Optional } from '@ephox/katamari';
-import { SugarElement } from '@ephox/sugar';
+import type { SugarElement } from '@ephox/sugar';
 
 import { renderSizeInput } from 'tinymce/themes/silver/ui/dialog/SizeInput';
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleteDelayedResponseTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/AutocompleteDelayedResponseTest.ts
@@ -3,9 +3,9 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
 import { TinyAssertions, TinyContentActions, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
-import { AutocompleterStructure, pAssertAutocompleterStructure, pWaitForAutocompleteToClose } from '../../module/AutocompleterUtils';
+import { type AutocompleterStructure, pAssertAutocompleterStructure, pWaitForAutocompleteToClose } from '../../module/AutocompleterUtils';
 
 interface Scenario {
   readonly triggerChar: string;

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/DisabledNestedMenuItemTest.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('webdriver.tinymce.themes.silver.editor.menubar.DisabledNestedMenuItemTest', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/SimpleControlsInlineTest.ts
@@ -3,7 +3,7 @@ import { describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.themes.silver.editor.core.SimpleControlsInlineTest', () => {
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/TabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/editor/TabbingTest.ts
@@ -4,7 +4,7 @@ import { Focus, Insert, Remove, SugarElement } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 describe('webdriver.tinymce.themes.silver.editor.TabbingTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/throbber/ThrobberTabbingTest.ts
@@ -5,7 +5,7 @@ import { Insert, Remove, SelectorFind, SugarBody, SugarDocument, SugarElement } 
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import Env from 'tinymce/core/api/Env';
 
 import * as UiUtils from '../../module/UiUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/toolbar/SearchableMenuTypingTest.ts
@@ -1,8 +1,8 @@
-import { ApproxStructure, Assertions, FocusTools, KeyPressAdt, Mouse, RealKeys, StructAssert, UiFinder } from '@ephox/agar';
+import { ApproxStructure, Assertions, FocusTools, type KeyPressAdt, Mouse, RealKeys, type StructAssert, UiFinder } from '@ephox/agar';
 import { GuiFactory } from '@ephox/alloy';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Fun, Id, Optional } from '@ephox/katamari';
-import { Attribute, Focus, SugarDocument, SugarElement, SugarNode, Value } from '@ephox/sugar';
+import { Attribute, Focus, SugarDocument, type SugarElement, SugarNode, Value } from '@ephox/sugar';
 
 import { renderMenuButton } from 'tinymce/themes/silver/ui/button/MenuButton';
 

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/ElementPathTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/ElementPathTooltipTest.ts
@@ -5,7 +5,7 @@ import { PlatformDetection } from '@ephox/sand';
 import { Attribute, SugarBody, SugarDocument } from '@ephox/sugar';
 import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 import I18n from 'tinymce/core/api/util/I18n';
 
 import * as TooltipUtils from '../../module/TooltipUtils';

--- a/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/HtmlPanelTooltipTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/webdriver/tooltip/HtmlPanelTooltipTest.ts
@@ -3,7 +3,7 @@ import { context, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
-import Editor from 'tinymce/core/api/Editor';
+import type Editor from 'tinymce/core/api/Editor';
 
 import * as TooltipUtils from '../../module/TooltipUtils';
 


### PR DESCRIPTION
Related Ticket: TINY-12807

Description of Changes:

- Update tinymce core to adhere to import/export type rules

NOTE: The PRs are too big to properly review. The eslint auto-fixer largely did most of the work so should be safe.

yarn build​ works witout issues with a tinymce.d.ts​ still correctly generated

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):