### PR TITLE
TINY-12804: Added options for the parser previously deemed not needed.

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/DomParser.ts
@@ -39,7 +39,6 @@ const makeMap = Tools.makeMap, extend = Tools.extend;
 export interface ParserArgs {
   getInner?: boolean | number;
   forced_root_block?: boolean | string;
-  root_name?: string;
   context?: string;
   isRootContent?: boolean;
   format?: string;
@@ -480,7 +479,7 @@ const DomParser = (settings: DomParserSettings = {}, schema = Schema()): DomPars
    */
   const parse = (html: string, args: ParserArgs = {}): AstNode => {
     const validate = defaultedSettings.validate;
-    const preferFullDocument = (args.root_name ?? defaultedSettings.root_name) === '#document';
+    const preferFullDocument = (args.context ?? defaultedSettings.root_name) === '#document';
     const rootName = args.context ?? (preferFullDocument ? 'html' : defaultedSettings.root_name);
 
     // Parse and sanitize the content


### PR DESCRIPTION
Related Ticket: TINY-12804

Description of Changes:
Adding it by way of the args was previously not thought needed, but it was determined that it was due to some changes in approach.

Pre-checks:
* ~~[x] Changelog entry added~~
* ~~[x] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to explicitly enforce full-document HTML parsing when a document context is specified. This improves consistency between fragment and full-document parsing while remaining backward compatible and requiring no changes to existing integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->