### PR TITLE
TINY-12807: Remove useVerbatimModuleSyntax from tsconfig

### DIFF
--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -16,7 +16,6 @@
     "noImplicitReturns": true,
     "strict": true,
     "noEmitOnError": true,
-    "types": [],
-    "verbatimModuleSyntax": true,
+    "types": []
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-12807

Description of Changes:

- Removing `useVerbatimModuleSyntax`​ for now as need to do more investigation to make sure it is not negatively effecting bundle size

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):