### PR TITLE
TINY-12810: Add missing dependency to `persona` module

### DIFF
--- a/modules/persona/package.json
+++ b/modules/persona/package.json
@@ -25,7 +25,7 @@
     "LEGAL.txt",
     "LICENSE.txt"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@ephox/katamari": "^10.0.0"
   },
   "main": "./lib/main/ts/main.js",


### PR DESCRIPTION
Related Ticket: [TINY-12810](https://ephocks.atlassian.net/browse/TINY-12810)

Description of Changes:
Added `@ephox/katamari` as a direct dependency to the `persona` module since it's using Katamari imports (Optional, Fun) but wasn't declaring it in its `package.json`. While this works in the core TinyMCE repo due to Yarn workspace hoisting, it fails when persona is consumed by external projects or in CI environments where packages are built in isolation and no cache is available. This change makes the dependency explicit.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-12810]: https://ephocks.atlassian.net/browse/TINY-12810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a development tooling dependency to the project to improve build/test tooling.
  * No changes to features, UI, or behavior; existing workflows remain unaffected.
  * No configuration updates required; current integrations continue to work as before.
  * Maintenance-only update laying groundwork for smoother development and long-term support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->