### PR TITLE
TINY-12759: Skip storybook deployment until Jenkinsfile is fixed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -356,7 +356,8 @@ timestamps { notifyStatusChange(
       if (env.BRANCH_NAME == primaryBranch) {
         echo "Deploying Storybook"
         tinyGit.withGitHubSSHCredentials {
-          exec('yarn -s --cwd modules/oxide-components deploy-storybook')
+           echo "Deploying Storybook skipped until the Jenkinsfile is fixed"
+          // exec('yarn -s --cwd modules/oxide-components deploy-storybook')
         }
       } else {
         echo "Skipping Storybook deployment as the pipeline is not running on the primary branch"


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Temporarily disabled Storybook deployment in the Jenkins pipeline
* Added an echo statement to indicate that deployment is skipped until the Jenkinsfile is fixed
* Commented out the exec command that was previously used to deploy Storybook

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration pipeline updated to skip Storybook deployment for the primary branch. No application functionality changes. Pipeline now outputs a clear skip message; behavior for other branches remains unchanged. The previous deployment step is replaced with a no-op, preserving an easy path to re-enable later. Storybook hosting from primary will not update until restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->