### PR TITLE
TINY-12318: Add disabled and placeholder props to AutoresizingTextarea component

### DIFF
--- a/modules/oxide-components/src/main/ts/components/autoresizingtextarea/AutoResizingTextarea.tsx
+++ b/modules/oxide-components/src/main/ts/components/autoresizingtextarea/AutoResizingTextarea.tsx
@@ -22,6 +22,8 @@ export interface AutoResizingTextareaProps {
   readonly className?: string;
   readonly value: string;
   readonly onChange?: (value: string) => void;
+  readonly disabled?: boolean;
+  readonly placeholder?: string;
 }
 
 export const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, AutoResizingTextareaProps>(({

--- a/modules/oxide-components/src/test/ts/browser/components/AutoResizingTextarea.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/AutoResizingTextarea.spec.tsx
@@ -7,6 +7,42 @@ import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 describe('browser.AutoResizingTextareaTest', () => {
+  it('Sanity check', async () => {
+    const placeHolder = 'Placeholder for disabled textarea';
+    const { getByTestId } = render(
+      <AutoResizingTextarea value='' placeholder={placeHolder} disabled={true} data-testid="textarea" />,
+      {
+
+        wrapper: ({ children }) => {
+          return (
+            <div className={classes([ 'tox' ])}>
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '10px'
+              }}>
+                <div style={{
+                  width: '120px'
+                }}>
+                  {children}
+                </div>
+              </div>
+            </div>
+          );
+        },
+      });
+
+    const textareaLocator = getByTestId('textarea');
+    await expect.element(textareaLocator, {
+      message: 'Textarea should have a placeholder'
+    }).toHaveAttribute('placeholder', placeHolder);
+    await expect.element(textareaLocator, {
+      message: 'Textarea should be disabled'
+    }).toBeDisabled();
+
+  });
+
   it('Should grow and shrink as needed', async () => {
 
     const maxHeight: Height = {


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Added `disabled` and `placeholder` props to the `AutoResizingTextareaProps` interface to support disabling the textarea and displaying placeholder text

Pre-checks:

- [x] ~Changelog entry added~
- [x] ~Tests have been added (if applicable)~
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] ~Milestone set~
- [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Auto-resizing textarea now supports placeholder text and a disabled state, improving usability and accessibility by allowing guidance text and programmatic disabling.

- Tests
  - Added a sanity test to verify the placeholder renders and the textarea respects the disabled state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->