### PR TITLE
TINY-12822: Fix deploy stoybook to gh-pages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -336,7 +336,7 @@ timestamps { notifyStatusChange(
       parallel processes
   }
 
-  devPods.nodeProducer(
+  devPods.nodeConsumer(
     nodeOpts: [
       resourceRequestCpu: '2',
       resourceRequestMemory: '4Gi',
@@ -346,7 +346,12 @@ timestamps { notifyStatusChange(
       resourceLimitEphemeralStorage: '16Gi'
     ],
     tag: '20',
-    build: cacheName
+    build: cacheName,
+    environment: {
+      tinyGit.addAuthorConfig()
+      tinyGit.addGitHubToKnownHosts()
+      sh "tar -zxf ./file.tar.gz"
+    }
   ) {
     props = readProperties(file: 'build.properties')
     String primaryBranch = props.primaryBranch
@@ -356,8 +361,7 @@ timestamps { notifyStatusChange(
       if (env.BRANCH_NAME == primaryBranch) {
         echo "Deploying Storybook"
         tinyGit.withGitHubSSHCredentials {
-           echo "Deploying Storybook skipped until the Jenkinsfile is fixed"
-          // exec('yarn -s --cwd modules/oxide-components deploy-storybook')
+          exec('yarn -s --cwd modules/oxide-components deploy-storybook')
         }
       } else {
         echo "Skipping Storybook deployment as the pipeline is not running on the primary branch"


### PR DESCRIPTION
Related Ticket: TINY-12822

Description of Changes:
* Fix `Deploy Storybook` stage to deploy to `gh-pages`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically deploys Storybook from the primary branch after successful builds, ensuring the latest component documentation is available.

* **Chores**
  * Updated CI pipeline to use a new node provisioning entry point.
  * Configures build environment with Git/SSH setup and artifact extraction steps.
  * Minor syntax cleanup in pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->