### PR TITLE
TINY-12830: Fix error while splitting list-item into two using enter key

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12830-2025-09-09.yaml
+++ b/.changes/unreleased/tinymce-TINY-12830-2025-09-09.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Error was thrown on the console while splitting list-item into two using enter
+  key.
+time: 2025-09-09T13:47:44.83911+02:00
+custom:
+  Issue: TINY-12830

--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -38,12 +38,13 @@ const moveToCaretPosition = (editor: Editor, root: Node): void => {
     const isList = (e: SugarElement) => /^(ul|ol|dl)$/.test(SugarNode.name(e));
     const findFirstList = (e: SugarElement) => isList(e) ? Optional.from(e) : PredicateFind.descendant(e, isList);
     const isEmpty = (e: SugarElement) => dom.isEmpty(e.dom);
+
     firstNonWhiteSpaceNodeSibling(root.firstChild).each((firstChild) => {
       findFirstList(firstChild).fold(
         () => {
           if (isEmpty(firstChild)) {
             const element = DomDescent.toLeaf(firstChild, 0).element;
-            if (!ElementType.isBr(element)) {
+            if (SugarNode.isElement(element) && !ElementType.isBr(element)) {
               Insert.append(element, SugarElement.fromText(Unicode.nbsp));
             }
           }

--- a/modules/tinymce/src/core/test/ts/browser/newline/NewlineInLiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/newline/NewlineInLiTest.ts
@@ -130,4 +130,12 @@ describe('browser.tinymce.core.newline.NewlineInLiTest', () => {
     TinyAssertions.assertContent(editor, expectedContent);
     TinyAssertions.assertCursor(editor, [ 0, 2, 0, 0, 0, 0 ], 0);
   });
+
+  it('TINY-12830: splitting li into two using enter should not throw an error', () => {
+    const editor = hook.editor();
+    editor.setContent('<ul><li>This is a paragraph</li></ul>');
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 'Th'.length);
+    TinyContentActions.keydown(editor, Keys.enter());
+    TinyAssertions.assertContent(editor, [ '<ul>', '<li>Th</li>', '<li>is is a paragraph</li>', '</ul>' ].join('\n'));
+  });
 });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
