### PR TITLE
TINY-12763: Forward the ref of the Button component and add necessary css

### DIFF
--- a/modules/oxide-components/src/main/ts/components/button/Button.tsx
+++ b/modules/oxide-components/src/main/ts/components/button/Button.tsx
@@ -1,5 +1,5 @@
 import type { Classes } from '@tinymce/oxide/skins/ui/default/skin.ts';
-import type { ButtonHTMLAttributes } from 'react';
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
 
 import { classes } from '../../utils/Styles';
 
@@ -23,20 +23,21 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 /** Primary UI component for user interaction */
-export const Button: React.FC<ButtonProps> = ({
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({
   children,
   type = 'button',
   variant = 'primary',
   className,
   ...props
-}) => {
+}, ref) => {
   return (
     <button
       type={type}
       className={`${classes(calculateClassFromVariant(variant))} ${className ?? ''}`}
+      ref={ref}
       {...props}
     >
       {children}
     </button>
   );
-};
+});

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -12,7 +12,7 @@
     align-self: flex-end;
     color: var(--tox-private-text-color, @text-color);
   }
-  
+
   .tox-ai__scroll {
     overflow: auto;
     background-color: var(--tox-private-background-color, @background-color);
@@ -24,7 +24,7 @@
     flex: 1 0 0;
     align-self: stretch;
   }
-  
+
   .tox-ai-response__content {
     padding: var(--tox-private-pad-sm, @pad-sm) 0;
     color: var(--tox-private-text-color, @text-color);
@@ -33,8 +33,24 @@
     font-style: normal;
     font-weight: var(--tox-private-font-weight-normal, @font-weight-normal);
     line-height: var(--tox-private-line-height, 18px);
+    white-space: pre-wrap;
   }
-  
+
+  .tox-ai__response.tox-ai__response-streaming {
+    background: linear-gradient(180deg, var(--tox-private-color-black, @color-black) 0%, color-mix(in srgb, var(--tox-private-color-black, @color-black) 0%, transparent) 100%);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .tox-ai__error-message {
+    border-radius: var(--lg, 6px);
+    border: 1px solid var(--tox-private-color-error, @color-error);
+    background: linear-gradient(0deg, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 0%, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 100%),  var(--tox-private-color-error, @color-error);
+    padding: var(--lg, 8px);
+    width: 100%;
+  }
+
   .tox-ai__footer {
     border-top: 1px solid var(--tox-private-ai-footer-border-color, darken(@background-color, 11%));
     padding: 12px;
@@ -43,7 +59,7 @@
     display: flex;
     flex-direction: column;
   }
-  
+
   .tox-ai__footer-actions {
     display: flex;
     gap: var(--tox-private-pad-sm, @pad-sm);


### PR DESCRIPTION
Related Ticket: TINY-12763

Description of Changes:

- Added `forwardRef` to the Button component to allow refs to be passed to the underlying button element
- Enhanced AI chat styling with white-space pre-wrap for better text formatting
- Added streaming response styling with gradient text effect
- Implemented error message styling with appropriate borders and background

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/`or `spike/`

Review:

- [x] ~~Milestone set~~
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * AI chat shows animated gradient styling during streaming responses.
  * Added a clearly styled error message display in AI chat.

* Bug Fixes
  * AI chat responses now preserve line breaks for accurate formatting.

* Style
  * Improved readability and visual polish of AI chat messages.

* Refactor
  * Button component updated to better support ref interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->