### PR TITLE
TINY-12289: Fix toolbar button's tooltip remained visible

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12289-2025-09-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-12289-2025-09-11.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tooltips on toolbar buttons sometimes remained visible if the button icon was updated while hovered.
+time: 2025-09-11T21:55:28.82473+08:00
+custom:
+    Issue: TINY-12289

--- a/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
+++ b/modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less
@@ -75,6 +75,10 @@
     text-transform: @toolbar-button-text-transform;
     width: @toolbar-button-width;
 
+    .tox-tbtn__icon-wrap {
+      pointer-events: none;
+    }
+
     @media (forced-colors: active) {
       &:hover,
       &.tox-tbtn:hover {

--- a/modules/oxide/src/less/theme/components/view/view.less
+++ b/modules/oxide/src/less/theme/components/view/view.less
@@ -20,7 +20,6 @@
     flex: 1 1 auto;
     flex-direction: column;
     overflow: hidden;
-    z-index: @z-index-view;
     background-color: @background-color;
   }
 

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -65,8 +65,7 @@
 @z-index-throbber: 1299;
 @z-index-sink: 1300;
 
-// views and onboarding overlay are rendered inside the editor, not in the sink, so they need to be higher to show above popups e.g. notifications, tooltips and menus
-@z-index-view: 1301;
+// onboarding overlay are rendered inside the editor, not in the sink, so they need to be higher to show above popups e.g. notifications, tooltips and menus
 @z-index-onboarding-overlay: 1302;
 
 // sink z-index stack


### PR DESCRIPTION
Related Ticket: TINY-12289

Description of Changes:
* When calling the `setIcon` API while the pointer is directly over a button’s `<svg>` icon, the icon element is replaced. Because the hovered element is destroyed instead of exited, the browser never dispatches a `mouseout` event, and the tooltip stays stuck.
* Applied `pointer-events: none` to the icon wrapper so the `<button>` itself is always the event target.
* Fiddle: https://fiddle.tiny.cloud/pis5xdYfig/0
  * Make some edits in the editor.
  * Hover directly over the SVG icon in a toolbar button.
  * Click the button → notice the tooltip does not dismiss.
  * Refresh.
  * Hover over the button background (not the SVG).
  * Click the button → tooltip dismisses correctly.
* Fix: https://fiddle.tiny.cloud/pis5xdYfig/1

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~ Manual testing required
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Resolved an issue where tooltips on toolbar buttons could remain visible if the icon changed while hovered.
- Style
  - Improved toolbar button interaction by preventing unintended pointer capture on icons.
  - Adjusted interface layering to ensure onboarding overlays appear correctly above other content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->