### PR TITLE
TINY-12384: Added attribute to dragster

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12384-2025-09-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-12384-2025-09-16.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Filtering out Dragster elements in serializer ( elements with classes starting with `ephox-dragster-` )
+body: Some UI elements related to dragging elements were not properly filtered out when fetching content.
 time: 2025-09-16T07:19:26.916854+02:00
 custom:
     Issue: TINY-12384

--- a/.changes/unreleased/tinymce-TINY-12384-2025-09-16.yaml
+++ b/.changes/unreleased/tinymce-TINY-12384-2025-09-16.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Filtering out Dragster elements in serializer ( elements with classes starting with `ephox-dragster-` )
+time: 2025-09-16T07:19:26.916854+02:00
+custom:
+    Issue: TINY-12384

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/Blocker.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/Blocker.ts
@@ -20,7 +20,7 @@ export const Blocker = (options: Partial<BlockerOptions>): Blocker => {
 
   const div = SugarElement.fromTag('div');
   Attribute.set(div, 'role', 'presentation');
-  Attribute.set(div, 'data-mce-bougs', 'all');
+  Attribute.set(div, 'data-mce-bogus', 'all');
   Css.setAll(div, {
     position: 'fixed',
     left: '0px',

--- a/modules/dragster/src/main/ts/ephox/dragster/detect/Blocker.ts
+++ b/modules/dragster/src/main/ts/ephox/dragster/detect/Blocker.ts
@@ -20,6 +20,7 @@ export const Blocker = (options: Partial<BlockerOptions>): Blocker => {
 
   const div = SugarElement.fromTag('div');
   Attribute.set(div, 'role', 'presentation');
+  Attribute.set(div, 'data-mce-bougs', 'all');
   Css.setAll(div, {
     position: 'fixed',
     left: '0px',

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional } from '@ephox/katamari';
+import { Arr, Optional, Strings } from '@ephox/katamari';
 
 import type DOMUtils from '../api/dom/DOMUtils';
 import type DomParser from '../api/html/DomParser';
@@ -23,7 +23,7 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
 
   htmlParser.addNodeFilter('div', (nodes) => {
     Arr.each(nodes, (node) => {
-      if (node.attributes && Arr.find(node.attributes, (attribute) => attribute.name === 'class' && attribute.value.includes('ephox-dragster-')).isSome()) {
+      if (node.attributes && Strings.contains(node.attr('class') || '', 'ephox-dragster')) {
         node.remove();
       }
     });

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional, Strings } from '@ephox/katamari';
+import { Arr, Optional } from '@ephox/katamari';
 
 import type DOMUtils from '../api/dom/DOMUtils';
 import type DomParser from '../api/html/DomParser';
@@ -19,14 +19,6 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
       node.attr('tabindex', node.attr('data-mce-tabindex'));
       node.attr(name, null);
     }
-  });
-
-  htmlParser.addNodeFilter('div', (nodes) => {
-    Arr.each(nodes, (node) => {
-      if (node.attributes && Strings.contains(node.attr('class') || '', 'ephox-dragster')) {
-        node.remove();
-      }
-    });
   });
 
   // Convert move data-mce-src, data-mce-href and data-mce-style into nodes or process them if needed

--- a/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
+++ b/modules/tinymce/src/core/main/ts/dom/DomSerializerFilters.ts
@@ -21,6 +21,14 @@ const register = (htmlParser: DomParser, settings: DomSerializerSettings, dom: D
     }
   });
 
+  htmlParser.addNodeFilter('div', (nodes) => {
+    Arr.each(nodes, (node) => {
+      if (node.attributes && Arr.find(node.attributes, (attribute) => attribute.name === 'class' && attribute.value.includes('ephox-dragster-')).isSome()) {
+        node.remove();
+      }
+    });
+  });
+
   // Convert move data-mce-src, data-mce-href and data-mce-style into nodes or process them if needed
   htmlParser.addAttributeFilter('src,href,style', (nodes, name) => {
     const internalName = 'data-mce-' + name;


### PR DESCRIPTION
Related Ticket: TINY-12384

Description of Changes:
Added filter to serializer to prevent Dragster elements showing up in `editor.getContent()`-calls.
Was not able to create a proper test as it'd involve triggering dragster during editor.getContent-call.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Serializer now excludes temporary drag-and-drop helper UI elements, preventing unintended markup in copy/paste, export, and save flows.
- **Chores**
  - Added an unreleased changelog entry recording the fix (TINY-12384).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->