### PR TITLE
TINY-12867: Remove `allow-same-origin` from sanbox spec

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/dialog/IFrame.ts
@@ -133,7 +133,7 @@ const renderIFrame = (spec: IframeSpec, providersBackstage: Backstage.UiFactoryB
   const attributes = {
     ...spec.label.map<{ title?: string }>((title) => ({ title })).getOr({}),
     ...initialData.map((html) => ({ srcdoc: html })).getOr({}),
-    ...spec.sandboxed ? { sandbox: 'allow-scripts allow-same-origin' } : { }
+    ...spec.sandboxed ? { sandbox: 'allow-scripts' } : {}
   };
 
   const sourcing = getDynamicSource(initialData, spec.streamContent);


### PR DESCRIPTION
Related Ticket: 
TINY-12867

Description of Changes:
- Removed `allow-same-origin` from sanbox spec

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
