### PR TITLE
TINY-12954: Bump Node.js image version to 22.20.0 across pods

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ def runTestPod(String cacheName, String name, String testname, String browser, S
           resourceLimitMemory: '6Gi',
           resourceLimitEphemeralStorage: '16Gi'
         ],
-        tag: '20',
+        tag: '22.20.0',
         build: cacheName,
         useContainers: ['node', 'aws-cli']
       ) {
@@ -222,7 +222,7 @@ timestamps { notifyStatusChange(
       resourceLimitMemory: '4Gi',
       resourceLimitEphemeralStorage: '16Gi'
     ],
-    tag: '20',
+    tag: '22.20.0',
     build: cacheName
   ) {
     props = readProperties(file: 'build.properties')
@@ -345,7 +345,7 @@ timestamps { notifyStatusChange(
       resourceLimitMemory: '4Gi',
       resourceLimitEphemeralStorage: '16Gi'
     ],
-    tag: '20',
+    tag: '22.20.0',
     build: cacheName,
     environment: {
       tinyGit.addAuthorConfig()


### PR DESCRIPTION
Related Ticket: [TINY-12954](https://ephocks.atlassian.net/browse/TINY-12954)

Description of Changes:
* Bumped the Node.js image version used in our CI pipeline pods to ensure builds and tests run on the latest Node release.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
