### PR TITLE
TINY-12883: add minimum width for `uc-video` resize

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -173,7 +173,14 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
           dom.setStyle(target, name, value);
         } else {
           if (isUcVideo(target)) {
+            // this is needed because otherwise the ghost for `uc-video` is not correctly rendered
             target[name] = value;
+            const minimumWidth = 400;
+            if (target.width > minimumWidth && !(name === 'width' && value < minimumWidth)) {
+              target[name] = value;
+            } else {
+              target[name] = name === 'height' ? minimumWidth * ratio : minimumWidth;
+            }
           } else {
             dom.setAttrib(target, name, '' + value);
           }


### PR DESCRIPTION
Related Ticket: TINY-12883

Description of Changes:
I put the test in the premium repo, I think the redundancy of the minim value will be solved when we will allow to configure the resize from the definition of the custom element

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
