### PR TITLE
INT-3373: Focus and caret placement order change.

### DIFF
--- a/.changes/unreleased/tinymce-INT-3373-2025-10-02.yaml
+++ b/.changes/unreleased/tinymce-INT-3373-2025-10-02.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Chromium browsers would in certain situations scroll the editor unexpectedly when dragging content over the editor.
+time: 2025-10-02T15:42:09.368737+02:00
+custom:
+    Issue: INT-3373

--- a/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
+++ b/modules/tinymce/src/core/main/ts/paste/DragDrop.ts
@@ -24,10 +24,10 @@ const isPlainTextFileUrl = (content: Clipboard.ClipboardContents): boolean => {
 };
 
 const setFocusedRange = (editor: Editor, rng: Range | undefined): void => {
-  editor.focus();
   if (rng) {
     editor.selection.setRng(rng);
   }
+  editor.focus();
 };
 
 const hasImage = (dataTransfer: DataTransfer): boolean =>

--- a/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/DragDropSummaryTest.ts
@@ -1,6 +1,7 @@
 import { Waiter } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import type Editor from 'tinymce/core/api/Editor';
 
@@ -55,6 +56,27 @@ describe('browser.tinymce.core.paste.DragDropSummaryTest', () => {
     editor.dispatch('input', InputEventUtils.makeInputEvent('input', { inputType: 'deleteByDrag' }));
     TinyAssertions.assertContentPresence(editor, { 'summary': 1, 'details > br': 0, 'summary > br': 1 });
     TinyAssertions.assertContent(editor, '<details><summary>&nbsp;</summary><div>body</div></details>');
+  });
+
+  it('INT-3373: The editor should not scroll away when gaining dragover focus.', async () => {
+    const editor = hook.editor();
+
+    editor.setContent('<p>Text</p>'.repeat(1000));
+    const div = document.createElement('div');
+    div.setAttribute('contentEditable', 'true');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    editor.getContainer().parentElement!.append(div);
+
+    const scrollAmount = 5000;
+    editor.getWin().scrollTo(0, scrollAmount);
+    await Waiter.pTryUntil('Scroll to point', () => assert.equal(editor.getWin().scrollY, scrollAmount));
+
+    assert.equal(scrollAmount, editor.getWin().scrollY);
+    div.focus();
+    editor.dispatch('dragover');
+    assert.equal(scrollAmount, editor.getWin().scrollY);
+
+    div.remove();
   });
 });
 


### PR DESCRIPTION
Related Ticket: INT-3373

Description of Changes:
When focus was given before moving the caret chrome would scroll to the top of the editor in some situations ( editor was not focused, caret was not in view at the time, the content was large enough to require a scroll ). Moving the caret first, then setting focus solves the issue.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents unexpected page/editor scrolling in Chromium when dragging content over the editor, even if another element is focused.

- Tests
  - Added an automated test to ensure no scroll occurs during dragover in the described scenario.

- Chores
  - Added an unreleased changelog entry documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->