### PR TITLE
TINY-12927: Add tinyai basic context css

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -5,6 +5,17 @@
 
 .tox-ai {
   .tox-ai__user-prompt {
+    display: flex;
+    flex-direction: column;
+    margin-left: auto;
+    gap: inherit;
+  }
+
+  .tox-ai__user-prompt__context {
+    margin-left: auto;
+  }
+
+  .tox-ai__user-prompt__text {
     background-color: var(--tox-private-ai-user-prompt-background, darken(@background-color, 6%));
     padding: var(--tox-private-pad-sm, @pad-sm) 12px;
     border-radius: var(--tox-private-control-border-radius, @control-border-radius);
@@ -25,7 +36,7 @@
     align-self: stretch;
   }
 
-  .tox-ai-response__content {
+  .tox-ai__response-content {
     padding: var(--tox-private-pad-sm, @pad-sm) 0;
     color: var(--tox-private-text-color, @text-color);
     font-feature-settings: 'liga' off, 'clig' off;
@@ -44,10 +55,10 @@
   }
 
   .tox-ai__error-message {
-    border-radius: var(--lg, 6px);
+    border-radius: var(--tox-private-panel-border-radius, @panel-border-radius);
     border: 1px solid var(--tox-private-color-error, @color-error);
     background: linear-gradient(0deg, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 0%, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 100%),  var(--tox-private-color-error, @color-error);
-    padding: var(--lg, 8px);
+    padding: var(--tox-private-pad-sm, @pad-sm);
     width: 100%;
   }
 
@@ -65,4 +76,3 @@
     gap: var(--tox-private-pad-sm, @pad-sm);
   }
 }
-

--- a/modules/oxide/src/less/theme/components/tag/tag.less
+++ b/modules/oxide/src/less/theme/components/tag/tag.less
@@ -1,0 +1,30 @@
+.tox {
+  .tox-tag {
+    width: fit-content;
+    display: flex;
+    padding: 4px 6px;
+    align-items: center;
+    gap: 4px;
+    border-radius: 3px;
+    background: linear-gradient(0deg,color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 0%, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 100%),  var(--tox-private-color-tint, @color-tint);
+    line-height: var(--tox-private-base-value, @base-value);
+    font-size: var(--tox-private-font-size-xs, @font-size-xs);
+
+    .tox-tag__icon {
+      height: var(--tox-private-base-value, @base-value);
+    }
+
+    .tox-tag__close {
+      height: var(--tox-private-base-value, @base-value);
+
+      .tox-button.tox-button--icon {
+        border: 0;
+        padding: 0;
+
+        &::before {
+          box-shadow: none;
+        }
+      }
+    }
+  }
+}

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -72,6 +72,7 @@
 @import 'components/source-code/source-code';
 @import 'components/spinner/spinner';
 @import 'components/statusbar/statusbar';
+@import 'components/tag/tag';
 @import 'components/throbber/throbber';
 @import 'components/toggle/toggle';
 @import 'components/toolbar-button/toolbar-button';


### PR DESCRIPTION
Related Ticket: TINY-12927

Description of Changes:

- Enhanced AI chat component styling with separate user prompt text and context elements
- Fixed class name for AI response content from `tox-ai-response__content` to `tox-ai__response-content`
- Updated error message styling to use consistent variables for border radius and padding
- Added new tag component with styling for icons and close buttons

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Added styled Tag component to the Oxide theme, including icon and close button support with a compact, gradient appearance.
- Style
    - Refined AI Chat layout: right-aligned user prompts with updated text bubble and context styling for clearer readability.
    - Improved error message look with adjusted padding and corner rounding for consistency.
    - Minor visual consistency updates across chat elements; no functional changes to scrolling, footer, or streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->