### PR TITLE
TINY-13021: add attribute set for `uc-video` to manage undo level correclty

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -178,8 +178,11 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
             const minimumWidth = 400;
             if (target.width > minimumWidth && !(name === 'width' && value < minimumWidth)) {
               target[name] = value;
+              dom.setAttrib(target, name, '' + value);
             } else {
-              target[name] = name === 'height' ? minimumWidth * ratio : minimumWidth;
+              const value = name === 'height' ? minimumWidth * ratio : minimumWidth;
+              target[name] = value;
+              dom.setAttrib(target, name, '' + value);
             }
           } else {
             dom.setAttrib(target, name, '' + value);


### PR DESCRIPTION
Related Ticket: TINY-13021

Description of Changes:
the tests are in the premium PR

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resizing embedded video elements now reliably updates both the displayed dimensions and the corresponding HTML width/height attributes.
  * Minimum size fallbacks are correctly applied and reflected in the saved markup.
  * Prevents mismatches between what you see in the editor and what appears in previews/exports.
  * Delivers more predictable behavior when using resize handles on videos, without affecting other element types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->