### PR TITLE
Revert "TINY-12315: Fix expandable accordions in disabled editor (#10556)"

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12315-2025-08-26.yaml
+++ b/.changes/unreleased/tinymce-TINY-12315-2025-08-26.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Fixed
-body: Accordions were expandable in disabled editors.
-time: 2025-08-26T13:25:04.837537+02:00
-custom:
-  Issue: TINY-12315


### PR DESCRIPTION
This reverts commit 4ee9c57bae67ed3dc19d61b8c5fc3cc20c0446f3.

Related Ticket: TINY-12315

Description of Changes:
* Unfortunately we're blocked in TINY-12316 and we should not release TINY-12315 without TINY-12316. We should try to squeeze in both in the next release.

Pre-checks:
~~* [ ] Changelog entry added~~
~~* [ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
~~* [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Refactor
  - Simplified disabled-mode click handling to reduce complexity and improve reliability without altering expected behavior.
- Tests
  - Updated tests to align with the refactor and streamline dependencies.
- Chores
  - Removed an outdated unreleased changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->