### PR TITLE
TINY-8724: Fixed an issue with Mac Firefox Meta key

### DIFF
--- a/modules/agar/src/main/ts/ephox/agar/keyboard/Keycodes.ts
+++ b/modules/agar/src/main/ts/ephox/agar/keyboard/Keycodes.ts
@@ -109,7 +109,8 @@ const keys: KeyInfo[] = [
   { keyCode: 89, code: 'KeyY', key: 'Y', data: 'Y', shiftKey: true },
   { keyCode: 90, code: 'KeyZ', key: 'z', data: 'z' },
   { keyCode: 90, code: 'KeyZ', key: 'Z', data: 'Z', shiftKey: true },
-  { keyCode: 91, code: 'MetaLeft', key: 'Meta' },
+  // Firefox Mac returns 224 for the keycode for meta
+  { keyCode: isFirefox && isMac ? 224 : 91, code: 'MetaLeft', key: 'Meta' },
   { keyCode: 92, code: 'MetaRight', key: 'Meta' },
   { keyCode: 93, code: 'ContextMenu', key: 'ContextMenu' },
   { keyCode: 96, code: 'Numpad0', key: '0', data: '0' },
@@ -161,11 +162,7 @@ const keys: KeyInfo[] = [
   { keyCode: 221, code: 'BracketRight', key: ']', data: ']' },
   { keyCode: 221, code: 'BracketRight', key: '}', data: '}', shiftKey: true },
   { keyCode: 222, code: 'Quote', key: '\'', data: '\'' },
-  { keyCode: 222, code: 'Quote', key: '"', data: '"', shiftKey: true },
-  // Firefox Mac returns 224 for the keycode for meta
-  { keyCode: isFirefox && isMac ? 224 : 91, code: 'MetaLeft', key: 'Meta' },
-  { keyCode: 17, code: 'ControlLeft', key: 'Control' },
-  { keyCode: 18, code: 'AltLeft', key: 'Alt' }
+  { keyCode: 222, code: 'Quote', key: '"', data: '"', shiftKey: true }
 ];
 
 const createKeyboardEvent = (


### PR DESCRIPTION
Related Ticket: TINY-8724

Description of Changes:
* One test failed where we keyup using the `Meta` key it turns out that Mac OS Firefox has a different keycode for this that the test uses.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the Command (Meta) key on macOS when using Firefox, ensuring shortcuts recognize the correct key code.
  * Ensured consistent handling of left-side modifier keys for more reliable shortcut behavior across platforms.
  * Refined cross-platform key mapping to reduce missed or incorrect shortcut activations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->