### PR TITLE
TINY-13099: remove data-mce-placeholder from print styles

### DIFF
--- a/modules/oxide/src/less/theme/content/print/print.less
+++ b/modules/oxide/src/less/theme/content/print/print.less
@@ -15,9 +15,5 @@
     .mce-edit-focus {
       outline: none !important;
     }
-
-    tiny-uploadcare-placeholder {
-      display: none !important; 
-    }
   }
 }

--- a/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
+++ b/modules/oxide/src/less/theme/content/uploadcare/uploadcare.less
@@ -97,3 +97,9 @@
   --tox-uc-loading-spinner-border-bottom-color: transparent;
   --tox-uc-loading-spinner-animation: tox-rotation 1s linear infinite;
 }
+
+@media print {
+  tiny-uploadcare-placeholder {
+    display: none !important; 
+  }
+}


### PR DESCRIPTION
Related Ticket:  TINY-13099

Description of Changes:
* Remove `[data-mce-placeholder]` from print styles due to the pagebreak bug
* Add `tiny-uploadcare-placeholder` sprint styles separately (before covered by `[data-mce-placeholder]`)

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):
