### PR TITLE
TINY-13114: remove unneccessary color mix

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -48,7 +48,7 @@
   }
 
   .tox-ai__response.tox-ai__response-streaming {
-    background: linear-gradient(180deg, var(--tox-private-color-black, @color-black) 0%, color-mix(in srgb, var(--tox-private-color-black, @color-black) 0%, transparent) 100%);
+    background: linear-gradient(180deg, var(--tox-private-color-black, @color-black) 0%, transparent 100%);
     background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;


### PR DESCRIPTION
Related Ticket: TINY-13114

Description of Changes:
* Simplified the linear gradient for streaming AI responses by replacing `color-mix(in srgb, var(--tox-private-color-black, @color-black) 0%, transparent)` with just `transparent`

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual gradient styling for AI chat responses to provide a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->