### PR TITLE
TINY-13065: Complete Storybook documentation and rename InlineToolbar to ContextToolbar

### DIFF
--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.stories.tsx
@@ -6,7 +6,7 @@ import { fn } from 'storybook/test';
 import { Button } from '../button/Button';
 import { IconButton } from '../iconbutton/IconButton';
 
-import * as InlineToolbar from './InlineToolbar';
+import * as ContextToolbar from './ContextToolbar';
 
 /* eslint-disable max-len */
 const resolvedIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
@@ -15,36 +15,36 @@ const resolvedIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height=
 /* eslint-enable max-len */
 
 const meta = {
-  title: 'components/InlineToolbar',
+  title: 'components/ContextToolbar',
   parameters: {
     layout: 'centered',
     docs: {
       description: {
         /* eslint-disable max-len */
         component: `
-A compound component for creating inline toolbars that anchor to trigger elements.
+A compound component for creating context toolbars that anchor to trigger elements.
 
 ## Usage
 
 \`\`\`tsx
-import * as InlineToolbar from 'oxide-components/InlineToolbar';
+import * as ContextToolbar from 'oxide-components/ContextToolbar';
 
 const MyComponent = () => {
   return (
     <div className='tox' style={{ position: 'relative' }}>
-      <InlineToolbar.Root persistent={false}>
-        <InlineToolbar.Trigger>
+      <ContextToolbar.Root persistent={false}>
+        <ContextToolbar.Trigger>
           <div style={{ backgroundColor: 'red', padding: '10px' }}>
             Click me!
           </div>
-        </InlineToolbar.Trigger>
-        <InlineToolbar.Toolbar>
-          <InlineToolbar.Group>
+        </ContextToolbar.Trigger>
+        <ContextToolbar.Toolbar>
+          <ContextToolbar.Group>
             <Button>Accept</Button>
             <Button>Reject</Button>
-          </InlineToolbar.Group>
-        </InlineToolbar.Toolbar>
-      </InlineToolbar.Root>
+          </ContextToolbar.Group>
+        </ContextToolbar.Toolbar>
+      </ContextToolbar.Root>
     </div>
   );
 };
@@ -99,14 +99,14 @@ Groups related buttons together for keyboard navigation. Buttons within a group 
 
 ## Default Behavior
 
-By default, the InlineToolbar anchors to the bottom left of the trigger element. It can position above/below or left/center/right based on the trigger element's inline positioning styles. The position-try-fallbacks CSS property automatically flips the toolbar when it would overflow the viewport.
+By default, the ContextToolbar anchors to the bottom left of the trigger element. It can position above/below or left/center/right based on the trigger element's inline positioning styles. The position-try-fallbacks CSS property automatically flips the toolbar when it would overflow the viewport.
 
 ## Key Features
 
 - **Native CSS positioning** using \`anchor()\` function
 - **Auto-detection** of anchor placement (top/bottom, left/center/right)
 - **Automatic viewport overflow handling** with \`position-try-fallbacks\`
-- **Dynamic gap** controlled by CSS variable \`--inline-toolbar-gap\`
+- **Dynamic gap** controlled by CSS variable \`--context-toolbar-gap\`
 - **Unique anchor names** per instance using \`Id.generate()\`
 
 ## How It Works
@@ -143,26 +143,26 @@ export const Basic: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Basic inline toolbar using **CSS anchor positioning**. Click the trigger to open the toolbar. The toolbar will close when clicking outside (unless `persistent={true}`).',
+        story: 'Basic context toolbar using **CSS anchor positioning**. Click the trigger to open the toolbar. The toolbar will close when clicking outside (unless `persistent={true}`).',
       },
     },
   },
   render: () => {
     return (
       <div className='tox' style={{ position: 'relative' }}>
-        <InlineToolbar.Root persistent={false}>
-          <InlineToolbar.Trigger>
+        <ContextToolbar.Root persistent={false}>
+          <ContextToolbar.Trigger>
             <div style={{ backgroundColor: 'red', padding: '10px' }}>
               Click me!
             </div>
-          </InlineToolbar.Trigger>
-          <InlineToolbar.Toolbar>
-            <InlineToolbar.Group>
+          </ContextToolbar.Trigger>
+          <ContextToolbar.Toolbar>
+            <ContextToolbar.Group>
               <Button onClick={fn()}>Accept</Button>
               <Button onClick={fn()}>Reject</Button>
-            </InlineToolbar.Group>
-          </InlineToolbar.Toolbar>
-        </InlineToolbar.Root>
+            </ContextToolbar.Group>
+          </ContextToolbar.Toolbar>
+        </ContextToolbar.Root>
       </div>
     );
   }
@@ -179,19 +179,19 @@ export const Persistent: Story = {
   render: () => {
     return (
       <div className='tox' style={{ position: 'relative' }}>
-        <InlineToolbar.Root persistent={true}>
-          <InlineToolbar.Trigger>
+        <ContextToolbar.Root persistent={true}>
+          <ContextToolbar.Trigger>
             <div style={{ backgroundColor: 'blue', padding: '10px' }}>
               Click me (Persistent)!
             </div>
-          </InlineToolbar.Trigger>
-          <InlineToolbar.Toolbar>
-            <InlineToolbar.Group>
+          </ContextToolbar.Trigger>
+          <ContextToolbar.Toolbar>
+            <ContextToolbar.Group>
               <Button onClick={fn()}>Accept</Button>
               <Button onClick={fn()}>Reject</Button>
-            </InlineToolbar.Group>
-          </InlineToolbar.Toolbar>
-        </InlineToolbar.Root>
+            </ContextToolbar.Group>
+          </ContextToolbar.Toolbar>
+        </ContextToolbar.Root>
       </div>
     );
   }
@@ -201,19 +201,19 @@ export const WithIconButtons: Story = {
   render: () => {
     return (
       <div className='tox' style={{ position: 'relative' }}>
-        <InlineToolbar.Root persistent={false}>
-          <InlineToolbar.Trigger>
+        <ContextToolbar.Root persistent={false}>
+          <ContextToolbar.Trigger>
             <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
               Click me!
             </div>
-          </InlineToolbar.Trigger>
-          <InlineToolbar.Toolbar>
-            <InlineToolbar.Group>
+          </ContextToolbar.Trigger>
+          <ContextToolbar.Toolbar>
+            <ContextToolbar.Group>
               <IconButton variant='primary' icon='checkmark' onClick={fn()} resolver={Fun.constant(resolvedIcon)} />
               <IconButton variant='secondary' icon='cross' onClick={fn()} resolver={Fun.constant(resolvedIcon)} />
-            </InlineToolbar.Group>
-          </InlineToolbar.Toolbar>
-        </InlineToolbar.Root>
+            </ContextToolbar.Group>
+          </ContextToolbar.Toolbar>
+        </ContextToolbar.Root>
       </div>
     );
   }
@@ -223,27 +223,27 @@ export const ManyButtons: Story = {
   render: () => {
     return (
       <div className='tox' style={{ position: 'relative' }}>
-        <InlineToolbar.Root persistent={false}>
-          <InlineToolbar.Trigger>
+        <ContextToolbar.Root persistent={false}>
+          <ContextToolbar.Trigger>
             <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
               Click me!
             </div>
-          </InlineToolbar.Trigger>
-          <InlineToolbar.Toolbar>
-            <InlineToolbar.Group>
+          </ContextToolbar.Trigger>
+          <ContextToolbar.Toolbar>
+            <ContextToolbar.Group>
               <Button variant='primary' onClick={fn()}>Accept</Button>
               <Button variant='secondary' onClick={fn()}>Reject</Button>
-            </InlineToolbar.Group>
-            <InlineToolbar.Group>
+            </ContextToolbar.Group>
+            <ContextToolbar.Group>
               <Button variant='outlined' onClick={fn()}>Edit</Button>
               <Button variant='naked' onClick={fn()}>Comment</Button>
-            </InlineToolbar.Group>
-            <InlineToolbar.Group>
+            </ContextToolbar.Group>
+            <ContextToolbar.Group>
               <Button variant='primary' onClick={fn()}>Share</Button>
               <Button variant='secondary' onClick={fn()}>More</Button>
-            </InlineToolbar.Group>
-          </InlineToolbar.Toolbar>
-        </InlineToolbar.Root>
+            </ContextToolbar.Group>
+          </ContextToolbar.Toolbar>
+        </ContextToolbar.Root>
       </div>
     );
   }
@@ -253,14 +253,14 @@ export const MixedContent: Story = {
   render: () => {
     return (
       <div className='tox' style={{ position: 'relative' }}>
-        <InlineToolbar.Root persistent={false}>
-          <InlineToolbar.Trigger>
+        <ContextToolbar.Root persistent={false}>
+          <ContextToolbar.Trigger>
             <div style={{ backgroundColor: 'lightyellow', padding: '10px' }}>
               Click me!
             </div>
-          </InlineToolbar.Trigger>
-          <InlineToolbar.Toolbar>
-            <InlineToolbar.Group>
+          </ContextToolbar.Trigger>
+          <ContextToolbar.Toolbar>
+            <ContextToolbar.Group>
               <IconButton icon='arrow-up' onClick={fn()} resolver={Fun.constant(resolvedIcon)} />
               <span style={{
                 padding: '8px',
@@ -271,13 +271,13 @@ export const MixedContent: Story = {
                 1/3
               </span>
               <IconButton icon='arrow-down' onClick={fn()} resolver={Fun.constant(resolvedIcon)} />
-            </InlineToolbar.Group>
-            <InlineToolbar.Group>
+            </ContextToolbar.Group>
+            <ContextToolbar.Group>
               <Button variant='primary' onClick={fn()}>Accept</Button>
               <Button variant='secondary' onClick={fn()}>Reject</Button>
-            </InlineToolbar.Group>
-          </InlineToolbar.Toolbar>
-        </InlineToolbar.Root>
+            </ContextToolbar.Group>
+          </ContextToolbar.Toolbar>
+        </ContextToolbar.Root>
       </div>
     );
   }
@@ -308,7 +308,7 @@ export const Corners: Story = {
     ] as const), []);
 
     return (
-      <div className='tox inline-toolbar-anchors' style={{ width: '520px' }}>
+      <div className='tox context-toolbar-anchors' style={{ width: '520px' }}>
         <div
           className='tox'
           style={{
@@ -322,19 +322,19 @@ export const Corners: Story = {
           }}
         >
           {triggerPositions.map((pos) => (
-            <InlineToolbar.Root key={pos.id} persistent={false}>
-              <InlineToolbar.Trigger>
+            <ContextToolbar.Root key={pos.id} persistent={false}>
+              <ContextToolbar.Trigger>
                 <div style={{ position: 'absolute', display: 'inline-flex', ...pos.style }}>
                   <Button>{pos.label}</Button>
                 </div>
-              </InlineToolbar.Trigger>
-              <InlineToolbar.Toolbar>
-                <InlineToolbar.Group>
+              </ContextToolbar.Trigger>
+              <ContextToolbar.Toolbar>
+                <ContextToolbar.Group>
                   <Button onClick={fn()}>Accept</Button>
                   <Button onClick={fn()}>Reject</Button>
-                </InlineToolbar.Group>
-              </InlineToolbar.Toolbar>
-            </InlineToolbar.Root>
+                </ContextToolbar.Group>
+              </ContextToolbar.Toolbar>
+            </ContextToolbar.Root>
           ))}
         </div>
       </div>

--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
@@ -14,25 +14,19 @@ import {
 
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
 
-import type {
-  InlineToolbarContextValue,
-  InlineToolbarProps,
-  TriggerProps,
-  ToolbarProps,
-  GroupProps
-} from './InlineToolbarTypes';
+import type { ContextToolbarContextValue, ContextToolbarProps, GroupProps, ToolbarProps, TriggerProps } from './ContextToolbarTypes';
 
-const InlineToolbarContext = createContext<InlineToolbarContextValue | null>(null);
+const ContextToolbarContext = createContext<ContextToolbarContextValue | null>(null);
 
-const useInlineToolbarContext = () => {
-  const context = useContext(InlineToolbarContext);
+const useContextToolbarContext = () => {
+  const context = useContext(ContextToolbarContext);
   if (!Type.isNonNullable(context)) {
-    throw new Error('useInlineToolbarContext must be used within an InlineToolbarProvider');
+    throw new Error('useContextToolbarContext must be used within an ContextToolbarProvider');
   }
   return context;
 };
 
-const Root: FC<InlineToolbarProps> = ({
+const Root: FC<ContextToolbarProps> = ({
   children,
   persistent = false
 }) => {
@@ -43,7 +37,7 @@ const Root: FC<InlineToolbarProps> = ({
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
 
-  const context = useMemo<InlineToolbarContextValue>(() => ({
+  const context = useMemo<ContextToolbarContextValue>(() => ({
     isOpen,
     open,
     close,
@@ -54,9 +48,9 @@ const Root: FC<InlineToolbarProps> = ({
   }), [ isOpen, open, close, persistent ]);
 
   return (
-    <InlineToolbarContext.Provider value={context}>
+    <ContextToolbarContext.Provider value={context}>
       {children}
-    </InlineToolbarContext.Provider>
+    </ContextToolbarContext.Provider>
   );
 };
 
@@ -66,7 +60,7 @@ const Trigger: FC<TriggerProps> = ({
   onMouseDown,
   ...rest
 }) => {
-  const { open, triggerRef } = useInlineToolbarContext();
+  const { open, triggerRef } = useContextToolbarContext();
   const handleClick = useCallback<MouseEventHandler<HTMLDivElement>>((event) => {
     open();
     onClick?.(event);
@@ -100,7 +94,7 @@ const Toolbar: FC<ToolbarProps> = ({
     triggerRef,
     close,
     persistent
-  } = useInlineToolbarContext();
+  } = useContextToolbarContext();
 
   const popoverMode = persistent ? 'manual' : 'auto';
 
@@ -181,7 +175,7 @@ const Toolbar: FC<ToolbarProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [ persistent, handleClickOutside ]);
 
-  const anchorName = useMemo(() => `--${Id.generate('inline-toolbar')}`, []);
+  const anchorName = useMemo(() => `--${Id.generate('context-toolbar')}`, []);
 
   useEffect(() => {
     if (!isOpen || !Type.isNonNullable(triggerRef.current) || !Type.isNonNullable(toolbarRef.current)) {
@@ -199,7 +193,7 @@ const Toolbar: FC<ToolbarProps> = ({
     Css.set(sugarToolbar, 'position-anchor', anchorName);
 
     const gap = Type.isNonNullable(toolbar.ownerDocument?.defaultView)
-      ? Css.get(sugarToolbar, '--inline-toolbar-gap') || '6px'
+      ? Css.get(sugarToolbar, '--context-toolbar-gap') || '6px'
       : '6px';
 
     const topValue = `calc(anchor(${anchorName} bottom) + ${gap})`;
@@ -223,7 +217,7 @@ const Toolbar: FC<ToolbarProps> = ({
     onMouseDown?.(event);
   }, [ onMouseDown ]);
 
-  const toolbarClasses = `tox-inline-toolbar${Type.isNonNullable(className) ? ` ${className}` : ''}`;
+  const toolbarClasses = `tox-context-toolbar${Type.isNonNullable(className) ? ` ${className}` : ''}`;
 
   return (
     <div

--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbarTypes.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbarTypes.tsx
@@ -1,11 +1,11 @@
 import type { CSSProperties, HTMLAttributes, MouseEventHandler, ReactNode, RefObject } from 'react';
 
-export interface InlineToolbarProps {
+export interface ContextToolbarProps {
   readonly children: HTMLAttributes<HTMLDivElement>['children'];
   readonly persistent?: boolean;
 }
 
-export interface InlineToolbarContextValue {
+export interface ContextToolbarContextValue {
   readonly isOpen: boolean;
   readonly open: () => void;
   readonly close: () => void;

--- a/modules/oxide-components/src/main/ts/main.ts
+++ b/modules/oxide-components/src/main/ts/main.ts
@@ -2,7 +2,7 @@ import { AutoResizingTextarea } from './components/autoresizingtextarea/AutoResi
 import { Button } from './components/button/Button';
 import { Draggable } from './components/draggable/Draggable';
 import { IconButton } from './components/iconbutton/IconButton';
-import * as InlineToolbar from './components/inlinetoolbar/InlineToolbar';
+import * as ContextToolbar from './components/contexttoolbar/ContextToolbar';
 import * as KeyboardNavigationTypes from './keynav/keyboard/NavigationTypes';
 import * as KeyboardNavigationHooks from './keynav/KeyboardNavigationHooks';
 import * as FocusHelpers from './utils/FocusHelpers';
@@ -13,7 +13,7 @@ export {
   Draggable,
   FocusHelpers,
   IconButton,
-  InlineToolbar,
+  ContextToolbar,
   KeyboardNavigationHooks,
   KeyboardNavigationTypes
 };

--- a/modules/oxide-components/src/test/ts/browser/components/ContextToolbar.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/ContextToolbar.spec.tsx
@@ -1,12 +1,12 @@
 import { page, userEvent } from '@vitest/browser/context';
-import * as InlineToolbar from 'oxide-components/components/inlinetoolbar/InlineToolbar';
+import * as ContextToolbar from 'oxide-components/components/contexttoolbar/ContextToolbar';
 import { classes } from 'oxide-components/utils/Styles';
 import { Fragment, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
-const triggerTestId = 'inline-toolbar-trigger';
-const toolbarTestId = 'inline-toolbar-toolbar';
+const triggerTestId = 'context-toolbar-trigger';
+const toolbarTestId = 'context-toolbar-toolbar';
 
 const Wrapper = ({ children }: { children: ReactNode }) => {
   return (
@@ -25,21 +25,21 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
   );
 };
 
-describe('browser.inlinetoolbar.InlineToolbar', () => {
+describe('browser.ContextToolbar.ContextToolbar', () => {
   it('TINY-13071: Should render trigger and toolbar', async () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }} />
-        <InlineToolbar.Root>
-          <InlineToolbar.Trigger>
+        <ContextToolbar.Root>
+          <ContextToolbar.Trigger>
             <div data-testid={triggerTestId}>Click Me</div>
-          </InlineToolbar.Trigger>
-          <InlineToolbar.Toolbar>
-            <InlineToolbar.Group>
+          </ContextToolbar.Trigger>
+          <ContextToolbar.Toolbar>
+            <ContextToolbar.Group>
               <div data-testid={toolbarTestId}>Toolbar Content</div>
-            </InlineToolbar.Group>
-          </InlineToolbar.Toolbar>
-        </InlineToolbar.Root>
+            </ContextToolbar.Group>
+          </ContextToolbar.Toolbar>
+        </ContextToolbar.Root>
       </Fragment>,
       { wrapper: Wrapper }
     );
@@ -54,31 +54,31 @@ describe('browser.inlinetoolbar.InlineToolbar', () => {
     await expect.element(toolbar).toBeVisible();
   });
 
-  it('TINY-13071: Should throw error when Trigger used outside of InlineToolbar', () => {
+  it('TINY-13071: Should throw error when Trigger used outside of ContextToolbar', () => {
     expect(() => {
       render(
-        <InlineToolbar.Trigger>
+        <ContextToolbar.Trigger>
           <div data-testid={triggerTestId}>Click Me</div>
-        </InlineToolbar.Trigger>,
+        </ContextToolbar.Trigger>,
         { wrapper: Wrapper }
       );
-    }).toThrow('useInlineToolbarContext must be used within an InlineToolbarProvider');
+    }).toThrow('useContextToolbarContext must be used within an ContextToolbarProvider');
   });
 
   it('TINY-13071: Should close toolbar on click outside when persistent={false}', async () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }}>
-          <InlineToolbar.Root persistent={false}>
-            <InlineToolbar.Trigger>
+          <ContextToolbar.Root persistent={false}>
+            <ContextToolbar.Trigger>
               <div data-testid={triggerTestId}>Click Me</div>
-            </InlineToolbar.Trigger>
-            <InlineToolbar.Toolbar>
-              <InlineToolbar.Group>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
                 <div data-testid={toolbarTestId}>Toolbar Content</div>
-              </InlineToolbar.Group>
-            </InlineToolbar.Toolbar>
-          </InlineToolbar.Root>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
         </div>
       </Fragment>,
       { wrapper: Wrapper }
@@ -101,16 +101,16 @@ describe('browser.inlinetoolbar.InlineToolbar', () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }}>
-          <InlineToolbar.Root>
-            <InlineToolbar.Trigger>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
               <div data-testid={triggerTestId}>Click Me</div>
-            </InlineToolbar.Trigger>
-            <InlineToolbar.Toolbar>
-              <InlineToolbar.Group>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
                 <div data-testid={toolbarTestId}>Toolbar Content</div>
-              </InlineToolbar.Group>
-            </InlineToolbar.Toolbar>
-          </InlineToolbar.Root>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
         </div>
       </Fragment>,
       { wrapper: Wrapper }
@@ -131,16 +131,16 @@ describe('browser.inlinetoolbar.InlineToolbar', () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }}>
-          <InlineToolbar.Root persistent={true}>
-            <InlineToolbar.Trigger>
+          <ContextToolbar.Root persistent={true}>
+            <ContextToolbar.Trigger>
               <div data-testid={triggerTestId}>Click Me</div>
-            </InlineToolbar.Trigger>
-            <InlineToolbar.Toolbar>
-              <InlineToolbar.Group>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
                 <div data-testid={toolbarTestId}>Toolbar Content</div>
-              </InlineToolbar.Group>
-            </InlineToolbar.Toolbar>
-          </InlineToolbar.Root>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
         </div>
       </Fragment>,
       { wrapper: Wrapper }
@@ -161,21 +161,21 @@ describe('browser.inlinetoolbar.InlineToolbar', () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }}>
-          <InlineToolbar.Root>
-            <InlineToolbar.Trigger>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
               <div data-testid={triggerTestId}>Click Me</div>
-            </InlineToolbar.Trigger>
-            <InlineToolbar.Toolbar>
-              <InlineToolbar.Group>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
                 <button data-testid='button1'>Button 1</button>
                 <button data-testid='button2'>Button 2</button>
-              </InlineToolbar.Group>
-              <InlineToolbar.Group>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
                 <button data-testid='button3'>Button 3</button>
                 <button data-testid='button4'>Button 4</button>
-              </InlineToolbar.Group>
-            </InlineToolbar.Toolbar>
-          </InlineToolbar.Root>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
         </div>
       </Fragment>,
       { wrapper: Wrapper }
@@ -200,18 +200,18 @@ describe('browser.inlinetoolbar.InlineToolbar', () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }}>
-          <InlineToolbar.Root>
-            <InlineToolbar.Trigger>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
               <div data-testid={triggerTestId}>Click Me</div>
-            </InlineToolbar.Trigger>
-            <InlineToolbar.Toolbar>
-              <InlineToolbar.Group>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
                 <button data-testid='button1'>Button 1</button>
                 <button data-testid='button2'>Button 2</button>
                 <button data-testid='button3'>Button 3</button>
-              </InlineToolbar.Group>
-            </InlineToolbar.Toolbar>
-          </InlineToolbar.Root>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
         </div>
       </Fragment>,
       { wrapper: Wrapper }
@@ -242,16 +242,16 @@ describe('browser.inlinetoolbar.InlineToolbar', () => {
     const { getByTestId } = render(
       <Fragment>
         <div className='tox' style={{ position: 'relative' }}>
-          <InlineToolbar.Root>
-            <InlineToolbar.Trigger>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
               <div data-testid={triggerTestId}>Click Me</div>
-            </InlineToolbar.Trigger>
-            <InlineToolbar.Toolbar>
-              <InlineToolbar.Group>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
                 <button data-testid='button1' onClick={onClick}>Button 1</button>
-              </InlineToolbar.Group>
-            </InlineToolbar.Toolbar>
-          </InlineToolbar.Root>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
         </div>
       </Fragment>,
       { wrapper: Wrapper }

--- a/modules/oxide/src/less/theme/components/context-toolbar/context-toolbar.less
+++ b/modules/oxide/src/less/theme/components/context-toolbar/context-toolbar.less
@@ -1,10 +1,10 @@
 //
-// Inline Toolbar
+// Context Toolbar
 //
 .tox {
-  .tox-inline-toolbar {
+  .tox-context-toolbar {
     // CSS variable for gap between anchor and toolbar
-    --inline-toolbar-gap: 6px;
+    --context-toolbar-gap: 6px;
 
     // CSS Anchor Positioning (required for anchor() to work)
     position: absolute;

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -52,7 +52,7 @@
 @import 'components/image-preview/image-preview';
 @import 'components/image-tools/image-tools';
 @import 'components/image-selector/image-selector';
-@import 'components/inline-toolbar/inline-toolbar';
+@import 'components/context-toolbar/context-toolbar';
 @import 'components/insert-table-picker/insert-table-picker';
 @import 'components/mentions/mentions';
 @import 'components/menu/menu';


### PR DESCRIPTION
Related Ticket: [TINY-13065](https://ephocks.atlassian.net/browse/TINY-13065)

Description of Changes:
* Wraps up the work on the component by finalizing the Storybook documentation and renaming the component from InlineToolbar to ContextToolbar to match core TinyMCE conventions.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13065]: https://ephocks.atlassian.net/browse/TINY-13065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ