### PR TITLE
TINY-13184: Skip flaking http chunk test

### DIFF
--- a/modules/agar/src/test/ts/browser/http/HttpMockingTest.ts
+++ b/modules/agar/src/test/ts/browser/http/HttpMockingTest.ts
@@ -204,7 +204,8 @@ describe('browser.agar.http.HttpMockingTest', () => {
     Assert.eq('Should be expected state', { count: 2 }, json2);
   });
 
-  it('TINY-13084: Should handle streaming response', async () => {
+  // TINY-13184: Skipped since it's flaking on lambdatest Firefox
+  it.skip('TINY-13084: Should handle streaming response', async () => {
     const response = await window.fetch('/custom/streaming');
     const body = response.body;
 


### PR DESCRIPTION
Related Ticket: TINY-13184

Description of Changes:
* Noticed that this test flakes so disabling it until we have time to look at it

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled a streaming test to improve test suite reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->