### PR TITLE
TINY-13110: create a custom offscreen element for uc-video

### DIFF
--- a/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
+++ b/modules/tinymce/src/core/main/ts/SelectionOverrides.ts
@@ -1,7 +1,6 @@
 import { Arr, Obj, Type, Unicode } from '@ephox/katamari';
 import { Attribute, Compare, Css, Focus, Insert, InsertAll, Remove, SelectorFilter, SelectorFind, SugarElement } from '@ephox/sugar';
 
-import { isUcVideo } from './api/dom/ControlSelection';
 import type Editor from './api/Editor';
 import VK from './api/util/VK';
 import * as CaretContainer from './caret/CaretContainer';
@@ -305,7 +304,7 @@ const SelectionOverrides = (editor: Editor): SelectionOverrides => {
   };
 
   const selectElement = (elm: HTMLElement) => {
-    const targetClone = isUcVideo(elm) ? getUcVideoClone(elm) : elm.cloneNode(true);
+    const targetClone = NodeType.isUcVideo(elm) ? getUcVideoClone(elm) : elm.cloneNode(true);
     const e = editor.dispatch('ObjectSelected', { target: elm, targetClone });
     if (e.isDefaultPrevented()) {
       return null;

--- a/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/ControlSelection.ts
@@ -42,17 +42,8 @@ interface SelectedResizeHandle extends ResizeHandle {
   };
 }
 
-const ucVideoNodeName = 'uc-video' as const;
-
-interface UcVideo extends HTMLElement {
-  nodeName: typeof ucVideoNodeName;
-  width: number;
-  height: number;
-}
-
-export const isUcVideo = (el: Element): el is UcVideo => el.nodeName.toLowerCase() === ucVideoNodeName;
 const elementSelectionAttr = 'data-mce-selected';
-const controlElmSelector = `table,img,figure.image,hr,video,span.mce-preview-object,details,${ucVideoNodeName}`;
+const controlElmSelector = `table,img,figure.image,hr,video,span.mce-preview-object,details,${NodeType.ucVideoNodeName}`;
 const abs = Math.abs;
 const round = Math.round;
 
@@ -172,7 +163,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
         if (target.style[name] || !editor.schema.isValid(target.nodeName.toLowerCase(), name)) {
           dom.setStyle(target, name, value);
         } else {
-          if (isUcVideo(target)) {
+          if (NodeType.isUcVideo(target)) {
             // this is needed because otherwise the ghost for `uc-video` is not correctly rendered
             target[name] = value;
             const minimumWidth = 400;
@@ -213,7 +204,7 @@ const ControlSelection = (selection: EditorSelection, editor: Editor): ControlSe
     width = width < 5 ? 5 : width;
     height = height < 5 ? 5 : height;
 
-    if ((isImage(selectedElm) || isMedia(selectedElm) || isUcVideo(selectedElm)) && Options.getResizeImgProportional(editor) !== false) {
+    if ((isImage(selectedElm) || isMedia(selectedElm) || NodeType.isUcVideo(selectedElm)) && Options.getResizeImgProportional(editor) !== false) {
       proportional = !VK.modifierPressed(e);
     } else {
       proportional = VK.modifierPressed(e);

--- a/modules/tinymce/src/core/main/ts/dom/NodeType.ts
+++ b/modules/tinymce/src/core/main/ts/dom/NodeType.ts
@@ -113,6 +113,16 @@ const isListItem = matchNodeName<HTMLLIElement>('li');
 const isDetails = matchNodeName<HTMLDetailsElement>('details');
 const isSummary = matchNodeName<HTMLElement>('summary');
 
+const ucVideoNodeName = 'uc-video' as const;
+
+interface UcVideo extends HTMLElement {
+  nodeName: typeof ucVideoNodeName;
+  width: number;
+  height: number;
+}
+
+const isUcVideo = (el: Element): el is UcVideo => el.nodeName.toLowerCase() === ucVideoNodeName;
+
 export {
   isText,
   isElement,
@@ -144,5 +154,7 @@ export {
   isTextareaOrInput,
   isListItem,
   isDetails,
-  isSummary
+  isSummary,
+  ucVideoNodeName,
+  isUcVideo
 };


### PR DESCRIPTION
Related Ticket: TINY-13110

Description of Changes:
that element for `uc-video` makes some sort of memory leak that make an audio duplication

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):
