### PR TITLE
TINY-13187: fix the minified css light-dark func

### DIFF
--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
@@ -3,10 +3,7 @@
 //
 
 .tox-sidebar when (@custom-properties-enabled = true) {
-  --tox-private-sidebar-background-color: light-dark(
-    hsl( from var(--tox-private-background-color) h s calc(l - 6)),
-    hsl( from var(--tox-private-background-color) h s calc(l + 10))
-  );
+  --tox-private-sidebar-background-color: light-dark(hsl( from var(--tox-private-background-color) h s calc(l - 6)), hsl( from var(--tox-private-background-color) h s calc(l + 10)));
 }
 
 @sidebar-background-color: contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 10%));


### PR DESCRIPTION
Related Ticket: TINY-13187

Description of Changes:
* Fixed CSS minifier resolving to 5 lines instead of 3 by removing line breaks and extra whitespace from CSS Custom Property declaration

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted theme color variable definition for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->