### PR TITLE
TINY-13045: Include scrollbars in draggable boundaries

### DIFF
--- a/modules/oxide-components/src/main/ts/components/draggable/Draggable.tsx
+++ b/modules/oxide-components/src/main/ts/components/draggable/Draggable.tsx
@@ -1,10 +1,10 @@
 import { Optional } from '@ephox/katamari';
 import { type FC, useState, useMemo, useRef, useCallback, forwardRef } from 'react';
 
-import { boundries, clamp, delta } from './internals/calculations';
+import { boundaries, clamp, delta } from './internals/calculations';
 import { useDraggable, DraggableContext } from './internals/context';
 import { getPositioningStyles } from './internals/styles';
-import type { DraggableProps, DraggableHandleProps, Shift, Position, Boundries, CssPosition } from './internals/types';
+import type { DraggableProps, DraggableHandleProps, Shift, Position, Boundaries, CssPosition } from './internals/types';
 
 const Root = forwardRef<HTMLDivElement, DraggableProps>(({ children, style, initialPosition = { top: 0, left: 0 }, declaredSize, ...props }, ref) => {
   const [ shift, setShift ] = useState<Shift>({ x: 0, y: 0 });
@@ -35,7 +35,7 @@ const Root = forwardRef<HTMLDivElement, DraggableProps>(({ children, style, init
 const Handle: FC<DraggableHandleProps> = ({ children }) => {
   const dragStartElementRef = useRef<Element | null>(null);
   const lastMousePositionRef = useRef<Position>({ x: 0, y: 0 });
-  const boundriesRef = useRef<Boundries>({ x: { min: 0, max: 0 }, y: { min: 0, max: 0 }});
+  const boundariesRef = useRef<Boundaries>({ x: { min: 0, max: 0 }, y: { min: 0, max: 0 }});
   const { setShift, draggableRef, isDragging, setIsDragging, setPosition } = useDraggable();
 
   const stopDragging = useCallback(() => {
@@ -58,14 +58,14 @@ const Handle: FC<DraggableHandleProps> = ({ children }) => {
     const mousePosition = { x: Math.round(event.clientX), y: Math.round(event.clientY) };
     lastMousePositionRef.current = mousePosition;
     const draggableRect = draggableRef.current.getBoundingClientRect();
-    boundriesRef.current = boundries(draggableRect, mousePosition, { x: 0, y: 0 }, { x: document.documentElement.clientWidth, y: document.documentElement.clientHeight });
+    boundariesRef.current = boundaries(draggableRect, mousePosition, { x: 0, y: 0 }, { x: document.documentElement.clientWidth, y: document.documentElement.clientHeight });
   }, [ draggableRef, setIsDragging ]);
 
   const onPointerMove = useCallback((event: React.PointerEvent) => {
     if (isDragging) {
       const currentPointerPosition = {
-        x: clamp(Math.round(event.clientX), boundriesRef.current.x.min, boundriesRef.current.x.max),
-        y: clamp(Math.round(event.clientY), boundriesRef.current.y.min, boundriesRef.current.y.max)
+        x: clamp(Math.round(event.clientX), boundariesRef.current.x.min, boundariesRef.current.x.max),
+        y: clamp(Math.round(event.clientY), boundariesRef.current.y.min, boundariesRef.current.y.max)
       };
       const { deltaX, deltaY } = delta(lastMousePositionRef.current, currentPointerPosition);
       lastMousePositionRef.current = currentPointerPosition;

--- a/modules/oxide-components/src/main/ts/components/draggable/internals/calculations.ts
+++ b/modules/oxide-components/src/main/ts/components/draggable/internals/calculations.ts
@@ -1,10 +1,10 @@
-import type { Boundries, Position, Size } from './types';
+import type { Boundaries, Position, Size } from './types';
 
 const delta = (start: Position, end: Position): { deltaX: number; deltaY: number } => ({ deltaX: end.x - start.x, deltaY: end.y - start.y });
 
 const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
 
-const boundries = (element: Position & Size, startMousePosition: Position, upperLeftCorner: Position, bottomRightCorner: Position): Boundries => {
+const boundaries = (element: Position & Size, startMousePosition: Position, upperLeftCorner: Position, bottomRightCorner: Position): Boundaries => {
   const elementRight = element.x + element.width;
   const elementBottom = element.y + element.height;
 
@@ -20,4 +20,4 @@ const boundries = (element: Position & Size, startMousePosition: Position, upper
   };
 };
 
-export { delta, clamp, boundries };
+export { delta, clamp, boundaries };

--- a/modules/oxide-components/src/main/ts/components/draggable/internals/types.ts
+++ b/modules/oxide-components/src/main/ts/components/draggable/internals/types.ts
@@ -37,7 +37,7 @@ export interface DraggableState {
   setPosition: React.Dispatch<React.SetStateAction<CssPosition | Position>>;
 };
 
-export interface Boundries {
+export interface Boundaries {
   x: { min: number; max: number };
   y: { min: number; max: number };
 };

--- a/modules/oxide-components/src/test/ts/atomic/draggable/calculations.spec.ts
+++ b/modules/oxide-components/src/test/ts/atomic/draggable/calculations.spec.ts
@@ -1,4 +1,4 @@
-import { delta, clamp, boundries } from 'oxide-components/components/draggable/internals/calculations';
+import { delta, clamp, boundaries } from 'oxide-components/components/draggable/internals/calculations';
 import { describe, expect, it } from 'vitest';
 
 describe('browser.draggable.calculations', () => {
@@ -32,16 +32,16 @@ describe('browser.draggable.calculations', () => {
     });
   });
 
-  describe('boundries', () => {
+  describe('boundaries', () => {
     it('should calculate max and min pointer position when left top is in 0, 0', () => {
       const upperLeftCorner = { x: 0, y: 0 };
       const bottomRightCorner = { x: 1500, y: 1500 };
       const element = { x: 50, y: 50, width: 300, height: 300 };
       const mousePosition = { x: 100, y: 100 };
 
-      const calculatedBoundries = boundries(element, mousePosition, upperLeftCorner, bottomRightCorner);
+      const calculatedBoundaries = boundaries(element, mousePosition, upperLeftCorner, bottomRightCorner);
 
-      expect(calculatedBoundries).toMatchObject({
+      expect(calculatedBoundaries).toMatchObject({
         x: {
           min: 50,
           max: 1250
@@ -58,9 +58,9 @@ describe('browser.draggable.calculations', () => {
       const bottomRightCorner = { x: 1500, y: 1500 };
       const element = { x: 700, y: 600, width: 50, height: 50 };
       const mousePosition = { x: 710, y: 620 };
-      const calculatedBoundries = boundries(element, mousePosition, upperLeftCorner, bottomRightCorner);
+      const calculatedBoundaries = boundaries(element, mousePosition, upperLeftCorner, bottomRightCorner);
 
-      expect(calculatedBoundries).toMatchObject({
+      expect(calculatedBoundaries).toMatchObject({
         x: {
           min: 510,
           max: 1460
@@ -72,14 +72,14 @@ describe('browser.draggable.calculations', () => {
       });
     });
 
-    it('should round boundries correctly', () => {
+    it('should round boundaries correctly', () => {
       const upperLeftCorner = { x: 0, y: 0 };
       const bottomRightCorner = { x: 1500, y: 1500 };
       const element = { x: 750, y: 285, width: 250, height: 500 };
       const mousePosition = { x: 751.5, y: 286.5 };
-      const calculatedBoundries = boundries(element, mousePosition, upperLeftCorner, bottomRightCorner);
+      const calculatedBoundaries = boundaries(element, mousePosition, upperLeftCorner, bottomRightCorner);
 
-      expect(calculatedBoundries).toMatchObject({
+      expect(calculatedBoundaries).toMatchObject({
         x: {
           min: 2, // 1.5 rounded up
           max: 1251 // 1251.5 rounded down

--- a/modules/oxide-components/src/test/ts/browser/components/Draggable.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Draggable.spec.tsx
@@ -95,7 +95,7 @@ describe('browser.draggable.Draggable', () => {
     assertPosition(draggableWrapper, { top: 0, left: 0 });
   });
 
-  it('TINY-12875: Should not exceed boundries', async () => {
+  it('TINY-12875: Should not exceed boundaries', async () => {
     const viewportWidth = 1500;
     const viewportHeight = 1300;
     const elementWidth = 300;


### PR DESCRIPTION
Related Ticket: TINY-13045

Description of Changes:
* Include scrollbars in draggable boundaries, so that draggable element can't go below scrollbar

Pre-checks:
~~* [ ] Changelog entry added~~
~~* [ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
~~* [ ] Milestone set~~
~~* [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed naming inconsistencies in draggable component boundary handling.
  * Improved viewport dimension detection for more accurate boundary constraints during drag operations.

* **Tests**
  * Updated test suite to validate boundary calculation refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->