### PR TITLE
TINY-12910: Added streaming response bubble to core.

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinyai/responses/StreamingAiResponse.stories.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinyai/responses/StreamingAiResponse.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { StreamingAiResponse } from './StreamingAiResponse';
+
+const meta = {
+  title: 'bespoke/tinyai/StreamingAiResponse',
+  component: StreamingAiResponse,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: 'centered',
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: [ 'autodocs', 'skip-visual-testing' ],
+} satisfies Meta<typeof StreamingAiResponse>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const SimpleStreamingAiResponse: Story = {
+  args: {
+    response: 'Value'
+  },
+};

--- a/modules/oxide-components/src/main/ts/bespoke/tinyai/responses/StreamingAiResponse.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinyai/responses/StreamingAiResponse.tsx
@@ -1,0 +1,21 @@
+import type { FunctionComponent } from 'react';
+
+import { classes } from '../../../utils/Styles';
+import { Spinner } from '../spinner/Spinner';
+
+interface AiResponseProps {
+  readonly response: string;
+}
+
+export const StreamingAiResponse: FunctionComponent<AiResponseProps> = ({ response }) => {
+  return (
+    <div className={classes([ 'tox-ai__response', 'tox-ai__response-streaming' ])}>
+      <div className={classes([ 'tox-ai__response' ])}>
+        <Spinner />
+      </div>
+      <div className={classes([ 'tox-ai__response' ])}>
+        {response}
+      </div>
+    </div>
+  );
+};

--- a/modules/oxide-components/src/main/ts/main.ts
+++ b/modules/oxide-components/src/main/ts/main.ts
@@ -1,4 +1,5 @@
 import ErrorMessage from './bespoke/tinyai/error/ErrorMessage';
+import { StreamingAiResponse } from './bespoke/tinyai/responses/StreamingAiResponse';
 import { Spinner } from './bespoke/tinyai/spinner/Spinner';
 import { Tag } from './bespoke/tinyai/tag/Tag';
 import { AutoResizingTextarea } from './components/autoresizingtextarea/AutoResizingTextarea';
@@ -25,5 +26,6 @@ export {
   KeyboardNavigationHooks,
   KeyboardNavigationTypes,
   Spinner,
+  StreamingAiResponse,
   Tag
 };


### PR DESCRIPTION
Related Ticket: TINY-12910

Description of Changes:
Moved over streaming response bubble

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new streaming AI response component that displays AI-generated content with a visual loading indicator during response generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->