### PR TITLE
TINY-13275: Omit licensekeymanager from showing in help dialog

### DIFF
--- a/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
+++ b/modules/tinymce/src/plugins/help/main/ts/ui/PluginsTab.ts
@@ -66,7 +66,7 @@ const tab = (editor: Editor): Dialog.TabSpec & { name: string } => {
   const getPluginKeys = (editor: Editor) => {
     const keys = Obj.keys(editor.plugins);
     const forcedPlugins = Options.getForcedPlugins(editor);
-    const hiddenPlugins = Type.isUndefined(forcedPlugins) ? [ 'onboarding' ] : forcedPlugins.concat([ 'onboarding' ] );
+    const hiddenPlugins = Type.isUndefined(forcedPlugins) ? [ 'onboarding', 'licensekeymanager' ] : forcedPlugins.concat([ 'onboarding', 'licensekeymanager' ] );
 
     return Arr.filter(keys, (k) => !Arr.contains(hiddenPlugins, k));
   };


### PR DESCRIPTION
Related Ticket: TINY-13275

Description of Changes:
* Added 'licensekeymanager' to the list of hidden plugins in the Help plugin's PluginsTab so that it doesn't show even if in the 'plugins' option list

Pre-checks:
* ~~[ ] Changelog entry added~~
* ~~[ ] Tests have been added (if applicable)~~
* [X] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):