### PR TITLE
TINY-13212: add wide sidebar css

### DIFF
--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-content.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-content.less
@@ -15,6 +15,12 @@
     max-width: 300px;
     width: 300px;
     border-left: 1px solid var(--tox-private-sidebar-border-color, darken(@background-color, 11%));
+
+    &--wide {
+      min-width: 440px;
+      max-width: 440px;
+      width: 440px;
+    }
   }
 
   .tox-sidebar-content__header {


### PR DESCRIPTION
Related Ticket: TINY-13212

Description of Changes:
* Added a new `--wide` modifier class to the sidebar content component that increases the width from 300px to 440px

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] ~~Milestone set~~ (targeting epic branch)
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):