### PR TITLE
TINY-13218: Fix width of user prompt bubble

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -3,12 +3,13 @@
   --tox-private-ai-footer-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 11));
 }
 
-.tox-ai {
+.tox .tox-ai {
   .tox-ai__user-prompt {
     display: flex;
     flex-direction: column;
     margin-left: auto;
     gap: inherit;
+    width: 100%;
   }
 
   .tox-ai__user-prompt__context {
@@ -150,5 +151,10 @@
 
   .tox-ai__models-menu__item__description__ability {
     font-weight: var(--tox-private-font-weight-bold, @font-weight-bold);
+  }
+
+  .tox-tooltip {
+    display: none;
+    padding: var(--tox-private-pad-xs, @pad-xs) 0 0;
   }
 }


### PR DESCRIPTION
Related Ticket:  TINY-13218

Description of Changes:
* Added `.tox` parent selector to `.tox-ai` to increase specificity
* Added `width: 100%` to `.tox-ai__user-prompt` to ensure proper sizing
* Added styling for `.tox-tooltip` within the AI chat component to control its display and padding

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):