### PR TITLE
TINY-13095: update toggle css to transitional stage

### DIFF
--- a/modules/oxide/src/less/theme/components/toggle/toggle.less
+++ b/modules/oxide/src/less/theme/components/toggle/toggle.less
@@ -1,19 +1,26 @@
 .tox {
-  .tox-toggle {
-    // private variables scoped to tox-toggle class
-    --tox-private-slider-background-color: @background-color;
-    --tox-private-slider-border-color: .bg-luma-checker(hsl(from @color-white h s calc(l - 11)), hsla(from @color-white h s l / 15%))[@result]; // to be figured out after the spike with conditionals in CSS
-    --tox-private-slider-handle-background-color: @text-color;
+  .tox-toggle when (@custom-properties-enabled = true) {
+    --tox-private-slider-background-color: var(--tox-private-background-color);
+    --tox-private-slider-border-color: light-dark(
+      hsl(from var(--tox-private-color-white) h s calc(l - 11)), 
+      hsl(from var(--tox-private-color-white) h s l / 15%));
+    --tox-private-slider-handle-background-color: var(--tox-private-text-color);
 
+    --tox-private-slider-checked-background-color: var(--tox-private-color-tint);
+    --tox-private-slider-checked-border-color: var(--tox-private-color-tint);
+    --tox-private-slider-checked-handle-background-color: var(--tox-private-color-white);
+  }
+
+  .tox-toggle {
     display: flex;
     align-items: center;
-    gap: @pad-xs;
-    padding: @pad-xs;
-    font-weight: @font-weight-normal;
-    line-height: 24px; // the same as in button and textfield. Button component is referencing the textfield variable so maybe it should be a global API? The textfield has a fixed value for line-height
+    gap: var(--tox-private-pad-xs, @pad-xs);
+    padding: var(--tox-private-pad-xs, @pad-xs);
+    font-weight: var(--tox-private-font-weight-normal, @font-weight-normal);
+    line-height: var(--tox-private-control-line-height, 24px);
     white-space: nowrap;
-    background-color: @background-color;
-    color: @text-color;
+    background-color: var(--tox-private-background-color, @background-color);
+    color: var(--tox-private-text-color, @text-color);
 
     input {
       position: absolute;
@@ -32,8 +39,10 @@
     border-radius: 34px; 
     width: 28px;
     height: 16px;
-    background-color: var(--tox-private-slider-background-color);
-    border: 1px solid var(--tox-private-slider-border-color);
+    background-color: var(--tox-private-slider-background-color, @background-color);
+    border: 1px solid var(
+      --tox-private-slider-border-color,
+      .bg-luma-checker(darken(@color-white, 11%), fade(@color-white, 15%))[@result]);
   }
 
   .tox-toggle__slider::before {
@@ -46,23 +55,23 @@
     -webkit-transition: 0.4s;
     transition: 0.4s;
     border-radius: 50%;
-    background-color: var(--tox-private-slider-handle-background-color);
+    background-color: var(--tox-private-slider-handle-background-color, @text-color);
   }
     
   input:checked + .tox-toggle__slider {
-    --tox-private-slider-background-color: @color-tint;
-    --tox-private-slider-border-color: @color-tint;
+    background-color: var(--tox-private-slider-checked-background-color, @color-tint);
+    border: 1px solid var(--tox-private-slider-checked-border-color, @color-tint);
   }
   
   input:focus + .tox-toggle__slider {
-    box-shadow: 0 0 0 1px @color-white, 0 0 0 2px @color-tint;
+    box-shadow: 0 0 0 1px var(--tox-private-color-white, @color-white), 0 0 0 2px var(--tox-private-color-tint, @color-tint);
   }
   
   input:checked + .tox-toggle__slider::before {
     -webkit-transform: translateX(12px);
     -ms-transform: translateX(12px);
     transform: translateX(12px);
-    --tox-private-slider-handle-background-color: @color-white;
+    background-color: var(--tox-private-slider-checked-handle-background-color, @color-white);
   }
 
   input:disabled + .tox-toggle__slider::before {


### PR DESCRIPTION
Related Ticket: TINY-13095

Description of Changes:
* Updated the toggle component to use CSS custom properties and follow CSS transitional stage guidelines 
* Add fallback values for CSS Custom Properties
* Added conditional loading of custom properties based on the `@custom-properties-enabled` flag
* Improved variable organization for toggle states (checked, unchecked)

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced toggle component styling to support theme customization using CSS custom properties with fallback values for improved design flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->