### PR TITLE
TINY-13258: Rename attribute to make all highlight sit above dimming

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -20,7 +20,7 @@
   @tinyai-selected-box-shadow
 );
 
-div[tinyai-data-active-diff="true"], span[tinyai-data-active-diff="true"] {
+div[tinyai-data-pending-diff="true"], span[tinyai-data-pending-diff="true"] {
   position: relative;
   z-index: 1;
   background: @color-white;


### PR DESCRIPTION
Related Ticket: TINY-13258

Description of Changes:
* Rename attribute to make all highlight sit above dimming

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):