### PR TITLE
TINY-13199: fix default margin to `uc-video`

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13199-2025-11-25.yaml
+++ b/.changes/unreleased/tinymce-TINY-13199-2025-11-25.yaml
@@ -1,6 +1,0 @@
-project: tinymce
-kind: Improved
-body: Now `uc-video` has proper customizable margins.
-time: 2025-11-25T16:11:27.516335794+01:00
-custom:
-  Issue: TINY-13199


### PR DESCRIPTION
Related Ticket: TINY-13199

Description of Changes:
fix margin style for `uc-video`

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * The Uploadcare video component now supports customizable margins for greater layout and spacing flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->