### PR TITLE
TINY-13310: Change the border-radius of the ContextToolbar component

### DIFF
--- a/modules/oxide/src/less/theme/components/context-toolbar/context-toolbar.less
+++ b/modules/oxide/src/less/theme/components/context-toolbar/context-toolbar.less
@@ -13,7 +13,7 @@
 
     background-color: #ffffff;
     border: 1px solid #e0e0e0;
-    border-radius: 9px;
+    border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     padding: 4px;
 


### PR DESCRIPTION
Related Ticket: [TINY-13310](https://ephocks.atlassian.net/browse/TINY-13310)

Description of Changes:
* Changes the `border-radius` of the new ContextToolbar component from `9px` to `6px` to match the design.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13310]: https://ephocks.atlassian.net/browse/TINY-13310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ