### PR TITLE
TINY-13362: Add a slight top-border to the `tinyai__bottom-bar`

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -10,7 +10,6 @@
 @tinymceai-selected-box-shadow: 0 -2px 0 0 @tinymceai-selected-outline-color inset, 0 -2px 0 0 @tinymceai-selected-outline-color;
 
 @tinymceai-dim-overlay-color: #222f3e80;
-@tinymceai-bottom-bar-border-color: #E3E3E3;
 
 .diff-content(
   tinymceai,
@@ -54,5 +53,5 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
   padding: 12px @pad-md;
   background: @color-white;
   z-index: 2;
-  border-top: 1px solid @tinymceai-bottom-bar-border-color;
+  border-top: 1px solid hsl(from var(--tox-color-white, @color-white) h s calc(l - 11));
 }


### PR DESCRIPTION
Related Ticket: [TINY-13362](https://ephocks.atlassian.net/browse/TINY-13362)

Description of Changes:
* Add a `border-top` to the bottom bar in the TinyMCE AI plugin so that there is separation between the iframe content and that bottom bar to match the design.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13362]: https://ephocks.atlassian.net/browse/TINY-13362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ