### PR TITLE
TINY-13376: Truncate ai chat title when it overflows

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -4,6 +4,13 @@
 }
 
 .tox .tox-ai {
+
+  .tox-sidebar-content__title {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
   .tox-ai__user-prompt {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Related Ticket: TINY-13376

Description of Changes:
* Added text overflow handling to the AI chat sidebar title with ellipsis, hidden overflow, and nowrap styling

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):