### PR TITLE
Fix: MediaResolver invalid after dimensions change

### DIFF
--- a/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/media/main/ts/ui/Dialog.ts
@@ -210,7 +210,7 @@ const showDialog = (editor: Editor): void => {
         ? { ...dialogData, embed: '' }
         : dialogData;
 
-    const embed = dataToHtml(editor, data);
+    const embed = dataToHtml(editor, data.embed ? { ...data, source: HtmlToData.htmlToData(data.embed, editor.schema).source } : data);
     api.setData(wrap({
       ...data,
       embed


### PR DESCRIPTION
Related Ticket: 
https://github.com/tinymce/tinymce/issues/9798

Description of Changes:
* Run htmlToData again after dimensions changed to prevent custom MediaResolver rules invalid.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
https://github.com/tinymce/tinymce/issues/9798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the media embed functionality to ensure proper synchronization between embed content and generated HTML, resulting in more reliable embed handling in the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->