### PR TITLE
TINY-13377: Add styles of the chat history items

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -205,4 +205,52 @@
     display: none;
     padding: var(--tox-private-pad-xs, @pad-xs) 0 0;
   }
+
+  .tox-ai-chat-history-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tox-private-pad-sm, @pad-sm);
+    padding-top: var(--tox-private-pad-xs, @pad-xs);
+    width: 100%;
+  }
+
+  .tox-ai-chat-history-list__title {
+    color: var(--tox-private-text-color-muted, @text-color-muted);
+    font-size: var(--tox-private-font-size-sm, @font-size-sm);
+    font-weight: var(--tox-private-font-weight-bold, @font-weight-bold);
+    line-height: 18px;
+    letter-spacing: 1px;
+  }
+
+  .tox-ai-chat-history-list__item {
+    display: flex;
+    // TODO: Replace with a proper global variable once we have it setup
+    padding: 12px;
+    gap: 8px;
+    &:hover {
+      // TODO: Replace with a proper global variable once we have it setup
+      background-color: #f0f0f0;
+    }
+    border-radius: var(--tox-private-control-border-radius, @control-border-radius);
+  }
+
+  .tox-ai-chat-history-list__item-content {
+    display: flex;
+    flex-direction: column;
+    margin-right: auto;
+  }
+
+  .tox-ai-chat-history-list__item-content-title {
+    color: var(--tox-private-text-color, @text-color);
+    font-size: var(--tox-private-font-size-base, @font-size-base);
+    font-weight: var(--tox-private-font-weight-bold, @font-weight-bold);
+    line-height: var(--tox-private-font-size-lg, @font-size-lg);
+  }
+
+  .tox-ai-chat-history-list__item-content-date {
+    color: var(--tox-private-text-color, @text-color);
+    font-size: var(--tox-private-font-size-xs, @font-size-xs);
+    line-height: var(--tox-private-line-height-base, @line-height-base);
+  }
+
 }


### PR DESCRIPTION
Related Ticket: TINY-13377

Description of Changes:
* Added styling for AI chat history list component
* Implemented styles for history list items, including title, content, and date
* Added hover effects for list items
* Set up proper spacing, colors, and typography for the chat history UI

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):