### PR TITLE
TINY-13484: Fix failing CopyAndPasteTest caused by lastest Chrome

### DIFF
--- a/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
+++ b/modules/tinymce/src/core/test/ts/module/test/PasteEventUtils.ts
@@ -70,15 +70,10 @@ const pWaitForAndAssertInputEvents = async (beforeinputEvent: SingletonEvent<Inp
   const assertInputEvent = (): void =>
     inputEvent.on((e) => {
       assert.equal(e.inputType, 'insertFromPaste', 'beforeinput event type should be "insertFromPaste"');
-      // TINY-11373: Chromium >= 129, e.data is no longer null when pasting plain text
       // TINY-12342: Chromium > 137, e.data once again null when pasting plain text
-      if (isNative && browser.isChromium() && browser.version.major >= 129 && browser.version.major <= 137) {
-        assert.isNotNull(e.data, 'input event data should not be null');
-      } else {
-        assert.isNull(e.data, 'input event data should be null');
-      }
+      assert.isNull(e.data, 'input event data should be null');
       const dataTransfer = e.dataTransfer;
-      if (isNative && (browser.isFirefox() || browser.isSafari())) {
+      if (isNative && (browser.isFirefox() || browser.isSafari() || (browser.isChromium() && browser.version.major >= 143))) {
         assert.equal(dataTransfer?.getData('text/html'), expectedBeforeinputDataTransferHtml, 'input event dataTransfer should contain expected html data');
       } else {
         assert.isNull(dataTransfer, 'input event dataTransfer should be null');


### PR DESCRIPTION
Related Ticket:  TINY-13484

Description of Changes:
* Chrome 143 fixed an issue where `DataTransfer` was not populated for `insertFromPaste`, `insertFromDrop`, and `insertReplacementText` input events. As a result, the test now fails because the test expectations were written against the old behavior.
* Changelog: https://developer.chrome.com/release-notes/143#datatransfer_property_for_insertfrompaste_insertfromdrop_and_insertreplacementtext_input_events
* Fiddle: https://jsfiddle.net/mLxg4vq6/ (try pasting in to the CeF and observe log)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
