### PR TITLE
TINY-12884: prevent refresh of `uc-video` at first level

### DIFF
--- a/modules/tinymce/src/core/main/ts/undo/Levels.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Levels.ts
@@ -14,7 +14,7 @@ import type { CompleteUndoLevel, FragmentedUndoLevel, NewUndoLevel, UndoLevel } 
 // innerHTML on a detached element will still make http requests to the images
 const lazyTempDocument = Thunk.cached(() => document.implementation.createHTMLDocument('undo'));
 
-const shouldBeFragmented = (body: HTMLElement) => body.querySelector('iframe') !== null || body.querySelector(NodeType.ucVideoNodeName) !== null;
+const shouldBeFragmented = (body: HTMLElement) => body.querySelector(`iframe, ${NodeType.ucVideoNodeName}`) !== null;
 
 const createFragmentedLevel = (fragments: string[]): FragmentedUndoLevel => {
   return {


### PR DESCRIPTION
Related Ticket: TINY-12884

Description of Changes:
this avoid `uc-video` reload on undo/redo like we do for `iFrame`

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] don't merge before `8.3.1`
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved undo handling to better detect embedded media (iframes and video-like nodes) and choose the appropriate snapshot strategy, increasing reliability when editing content containing those elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->