### PR TITLE
TINY-13517: change FloatingSidebar default size, add configuration through css variables

### DIFF
--- a/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.stories.tsx
@@ -46,14 +46,6 @@ When dragged, the sidebar remains within viewport bounds and maintains its posit
         defaultValue: { summary: 'true' }
       }
     },
-    height: {
-      description: 'The requested height of the sidebar. The actual height may be constrained by viewport size.',
-      control: 'text',
-      table: {
-        type: { summary: 'text' },
-        defaultValue: { summary: '600px' }
-      }
-    },
     initialPosition: {
       description: `The initial position of the sidebar with x and y coordinates, and an origin point.
 The origin determines which corner of the sidebar is anchored to the coordinates:
@@ -141,7 +133,6 @@ export const InitialPosition: StoryObj<InitialPositionStoryArgs & FloatingSideba
   name: 'Initial position',
   args: {
     origin: 'bottomright',
-    height: '250px',
   },
   argTypes: {
     origin: {
@@ -157,8 +148,8 @@ export const InitialPosition: StoryObj<InitialPositionStoryArgs & FloatingSideba
       <div style={{ position: 'absolute', top: 300, left: 400, height: '15px', width: '15px', backgroundColor: 'red' }}></div>
       <FloatingSidebar.Root
         key={args.origin}
+        style={{ '--tox-private-floating-sidebar-height': '250px' }}
         isOpen={true}
-        height={args.height}
         initialPosition={{ x: 400, y: 300, origin: args.origin }}
       >
         <FloatingSidebar.Header>

--- a/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.tsx
+++ b/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.tsx
@@ -1,5 +1,4 @@
-import type { Property } from 'csstype';
-import { useRef, type FC, type PropsWithChildren } from 'react';
+import { useRef, type CSSProperties, type FC, type PropsWithChildren } from 'react';
 
 import * as Bem from '../../utils/Bem';
 import { classes } from '../../utils/Styles';
@@ -14,8 +13,8 @@ interface InitialPosition {
 }
 export interface FloatingSidebarProps extends PropsWithChildren {
   isOpen?: boolean;
-  height?: Property.Height;
   initialPosition?: InitialPosition;
+  style?: CSSProperties;
 }
 interface HeaderProps extends PropsWithChildren {};
 
@@ -32,7 +31,7 @@ const transformToCss = (position: InitialPosition): CssPosition => {
   }
 };
 
-const Root: FC<FloatingSidebarProps> = ({ isOpen = true, height = '600px', children, ...props }) => {
+const Root: FC<FloatingSidebarProps> = ({ isOpen = true, children, style, ...props }) => {
   const elementRef = useRef<HTMLDivElement | null>(null);
   const initialPosition = transformToCss(props.initialPosition ?? { x: 0, y: 0, origin: 'topleft' });
 
@@ -40,9 +39,9 @@ const Root: FC<FloatingSidebarProps> = ({ isOpen = true, height = '600px', child
     <Draggable.Root
       ref={elementRef}
       className={Bem.block('tox-floating-sidebar', { open: isOpen })}
-      style={{ '--tox-private-floating-sidebar-requested-height': height }}
       initialPosition={initialPosition}
       declaredSize={{ width: 'var(--tox-private-floating-sidebar-width)', height: 'var(--tox-private-floating-sidebar-height)' }}
+      style={style}
     >
       <aside className={classes([ 'tox-floating-sidebar__content-wrapper' ])}>
         { children }

--- a/modules/oxide-components/src/main/ts/module/css.ts
+++ b/modules/oxide-components/src/main/ts/module/css.ts
@@ -3,7 +3,8 @@ import type * as CSS from 'csstype';
 declare module 'csstype' {
   interface Properties {
     // Allow CSS custom property
-    '--tox-private-floating-sidebar-requested-height'?: CSS.Property.Height;
+    '--tox-private-floating-sidebar-width'?: CSS.Property.Width;
+    '--tox-private-floating-sidebar-height'?: CSS.Property.Height;
     '--tox-private-floating-sidebar-requested-top'?: CSS.Property.Top;
     '--tox-private-floating-sidebar-requested-left'?: CSS.Property.Left;
   }

--- a/modules/oxide-components/src/test/ts/browser/components/FloatingSidebar.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/FloatingSidebar.spec.tsx
@@ -201,7 +201,7 @@ describe('browser.components.FloatingSidebar', () => {
 
     const renderWithPosition = (initialPosition: { x: number; y: number; origin: 'topleft' | 'topright' | 'bottomleft' | 'bottomright' }): { containerElement: HTMLElement } => {
       const { getByTestId } = render(
-        <FloatingSidebar.Root initialPosition={initialPosition} height={'100px'}>
+        <FloatingSidebar.Root initialPosition={initialPosition} style={{ '--tox-private-floating-sidebar-height': '100px' }}>
           <FloatingSidebar.Header>
             <div data-testid={floatingSidebarHeaderTestId}>Header</div>
           </FloatingSidebar.Header>

--- a/modules/oxide/src/less/theme/components/floating-sidebar/floating-sidebar.less
+++ b/modules/oxide/src/less/theme/components/floating-sidebar/floating-sidebar.less
@@ -4,10 +4,9 @@
 
 .tox {
   .tox-floating-sidebar {
-    // This is our internal variable, it's not meant to be a part of an external skinning API. It's value is being set by javascript. It is not behind a feature flag on purpose.
-    --tox-private-floating-sidebar-requested-height: 600px;
+    // This is our internal variable, it's not meant to be a part of an external skinning API. It is not behind a feature flag on purpose.
     --tox-private-floating-sidebar-width: min(380px, 90vw);
-    --tox-private-floating-sidebar-height: ~"min(var(--tox-private-floating-sidebar-requested-height), 80vh)";
+    --tox-private-floating-sidebar-height: 80vh;
 
     position: fixed;
     z-index: var(--tox-private-z-index-floatingsidebar, @z-index-floatingsidebar);


### PR DESCRIPTION
Related Ticket: TINY-13517

Description of Changes:

- Set floating sidebar height to `80vh`
- Remove `height` property
- Expose `style` property. Developers can change sidebars size through css variables, defined inline on `FloatingSidebar` element.

Pre-checks:

~~- [ ] Changelog entry added~~
~~- [ ] Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

~~- [ ] Milestone set~~
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):