### PR TITLE
TINY-13536: Fix issue where suggestions made to list items didn't receive highlighting

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -26,6 +26,10 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
   background: @color-white;
 }
 
+span[tinymceai-data-pending-diff="true"]:has(li, p, div, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, pre, table) {
+  display: block;
+}
+
 .tox-tinymceai__dim-overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
Related Ticket: [TINY-13536](https://ephocks.atlassian.net/browse/TINY-13536)

Description of Changes:
* Suggestions are wrapped in either a div or span element and we apply a white background to this element in order to achieve the highlighting effect in the diff preview. This works fine when the parent is a div but if the parent element is a span and its children are block-level elements, they don't necessarily respect the styling of the parent, especially when it comes to background colors. 
* This PR applies an inline-block styling to that parent span element if it contains children which are block-level elements so that the highlighting is applied correctly in these cases.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13536]: https://ephocks.atlassian.net/browse/TINY-13536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ