### PR TITLE
TINY-13213: Prevent list element selection from being overzealous

### DIFF
--- a/modules/tinymce/src/core/main/ts/lists/actions/ToggleList.ts
+++ b/modules/tinymce/src/core/main/ts/lists/actions/ToggleList.ts
@@ -219,7 +219,7 @@ const getRootSearchStart = (editor: Editor, range: Range): Node => {
 const applyList = (editor: Editor, listName: string, detail: ListDetail): void => {
   const rng = editor.selection.getRng();
   let listItemName = 'LI';
-  const root = Selection.getClosestListHost(editor, getRootSearchStart(editor, rng));
+  const root = Selection.getClosestListHost(editor, getRootSearchStart(editor, rng), rng.collapsed);
   const dom = editor.dom;
 
   if (dom.getContentEditable(editor.selection.getNode()) === 'false') {

--- a/modules/tinymce/src/core/test/ts/browser/lists/ApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/lists/ApplyTest.ts
@@ -22,6 +22,24 @@ describe('browser.tinymce.core.lists.ApplyTest', () => {
     base_url: '/project/tinymce/js/tinymce'
   });
 
+  const forcedhook = TinyHooks.bddSetupLight<Editor>({
+    plugins: '',
+    add_unload_trigger: false,
+    disable_nodechange: true,
+    indent: false,
+    entities: 'raw',
+    extended_valid_elements:
+      'li[style|class|data-custom|data-custom1|data-custom2],ol[style|class|data-custom|data-custom1|data-custom2],' +
+      'ul[style|class|data-custom|data-custom1|data-custom2],dl,dt,dd,em,strong,span,#p,div,br',
+    forced_root_block: 'div',
+    valid_styles: {
+      '*': 'color,font-size,font-family,background-color,font-weight,' +
+        'font-style,text-decoration,float,margin,margin-top,margin-right,' +
+        'margin-bottom,margin-left,display,position,top,left,list-style-type'
+    },
+    base_url: '/project/tinymce/js/tinymce'
+  });
+
   it('TBA: Apply UL list to single P', () => {
     const editor = hook.editor();
     editor.setContent('<p>a</p>');
@@ -908,6 +926,49 @@ describe('browser.tinymce.core.lists.ApplyTest', () => {
     editor.execCommand('bold');
     editor.execCommand('InsertUnorderedList');
     TinyAssertions.assertContent(editor, '<p><strong>a</strong></p><ul><li></li></ul><p><strong>b</strong></p>');
+  });
+
+  it('TINY-13213: Apply OL to UL list', () => {
+    const editor = forcedhook.editor();
+    editor.setContent(
+      '<div>' +
+      '<div>' +
+      '<span>AAA</span>' +
+      '</div>' +
+      '<br>' +
+      '<div>' +
+      '<span>BBB</span>' +
+      '</div>' +
+      '<br>' +
+      '<div>' +
+      '<span>CCC</span>' +
+      '</div>' +
+      '</div>'
+    );
+
+    TinySelections.setSelection(editor, [ 0, 0, 0, 0 ], 2, [ 0, 1 ], 0);
+    editor.execCommand('InsertOrderedList');
+
+    TinyAssertions.assertContent(
+      editor,
+      '<div>' +
+      '<ol>' +
+      '<li>' +
+      '<span>AAA</span>' +
+      '</li>' +
+      '<li>' +
+      '</li>' +
+      '</ol>' +
+      '<div>' +
+      '<span>BBB</span>' +
+      '</div>' +
+      '<br>' +
+      '<div>' +
+      '<span>CCC</span>' +
+      '</div>' +
+      '</div>'
+    );
+    TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0 ], 2, [ 0, 0, 1 ], 0);
   });
 
   context('Parent context', () => {

--- a/modules/tinymce/src/plugins/lists/main/ts/ui/Util.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/ui/Util.ts
@@ -52,13 +52,13 @@ const listSelector = listNames.join(',');
 const getParentList = (editor: Editor, node?: Node): HTMLElement | null => {
   const selectionStart = node || editor.selection.getStart(true);
 
-  return editor.dom.getParent(selectionStart, listSelector, getClosestListHost(editor, selectionStart));
+  return editor.dom.getParent(selectionStart, listSelector, getClosestListHost(editor, selectionStart, editor.selection.isCollapsed()));
 };
 
-const getClosestListHost = (editor: Editor, elm: Node): HTMLElement => {
+const getClosestListHost = (editor: Editor, elm: Node, isCollapsed: boolean): HTMLElement => {
   const parentBlocks = editor.dom.getParents<HTMLElement>(elm, editor.dom.isBlock);
   const isNotForcedRootBlock = (elm: HTMLElement) => elm.nodeName.toLowerCase() !== getForcedRootBlock(editor);
-  const parentBlock = Arr.find(parentBlocks, (elm) => isNotForcedRootBlock(elm) && isListHost(editor.schema, elm));
+  const parentBlock = Arr.find(parentBlocks, (elm) => (!isCollapsed || isNotForcedRootBlock(elm)) && isListHost(editor.schema, elm));
 
   return parentBlock.getOr(editor.getBody());
 };


### PR DESCRIPTION
Related Ticket: TINY-13213

Description of Changes:
If we are dealing with a non-collapsed range we want to ignore the forced root block as it causes the selection to step too far up and into parent elements ( it keeps going up divs, if you have a structure with several divs I'd just end up selecting everything after ).
The original issue that caused the check appears to have something to do with empty selection ranges, so this one attempts to side-step that issue by skipping that check if the selection is not collapsed.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved handling of list operations when the text selection is collapsed, ensuring correct list context is maintained.
* Fixed issue when applying ordered list formatting to unordered lists, preserving the correct structure and selection state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->