### PR TITLE
TINY-13374: Add styles and api needed for renaming a conversation

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/spinner/Spinner.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/spinner/Spinner.tsx
@@ -1,6 +1,5 @@
+import { Bem } from 'oxide-components/main';
 import type { FunctionComponent } from 'react';
-
-import * as Bem from '../../../utils/Bem';
 
 interface SpinnerProps {
   type?: 'circle' | 'dots';

--- a/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
+++ b/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
@@ -38,8 +38,7 @@ export const useTabKeyNavigation = (props: TabKeyingProps): void => {
     } else {
       return Fun.noop;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [ props ]);
 };
 
 export interface FlowKeyingProps extends BaseProps, FlowType.FlowConfig { }
@@ -54,8 +53,7 @@ export const useFlowKeyNavigation = (props: FlowKeyingProps): void => {
     } else {
       return Fun.noop;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [ props ]);
 };
 
 export interface SpecialKeyingProps extends BaseProps, SpecialType.SpecialConfig { }

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/TabbingType.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/TabbingType.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
-import { Compare, Height, SelectorFilter, SelectorFind, SugarElement, Traverse } from '@ephox/sugar';
+import { Compare, Height, SelectorFilter, SelectorFind, type SugarElement, Traverse } from '@ephox/sugar';
 
 import * as ArrNavigation from '../navigation/ArrNavigation';
 

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -1,5 +1,5 @@
 .tox-ai when (@custom-properties-enabled = true) {
-  --tox-private-ai-user-prompt-background: hsl( from var(--tox-private-background-color) h s calc(l - 6));
+  --tox-private-background-secondary: hsl( from var(--tox-private-background-color) h s calc(l - 6));
   --tox-private-ai-footer-border-color: hsl( from var(--tox-private-background-color) h s calc(l - 11));
 }
 
@@ -30,7 +30,7 @@
   }
 
   .tox-ai__user-prompt__text {
-    background-color: var(--tox-private-ai-user-prompt-background, darken(@background-color, 6%));
+    background-color: var(--tox-private-background-secondary, darken(@background-color, 6%));
     padding: var(--tox-private-pad-sm, @pad-sm) 12px;
     border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     max-width: 80%;
@@ -49,6 +49,10 @@
     gap: 12px;
     flex: 1 0 0;
     align-self: stretch;
+  }
+
+  .tox-ai__spinner svg {
+    fill: var(--tox-private-color-tint, @color-tint);
   }
 
   .tox-ai__response {
@@ -239,13 +243,29 @@
     // TODO: Replace with a proper global variable once we have it setup
     padding: 12px;
     gap: 8px;
-    &:hover, &:focus {
-      // TODO: Replace with a proper global variable once we have it setup
-      background-color: #f0f0f0;
-    }
     border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     cursor: pointer;
+
+    &:hover, &:focus {
+      background-color: var(--tox-private-background-secondary, darken(@background-color, 6%));
+    }
+    &.tox-ai-chat-history-list__item-edit-title {
+      background-color: var(--tox-private-background-secondary, darken(@background-color, 6%));
+      flex-direction: column;
+    }
   }
+
+  .tox-ai-chat-history-list__item-edit-actions {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    gap: 8px;
+
+    .tox-ai__spinner svg {
+      fill: rgba(from var(--tox-private-color-white, @color-white) r g b / 0.5);
+    }
+  }
+
 
   .tox-ai-chat-history-list__item-content {
     display: flex;


### PR DESCRIPTION
Related Ticket: TINY-13374

Description of Changes:
* Updated the Spinner component to use Bem utility instead of classes utility
* Removed fill color from SVG path in Spinner component and moved it to CSS
* Fixed dependency arrays in useTabKeyNavigation and useFlowKeyNavigation hooks
* Added type import for SugarElement in TabbingType.ts
* Added styling for spinner in AI chat component
* Added styles for edit mode in chat history list items

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):