### PR TITLE
TINY-13486: change text gradients

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -114,7 +114,9 @@
     right: 0;
     height: min(100px, 100%);
     pointer-events: none;
-    background: linear-gradient(to bottom, transparent, var(--tox-private-background-color, @background-color));
+
+    // 60px of transparent background and then a gradient from transparent to background color. This ensures the loader and first line of streamed response don't have gradient style #TINY-13486
+    background: linear-gradient(to bottom, transparent 60px, transparent 60px, var(--tox-private-background-color, @background-color));
   }
 
   .tox-ai-error {

--- a/modules/oxide/src/less/theme/components/expandablebox/expandablebox.less
+++ b/modules/oxide/src/less/theme/components/expandablebox/expandablebox.less
@@ -30,7 +30,7 @@
     right: 0;
     height: min(100px, 100%);
     pointer-events: none;
-    background: linear-gradient(to bottom, transparent, var(--tox-private-background-color, @background-color));
+    background: linear-gradient(to bottom, transparent 50%, var(--tox-private-background-color, @background-color));
   }
 
   .tox-expandable-box__content--expanded {


### PR DESCRIPTION
Related Ticket: TINY-13486 & TINY-13363

Description of Changes:
* Modified the gradient in AI chat component to ensure the loader and first line of streamed response don't have gradient style
* Updated the gradient in expandablebox component to start at 50% height instead of the top. The first line doesn't have the gradient now.

Pre-checks:
* [x] ~~Changelog entry added~~ (epic)
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] ~~Milestone set~~ (epic)
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):