### PR TITLE
TINY-13479: Add HashSet and HashMap to katamari

### DIFF
--- a/.changes/unreleased/katamari-TINY-13479-2026-01-09.yaml
+++ b/.changes/unreleased/katamari-TINY-13479-2026-01-09.yaml
@@ -1,0 +1,6 @@
+project: katamari
+kind: Added
+body: New `HashSet` and `HashMap` APIs.
+time: 2026-01-09T14:06:31.290549+10:00
+custom:
+    Issue: TINY-13479

--- a/modules/katamari/src/main/ts/ephox/katamari/api/HashMap.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/HashMap.ts
@@ -202,7 +202,7 @@ export const remove = <K, V>(map: Map<K, V>, key: K): Map<K, V> => {
  */
 export const get = <K, V>(map: Map<K, V>, key: K): Optional<V> => {
   const value = map.get(key);
-  return value !== undefined || map.has(key) ? Optional.some(value as V) : Optional.none();
+  return Optional.from(value);
 };
 
 /**
@@ -304,17 +304,6 @@ export const exists = <K, V>(map: ReadonlyMap<K, V>, pred: MapPredicate<K, V>): 
 };
 
 /**
- * Alias for `exists`. Checks if at least one value in the map satisfies the predicate.
- * This is an alias for `exists` to match common naming conventions.
- * Returns false for empty maps (no entries exist that satisfy the predicate).
- *
- * @param map - The map to test
- * @param pred - The predicate function to test each value and key
- * @returns true if any value satisfies the predicate, false otherwise (including empty maps)
- */
-export const some = <K, V>(map: ReadonlyMap<K, V>, pred: MapPredicate<K, V>): boolean => exists(map, pred);
-
-/**
  * Tests whether all values in the map satisfy the predicate.
  * Returns true for empty maps (vacuous truth - all zero entries satisfy the predicate).
  *
@@ -330,17 +319,6 @@ export const forall = <K, V>(map: ReadonlyMap<K, V>, pred: MapPredicate<K, V>): 
   }
   return true;
 };
-
-/**
- * Alias for `forall`. Checks if every value in the map satisfies a predicate.
- * This is an alias for `forall` to match common naming conventions.
- * Returns true for empty maps (vacuous truth - all zero entries satisfy the predicate).
- *
- * @param map - The map to test
- * @param pred - The predicate function to test each value and key
- * @returns true if all values satisfy the predicate, false otherwise (true for empty maps)
- */
-export const every = <K, V>(map: ReadonlyMap<K, V>, pred: MapPredicate<K, V>): boolean => forall(map, pred);
 
 /**
  * Tests whether two Maps are equal based on custom equality functions for keys and values.
@@ -546,16 +524,6 @@ export const bind = <K, V, K2, V2>(map: ReadonlyMap<K, V>, f: (value: V, key: K)
   return result;
 };
 
-/**
- * Maps a function over the map and flattens the result.
- * This is an alias for `bind` to match common naming conventions.
- *
- * @param map - The map to transform
- * @param f - A function that transforms each entry into a Map
- * @returns A new Map containing all entries from all resulting Maps
- */
-export const flatMap = <K, V, K2, V2>(map: ReadonlyMap<K, V>, f: (value: V, key: K) => ReadonlyMap<K2, V2>): Map<K2, V2> => bind(map, f);
-
 // ============================================================================
 // Iteration & Traversal
 // ============================================================================
@@ -588,17 +556,6 @@ export const foldl = <K, V, U>(map: ReadonlyMap<K, V>, f: (acc: U, value: V, key
   });
   return acc;
 };
-
-/**
- * Reduces a map to a single value by applying a function to each entry and an accumulator.
- * This is an alias for `foldl` to match common naming conventions.
- *
- * @param map - The map to reduce
- * @param f - The reducer function that takes the accumulator, value, and key
- * @param acc - The initial accumulator value
- * @returns The final accumulated value
- */
-export const reduce = <K, V, U>(map: ReadonlyMap<K, V>, f: (acc: U, value: V, key: K) => U, acc: U): U => foldl(map, f, acc);
 
 // ============================================================================
 // Searching

--- a/modules/katamari/src/main/ts/ephox/katamari/api/HashSet.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/HashSet.ts
@@ -185,16 +185,6 @@ export const toggle = <T>(set: Set<T>, value: T): Set<T> => {
  */
 export const contains = <T>(set: ReadonlySet<T>, value: T): boolean => set.has(value);
 
-/**
- * Checks if a value exists in the set.
- * This is an alias for `contains` to match the naming convention of JavaScript's Set.has().
- *
- * @param set - The set to search
- * @param value - The value to look for
- * @returns true if the value is in the set, false otherwise
- */
-export const has = <T>(set: ReadonlySet<T>, value: T): boolean => contains(set, value);
-
 // ============================================================================
 // Getters & Properties
 // ============================================================================
@@ -231,15 +221,6 @@ export const values = <T>(set: Set<T>): IterableIterator<T> => set.values();
  */
 export const toArray = <T>(set: Set<T>): T[] => Array.from(set);
 
-/**
- * Converts a Set to an array of values.
- * This is an alias for `toArray` for consistency with other APIs.
- *
- * @param set - The set to convert
- * @returns An array containing all elements from the set
- */
-export const toValues = <T>(set: Set<T>): T[] => toArray(set);
-
 // ============================================================================
 // Predicates & Testing
 // ============================================================================
@@ -262,17 +243,6 @@ export const exists = <T>(set: ReadonlySet<T>, pred: SetPredicate<T>): boolean =
 };
 
 /**
- * Alias for `exists`. Checks if at least one element in the set satisfies the predicate.
- * This is an alias for `exists` to match common naming conventions.
- * Returns false for empty sets (no elements exist that satisfy the predicate).
- *
- * @param set - The set to test
- * @param pred - The predicate function to test each element
- * @returns true if any element satisfies the predicate, false otherwise (including empty sets)
- */
-export const some = <T>(set: ReadonlySet<T>, pred: SetPredicate<T>): boolean => exists(set, pred);
-
-/**
  * Tests whether all elements in the set satisfy the predicate.
  * Returns true for empty sets (vacuous truth - all zero elements satisfy the predicate).
  *
@@ -288,17 +258,6 @@ export const forall = <T>(set: ReadonlySet<T>, pred: SetPredicate<T>): boolean =
   }
   return true;
 };
-
-/**
- * Alias for `forall`. Checks if every element in the set satisfies a predicate.
- * This is an alias for `forall` to match common naming conventions.
- * Returns true for empty sets (vacuous truth - all zero elements satisfy the predicate).
- *
- * @param set - The set to test
- * @param pred - The predicate function to test each element
- * @returns true if all elements satisfy the predicate, false otherwise (true for empty sets)
- */
-export const every = <T>(set: ReadonlySet<T>, pred: SetPredicate<T>): boolean => forall(set, pred);
 
 /**
  * Tests whether two Sets are equal based on a custom equality function.
@@ -498,23 +457,6 @@ export const partition = <T>(set: ReadonlySet<T>, pred: SetPredicate<T>): { pass
 };
 
 /**
- * Flattens a Set of Sets into a single Set containing all elements.
- * Duplicate elements are automatically removed due to Set semantics.
- *
- * @param set - A Set containing other Sets
- * @returns A new Set containing all elements from all inner Sets
- */
-export const flatten = <T>(set: ReadonlySet<ReadonlySet<T>>): Set<T> => {
-  const result = new Set<T>();
-  for (const innerSet of set) {
-    for (const x of innerSet) {
-      result.add(x);
-    }
-  }
-  return result;
-};
-
-/**
  * Maps a function over the set and flattens the result.
  * Similar to flatMap in other functional libraries.
  *
@@ -522,18 +464,17 @@ export const flatten = <T>(set: ReadonlySet<ReadonlySet<T>>): Set<T> => {
  * @param f - A function that transforms each element into a Set
  * @returns A new Set containing all elements from all resulting Sets
  */
-export const bind = <T, U>(set: ReadonlySet<T>, f: SetMorphism<T, ReadonlySet<U>>): Set<U> =>
-  flatten(map(set, f));
-
-/**
- * Maps a function over the set and flattens the result.
- * This is an alias for `bind` to match common naming conventions.
- *
- * @param set - The set to transform
- * @param f - A function that transforms each element into a Set
- * @returns A new Set containing all elements from all resulting Sets
- */
-export const flatMap = <T, U>(set: ReadonlySet<T>, f: SetMorphism<T, ReadonlySet<U>>): Set<U> => bind(set, f);
+export const bind = <T, U>(set: ReadonlySet<T>, f: SetMorphism<T, ReadonlySet<U>>): Set<U> => {
+  const result = new Set<U>();
+  for (const x of set) {
+    const inner = f(x);
+    for (const y of inner) {
+      result.add(y);
+    }
+  }
+  return result;
+};
+// flatten(map(set, f));
 
 // ============================================================================
 // Iteration & Traversal
@@ -567,17 +508,6 @@ export const foldl = <T, U>(set: ReadonlySet<T>, f: (acc: U, x: T) => U, acc: U)
   });
   return acc;
 };
-
-/**
- * Reduces a set to a single value by applying a function to each element and an accumulator.
- * This is an alias for `foldl` to match common naming conventions.
- *
- * @param set - The set to reduce
- * @param f - The reducer function that takes the accumulator and current element
- * @param acc - The initial accumulator value
- * @returns The final accumulated value
- */
-export const reduce = <T, U>(set: ReadonlySet<T>, f: (acc: U, x: T) => U, acc: U): U => foldl(set, f, acc);
 
 // ============================================================================
 // Searching

--- a/modules/katamari/src/test/ts/atomic/api/hash_datasets/HashMapTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/hash_datasets/HashMapTest.ts
@@ -171,23 +171,11 @@ describe('atomic.katamari.api.hash_datasets.HashMapTest', () => {
       assert.isTrue(HashMap.exists(map, (_v, k) => k === 'b'));
     });
 
-    it('TINY-13479: some is alias for exists', () => {
-      const map = HashMap.make<string, number>([ 'a', 1 ], [ 'b', 2 ]);
-      assert.isTrue(HashMap.some(map, (v) => v === 2));
-      assert.isFalse(HashMap.some(map, (v) => v === 10));
-    });
-
     it('TINY-13479: forall checks if all values satisfy predicate', () => {
       const map = HashMap.make<string, number>([ 'a', 2 ], [ 'b', 4 ], [ 'c', 6 ]);
       assert.isTrue(HashMap.forall(map, (v) => v % 2 === 0));
       assert.isFalse(HashMap.forall(map, (v) => v > 5));
       assert.isTrue(HashMap.forall(HashMap.empty(), Fun.never));
-    });
-
-    it('TINY-13479: every is alias for forall', () => {
-      const map = HashMap.make<string, number>([ 'a', 1 ], [ 'b', 2 ]);
-      assert.isTrue(HashMap.every(map, (v) => v > 0));
-      assert.isFalse(HashMap.every(map, (v) => v > 1));
     });
 
     it('TINY-13479: equal checks if two maps are equal', () => {
@@ -288,14 +276,6 @@ describe('atomic.katamari.api.hash_datasets.HashMapTest', () => {
       HashMap.get(result, 'b1').each((val) => assert.equal(val, 2));
       HashMap.get(result, 'b2').each((val) => assert.equal(val, 20));
     });
-
-    it('TINY-13479: flatMap is alias for bind', () => {
-      const map = HashMap.make<string, number>([ 'a', 1 ]);
-      const f = (v: number, k: string) => HashMap.make<string, number>([ k + '_1', v ], [ k + '_2', v * 2 ]);
-      const result1 = HashMap.bind(map, f);
-      const result2 = HashMap.flatMap(map, f);
-      assert.isTrue(HashMap.equal(result1, result2));
-    });
   });
 
   describe('Iteration & Traversal', () => {
@@ -319,14 +299,6 @@ describe('atomic.katamari.api.hash_datasets.HashMapTest', () => {
       const map = HashMap.make<string, number>([ 'a', 1 ], [ 'b', 2 ]);
       const result = HashMap.foldl(map, (acc, v, k) => acc + k + v, '');
       assert.isTrue(result === 'a1b2' || result === 'b2a1'); // Order not guaranteed
-    });
-
-    it('TINY-13479: reduce is alias for foldl', () => {
-      const map = HashMap.make<string, number>([ 'a', 1 ], [ 'b', 2 ]);
-      const f = (acc: number, v: number, _k: string) => acc + v;
-      const result1 = HashMap.foldl(map, f, 0);
-      const result2 = HashMap.reduce(map, f, 0);
-      assert.equal(result1, result2);
     });
   });
 

--- a/modules/katamari/src/test/ts/atomic/api/hash_datasets/HashSetTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/hash_datasets/HashSetTest.ts
@@ -119,12 +119,6 @@ describe('atomic.katamari.api.hash_datasets.HashSetTest', () => {
       const arr = HashSet.toArray(set).sort();
       assert.deepEqual(arr, [ 1, 2, 3 ]);
     });
-
-    it('TINY-13479: toValues converts set to array of values', () => {
-      const set = HashSet.make(3, 1, 2);
-      const vals = HashSet.toValues(set).sort();
-      assert.deepEqual(vals, [ 1, 2, 3 ]);
-    });
   });
 
   describe('Predicates & Testing', () => {
@@ -135,23 +129,11 @@ describe('atomic.katamari.api.hash_datasets.HashSetTest', () => {
       assert.isFalse(HashSet.exists(HashSet.empty(), Fun.always));
     });
 
-    it('TINY-13479: some is alias for exists', () => {
-      const set = HashSet.make(1, 2, 3);
-      assert.isTrue(HashSet.some(set, (x) => x === 2));
-      assert.isFalse(HashSet.some(set, (x) => x === 10));
-    });
-
     it('TINY-13479: forall checks if all elements satisfy predicate', () => {
       const set = HashSet.make(2, 4, 6, 8);
       assert.isTrue(HashSet.forall(set, (x) => x % 2 === 0));
       assert.isFalse(HashSet.forall(set, (x) => x > 5));
       assert.isTrue(HashSet.forall(HashSet.empty(), Fun.never));
-    });
-
-    it('TINY-13479: every is alias for forall', () => {
-      const set = HashSet.make(1, 2, 3);
-      assert.isTrue(HashSet.every(set, (x) => x > 0));
-      assert.isFalse(HashSet.every(set, (x) => x > 2));
     });
 
     it('TINY-13479: equal checks if two sets are equal', () => {
@@ -251,28 +233,10 @@ describe('atomic.katamari.api.hash_datasets.HashSetTest', () => {
       assert.deepEqual(HashSet.toArray(fail).sort(), [ 1, 3, 5 ]);
     });
 
-    it('TINY-13479: flatten flattens a set of sets', () => {
-      const set = HashSet.make(
-        HashSet.make(1, 2),
-        HashSet.make(3, 4),
-        HashSet.make(4, 5)
-      );
-      const result = HashSet.flatten(set);
-      assert.deepEqual(HashSet.toArray(result).sort(), [ 1, 2, 3, 4, 5 ]);
-    });
-
     it('TINY-13479: bind maps and flattens', () => {
       const set = HashSet.make(1, 2, 3);
       const result = HashSet.bind(set, (x) => HashSet.make(x, x * 10));
       assert.deepEqual(HashSet.toArray(result).sort((a, b) => a - b), [ 1, 2, 3, 10, 20, 30 ]);
-    });
-
-    it('TINY-13479: flatMap is alias for bind', () => {
-      const set = HashSet.make(1, 2);
-      const f = (x: number) => HashSet.make(x, x + 10);
-      const result1 = HashSet.bind(set, f);
-      const result2 = HashSet.flatMap(set, f);
-      assert.isTrue(HashSet.equal(result1, result2));
     });
   });
 
@@ -288,13 +252,6 @@ describe('atomic.katamari.api.hash_datasets.HashSetTest', () => {
       const set = HashSet.make(1, 2, 3, 4);
       const result = HashSet.foldl(set, (acc, x) => acc + x, 0);
       assert.equal(result, 10);
-    });
-
-    it('TINY-13479: reduce is alias for foldl', () => {
-      const set = HashSet.make(1, 2, 3);
-      const result1 = HashSet.foldl(set, (acc, x) => acc + x, 0);
-      const result2 = HashSet.reduce(set, (acc, x) => acc + x, 0);
-      assert.equal(result1, result2);
     });
   });
 


### PR DESCRIPTION
Related Ticket: TINY-13479

Description of Changes:

- Added new immutable collection APIs: `HashMap` and `HashSet` that help work with the native Map and Set data structures

Pre-checks:

- [  ] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added immutable, functional Map API (creation, query, transform, merge, search, equality).
    - Added immutable, functional Set API (creation, set-theoretic ops, transform, search, equality).
- **Tests**
    - Added comprehensive unit and property-based tests covering both Map and Set APIs.
- **Chores**
    - Added changelog entry announcing the new APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->