### PR TITLE
TINY-13547: Improve selection handling in Draggable

### DIFF
--- a/modules/oxide-components/src/main/ts/components/draggable/Draggable.tsx
+++ b/modules/oxide-components/src/main/ts/components/draggable/Draggable.tsx
@@ -73,6 +73,7 @@ const Handle: FC<DraggableHandleProps> = ({ children }) => {
 
   const onPointerMove = useCallback((event: React.PointerEvent) => {
     if (isDragging) {
+      event.preventDefault(); // Prevents text selection while dragging on Safari
       const currentPointerPosition = {
         x: clamp(Math.round(event.clientX), boundariesRef.current.x.min, boundariesRef.current.x.max),
         y: clamp(Math.round(event.clientY), boundariesRef.current.y.min, boundariesRef.current.y.max)
@@ -95,16 +96,17 @@ const Handle: FC<DraggableHandleProps> = ({ children }) => {
     }
   }, [ stopDragging, isDragging ]);
 
+  const style = isDragging ?
+    { cursor: 'grabbing', userSelect: 'none', WebkitUserSelect: 'none' } as const :
+    { cursor: 'grab' } as const;
+
   return (
     <div
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
       onPointerMove={onPointerMove}
       onLostPointerCapture={onLostPointerCapture}
-      style={{
-        cursor: isDragging ? 'grabbing' : 'grab',
-        userSelect: 'none'
-      }}>
+      style={style}>
       {children}
     </div>
   );


### PR DESCRIPTION
Related Ticket: TINY-13547

Description of Changes:

- Fix safari selection problems
    - Use prefixed `user-select`
    - preventDefault `mousemove` event while dragging
- Apply `user-select: none;` only while dragging. I've noticed that's what other libraries are doing by default and I would rather keep it less strict for now as we can always make it stricter later

Pre-checks:

~~- [ ] Changelog entry added~~
~~- [ ] Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

~~- [ ] Milestone set~~
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):