### PR TITLE
TINY-13553: Add drag events to Draggable component

### DIFF
--- a/modules/oxide-components/src/main/ts/components/draggable/Draggable.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/draggable/Draggable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 
 import * as Draggable from './Draggable';
 import type { DraggableProps } from './internals/types';
@@ -90,9 +91,17 @@ The origin affects how the position is calculated and which edges of the viewpor
 You can omit setting this property if you don't care about window resize.
 If you do care about it, but don't know the exact size of the element you'll have to calculate it using javascript.`
     },
+    onDragStart: {
+      description: 'Optional callback function that is called when dragging begins.'
+    },
+    onDragEnd: {
+      description: 'Optional callback function that is called when dragging ends.'
+    },
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: [ 'autodocs', 'skip-visual-testing' ],
+  // Use `fn` to spy on the callback args, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  args: { onDragStart: fn(), onDragEnd: fn() },
 } satisfies Meta<typeof Draggable.Root>;
 
 export default meta;

--- a/modules/oxide-components/src/main/ts/components/draggable/internals/types.ts
+++ b/modules/oxide-components/src/main/ts/components/draggable/internals/types.ts
@@ -15,6 +15,8 @@ export interface DraggableProps extends HTMLAttributes<HTMLDivElement> {
   initialPosition?: CssPosition;
   declaredSize?: CssSize;
   allowedOverflow?: Partial<AllowedOverflow>;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
 }
 
 export interface DraggableHandleProps extends PropsWithChildren { }
@@ -46,6 +48,8 @@ export interface DraggableState {
   setPosition: React.Dispatch<React.SetStateAction<CssPosition | Position>>;
   allowedOverflow: AllowedOverflow;
   origin: Origin;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
 };
 
 export interface Boundaries {

--- a/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.stories.tsx
@@ -1,6 +1,7 @@
 import { Fun } from '@ephox/katamari';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { UniverseProvider } from 'oxide-components/contexts/UniverseContext/UniverseProvider';
+import { fn } from 'storybook/test';
 
 import { IconButton } from '../iconbutton/IconButton';
 
@@ -58,12 +59,20 @@ The \`x\` and \`y\` values in \`initialPosition\` correspond to these CSS proper
     initialPosition: {
       description: `Sets the initial position of the sidebar as an object with \`x\` and \`y\` coordinates.
 These values can be specified in any CSS length unit (pixels, percentages, etc.).
-The \`x\` and \`y\` values map to the CSS positioning properties determined 
+The \`x\` and \`y\` values map to the CSS positioning properties determined
 by the \`origin\` prop (e.g., with \`origin="top-left"\`, \`x\` maps to \`left\` and \`y\` maps to \`top\`)`,
+    },
+    onDragStart: {
+      description: 'Optional callback function that is called when dragging begins.'
+    },
+    onDragEnd: {
+      description: 'Optional callback function that is called when dragging ends.'
     },
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: [ 'autodocs' ],
+  // Use `fn` to spy on the callback args, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  args: { onDragStart: fn(), onDragEnd: fn() },
 } satisfies Meta<typeof FloatingSidebar.Root>;
 
 export default meta;

--- a/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.tsx
+++ b/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.tsx
@@ -10,10 +10,12 @@ export interface FloatingSidebarProps extends PropsWithChildren {
   origin?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
   initialPosition?: { x: Property.Top; y: Property.Left };
   style?: CSSProperties;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
 }
 interface HeaderProps extends PropsWithChildren {};
 
-const Root: FC<FloatingSidebarProps> = ({ isOpen = true, children, style, origin = 'top-right', initialPosition = { x: 0, y: 0 }}) => {
+const Root: FC<FloatingSidebarProps> = ({ isOpen = true, children, style, origin = 'top-right', initialPosition = { x: 0, y: 0 }, onDragStart, onDragEnd }) => {
   return (
     <Draggable.Root
       className={Bem.block('tox-floating-sidebar', { open: isOpen })}
@@ -21,6 +23,8 @@ const Root: FC<FloatingSidebarProps> = ({ isOpen = true, children, style, origin
       initialPosition={initialPosition}
       allowedOverflow={{ horizontal: 0.8 }}
       declaredSize={{ width: 'var(--tox-private-floating-sidebar-width)', height: 'var(--tox-private-floating-sidebar-height)' }}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       style={style}
     >
       <aside className={classes([ 'tox-floating-sidebar__content-wrapper' ])}>

--- a/modules/oxide-components/src/test/ts/browser/components/draggable/Draggable.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/draggable/Draggable.spec.tsx
@@ -494,4 +494,52 @@ describe('browser.components.Draggable', () => {
       expectedPosition: { top: 1500 - 50 - 300, left: 1500 - 50 - 250 }
     });
   });
+
+  describe('Drag state callbacks', () => {
+    it('TINY-13553: onDragStart callback is called when dragging begins', async () => {
+      let dragStartCount = 0;
+      const onDragStart = () => dragStartCount++;
+      const { handle } = await renderDraggable({ width: 250, height: 300 }, { onDragStart });
+
+      await userEvent.hover(handle, { position: { x: 10, y: 10 }});
+      await Mouse.down();
+
+      expect(dragStartCount).toBe(1);
+    });
+
+    it('TINY-13553: onDragEnd callback is called when dragging ends via pointer up', async () => {
+      let dragEndCount = 0;
+      const onDragEnd = () => dragEndCount++;
+
+      const { handle } = await renderDraggable({ width: 250, height: 300 }, { onDragEnd });
+
+      await userEvent.hover(handle, { position: { x: 10, y: 10 }});
+      await Mouse.down();
+      await Mouse.move(50, 50);
+      await Mouse.up();
+
+      expect(dragEndCount).toBe(1);
+    });
+
+    it('TINY-13553: Both callbacks are called in a complete drag sequence', async () => {
+      let dragStartCount = 0;
+      let dragEndCount = 0;
+      const onDragStart = () => dragStartCount++;
+      const onDragEnd = () => dragEndCount++;
+
+      const { handle } = await renderDraggable({ width: 250, height: 300 }, { onDragStart, onDragEnd });
+
+      await userEvent.hover(handle, { position: { x: 10, y: 10 }});
+      await Mouse.down();
+
+      expect(dragStartCount).toBe(1);
+      expect(dragEndCount).toBe(0);
+
+      await Mouse.move(50, 50);
+      await Mouse.up();
+
+      expect(dragStartCount).toBe(1);
+      expect(dragEndCount).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-13553

Description of Changes:

- Add `onDragStart` and `onDragEnd` properties to `FloatingSidebar` and `Draggable` components

Pre-checks:

~~- [ ] Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

~~- [ ] Milestone set~~
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):