### PR TITLE
TINY-13381 TINY-13382: Make tags clickable and wrap sources across multiple lines

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.stories.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.stories.tsx
@@ -18,6 +18,7 @@ type Story = StoryObj<typeof meta>;
 export const ClosableTag: Story = {
   args: {
     closeable: true,
+    link: false,
     label: 'Value',
     onClose: Fun.noop
   },

--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
@@ -15,32 +15,43 @@ const TagCloseIcon: FunctionComponent = () => {
 interface BaseTagProps {
   readonly label: string;
   readonly icon?: JSX.Element;
-  readonly onMouseEnter?: (event: React.MouseEvent<HTMLDivElement>) => void;
-  readonly onMouseLeave?: (event: React.MouseEvent<HTMLDivElement>) => void;
-  readonly onFocus?: (event: React.FocusEvent<HTMLDivElement>) => void;
-  readonly onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
+  readonly onMouseEnter?: (event: React.MouseEvent<HTMLElement>) => void;
+  readonly onMouseLeave?: (event: React.MouseEvent<HTMLElement>) => void;
+  readonly onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
+  readonly onBlur?: (event: React.FocusEvent<HTMLElement>) => void;
+  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   readonly ariaLabel?: string;
 }
 
-interface NonClosableTagProps extends BaseTagProps {
+interface NonLinkTagProps {
+  readonly link: false;
+}
+
+interface LinkTagProps {
+  readonly link: true;
+  readonly href: string;
+}
+
+interface NonClosableProps {
   readonly closeable: false;
 }
 
-interface ClosableTagProps extends BaseTagProps {
+interface ClosableProps {
   readonly closeable: true;
   readonly onClose: () => void;
   readonly disabled?: boolean;
 }
 
-export type TagProps = NonClosableTagProps | ClosableTagProps;
+export type TagProps = (NonLinkTagProps | LinkTagProps) & (NonClosableProps | ClosableProps) & BaseTagProps;
 
 // Tag is here in reference to a tagging/labeling context, not a HTML tag.
-export const Tag = forwardRef<HTMLDivElement, TagProps>((props, ref) => {
-  const { label, icon, closeable, ariaLabel, ...rest } = props;
+export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((props, ref) => {
+  const { label, icon, closeable, ariaLabel, link, ...rest } = props;
   const disabled = closeable && props.disabled === true;
+  const href = link ? props.href : undefined;
 
-  return (
-    <div className={Bem.block('tox-tag')} ref={ref} {...rest}>
+  const content = (
+    <>
       {icon}
       <span className={Bem.element('tox-tag', 'label')}>{label}</span>
       {closeable && (
@@ -52,6 +63,16 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>((props, ref) => {
           </Button>
         </span>
       )}
+    </>
+  );
+
+  return link ? (
+    <a className={Bem.block('tox-tag')} href={href} ref={ref as React.Ref<HTMLAnchorElement>} {...rest}>
+      {content}
+    </a>
+  ) : (
+    <div className={Bem.block('tox-tag')} ref={ref as React.Ref<HTMLDivElement>} {...rest}>
+      {content}
     </div>
   );
 });

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -68,12 +68,14 @@
     align-items: center;
     gap: 8px;
     align-self: stretch;
+    flex-wrap: wrap;
 
     .tox-tag {
       border: 1px solid var(--tox-private-border-color, @border-color);
       background-color: transparent;
       max-width: 132px;
       max-height: 24px;
+      cursor: pointer;
 
       svg, img {
         width: 16px;


### PR DESCRIPTION
Related Ticket: TINY-13381 TINY-13382

Description of Changes:
* Added `onClick` event handler to the `BaseTagProps` interface in `Tag.tsx`
* Added `flex-wrap: wrap` to the AI chat component to handle overflow
* Added `cursor: pointer` to the tag styling to indicate clickability
* Added SVG fill color styling to the AI spinner component

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):