### PR TITLE
TINY-13027: Fix failing test

### DIFF
--- a/modules/tinymce/src/plugins/table/test/ts/atomic/UtilsTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/atomic/UtilsTest.ts
@@ -9,7 +9,7 @@ describe('atomic.tinymce.plugins.table.core.UtilsTest', () => {
     assert.equal(removePxSuffix(''), '', 'Empty string is identical');
     assert.equal(removePxSuffix('10px'), '10', 'Pixel string has pixel removed');
 
-    fc.assert(fc.property(fc.float({ min: 1, max: 100 }), (n) => {
+    fc.assert(fc.property(fc.float({ min: 1, max: 100, noNaN: true, noDefaultInfinity: true }), (n) => {
       assert.equal(removePxSuffix(n + 'px'), n + '', 'Arbitrary float with px string is true');
       assert.equal(removePxSuffix(n + ''), n + '', 'Number string is identical');
       assert.equal(removePxSuffix('px' + n), 'px' + n, 'String with pixel prefix is identical');
@@ -21,7 +21,7 @@ describe('atomic.tinymce.plugins.table.core.UtilsTest', () => {
     assert.equal(addPxSuffix(''), '', 'Empty string is identical');
     assert.equal(addPxSuffix('10'), '10px', 'Number string has px added');
 
-    fc.assert(fc.property(fc.float({ min: 1, max: 100 }), (n) => {
+    fc.assert(fc.property(fc.float({ min: 1, max: 100, noNaN: true, noDefaultInfinity: true }), (n) => {
       assert.equal(addPxSuffix(n + ''), n + 'px', 'Arbitrary float with px string is true');
       assert.equal(addPxSuffix(n + '%'), n + '%', 'Percent string is identical');
       assert.equal(addPxSuffix(n + 'px'), n + 'px', 'Pixel string is identical');


### PR DESCRIPTION
Related Ticket: TINY-13027

Description of Changes:
* Fix failing test from fast-check generating `NaN` in table plugin test

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by constraining test values to finite numbers in table utility tests, ensuring more robust test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->