### PR TITLE
TINY-13379: Add content_id editor option

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13379-2026-01-12.yaml
+++ b/.changes/unreleased/tinymce-TINY-13379-2026-01-12.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Editor option `content_id` that sets the id of the edited document.
+time: 2026-01-12T11:11:49.041709+01:00
+custom:
+    Issue: TINY-13379

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -921,6 +921,10 @@ const register = (editor: Editor): void => {
     default: 'Anonymous'
   });
 
+  registerOption('content_id', {
+    processor: 'string',
+  });
+
   registerOption('fetch_users', {
     processor: (value) => {
       if (value === undefined) {


### PR DESCRIPTION
Related Ticket: TINY-13379

Description of Changes:

- Added a new `content_id` option to TinyMCE core
- Implemented processor to validate that the option value is a string
- Added getter function `getContentId()` to retrieve the option value

Pre-checks:

- [x] Changelog entry added
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] ~~Milestone set~~
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):