### PR TITLE
TINY-12390: Set agar-sw and persona packages to private

### DIFF
--- a/modules/agar-sw/package.json
+++ b/modules/agar-sw/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ephox/agar-sw",
   "version": "1.0.0",
+  "private": true,
   "description": "HTTP mocking service worker",
   "repository": {
     "type": "git",

--- a/modules/persona/package.json
+++ b/modules/persona/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tinymce/persona",
   "version": "1.0.0",
+  "private": true,
   "description": "Default avatar generation utility for TinyMCE",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Added `"private": true` to package.json files for `@ephox/agar-sw` and `@tinymce/persona` modules to prevent publishing with lerna

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked internal packages as private to prevent unintended publication to npm registry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->