### PR TITLE
TINY-13379: Add content_id editor option

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13379-2026-01-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-13379-2026-01-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Editor option `content_id` that sets the id of the edited document.
+time: 2026-01-13T07:50:53.442934+01:00
+custom:
+    Issue: TINY-13379

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -228,6 +228,7 @@ interface BaseEditorOptions {
   submit_patch?: boolean;
   suffix?: string;
   user_id?: string;
+  content_id?: string;
   table_tab_navigation?: boolean;
   target?: HTMLElement;
   text_patterns?: RawPattern[] | false;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -921,6 +921,10 @@ const register = (editor: Editor): void => {
     default: 'Anonymous'
   });
 
+  registerOption('content_id', {
+    processor: 'string',
+  });
+
   registerOption('fetch_users', {
     processor: (value) => {
       if (value === undefined) {


### PR DESCRIPTION
Related Ticket: TINY-13379

Description of Changes:

- Added a new `content_id` option to the TinyMCE editor with string processor type

Pre-checks:

- [x] Changelog entry added
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - New `content_id` configuration option available to set the identifier for edited documents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->