### PR TITLE
TINY-13560: Add preview loader styles to oxide

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-preview/ai-previewloader.less
+++ b/modules/oxide/src/less/theme/components/ai-preview/ai-previewloader.less
@@ -1,0 +1,32 @@
+.tox .tox-tinymceai-previewloader when (@custom-properties-enabled = true) {
+  --tox-private-ai-preview-loader-box-shadow: 0 0 40px 1px hsl( from var(--tox-private-color-black) h s l / 15%), 0 16px 16px -10px hsl( from var(--tox-private-color-black) h s l / 15%);
+}
+
+.tox {
+  .tox-tinymceai-previewloader {
+    display: flex;
+    align-items: center;
+    width: fit-content;
+    height: fit-content;
+    position: fixed;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+    gap: var(--tox-private-pad-md, @pad-md);
+    padding: var(--tox-private-pad-sm, @pad-sm);
+    border-radius: var(--tox-private-panel-border-radius, @panel-border-radius);
+    box-shadow: var(--tox-private-ai-preview-loader-box-shadow, 0 0 40px 1px fade(@color-black, 15%), 0 16px 16px -10px fade(@color-black, 15%));
+    background-color: var(--tox-private-background-color, @background-color);
+
+    &__content {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 var(--tox-private-pad-xs, @pad-xs);
+      gap: var(--tox-private-pad-sm, @pad-sm);
+    }
+  }
+}

--- a/modules/oxide/src/less/theme/theme.less
+++ b/modules/oxide/src/less/theme/theme.less
@@ -71,6 +71,7 @@
 @import 'components/ai-chat/ai-chat';
 @import 'components/ai-chat/ai-chat-html-content';
 @import 'components/ai-preview/ai-preview';
+@import 'components/ai-preview/ai-previewloader';
 @import 'components/selector/selector';
 @import 'components/skeleton/skeleton.less';
 @import 'components/slider/slider';


### PR DESCRIPTION
Related Ticket: TINY-13560

Description of Changes:
* Add previewloader styles to oxide

Pre-checks:
~~* [ ] Changelog entry added~~
~~* [ ] Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
~~* [ ] Milestone set~~
~~* [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added styling for the AI preview loader component with fixed positioning, centered layout, and shadow effects to enhance visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->