### PR TITLE
TINY-13600: Update Bem helpers to pick up classes from the content ui css as well

### DIFF
--- a/modules/oxide-components/src/main/ts/main.ts
+++ b/modules/oxide-components/src/main/ts/main.ts
@@ -22,6 +22,7 @@ import type { UniverseResources } from './contexts/UniverseContext/UniverseTypes
 import * as KeyboardNavigationTypes from './keynav/keyboard/NavigationTypes';
 import * as KeyboardNavigationHooks from './keynav/KeyboardNavigationHooks';
 import * as Bem from './utils/Bem';
+import * as ContentUiBem from './utils/ContentUiBem';
 import * as FocusHelpers from './utils/FocusHelpers';
 
 export {
@@ -29,6 +30,7 @@ export {
   AutoResizingTextarea,
   Bem,
   Button,
+  ContentUiBem,
   ContextToolbar,
   Draggable,
   Dropdown,

--- a/modules/oxide-components/src/main/ts/utils/ContentUiBem.ts
+++ b/modules/oxide-components/src/main/ts/utils/ContentUiBem.ts
@@ -1,0 +1,106 @@
+import { Arr, Obj, Strings, Type } from '@ephox/katamari';
+import type { Classes } from '@tinymce/oxide/skins/ui/default/content.ts';
+
+type ValidClassName = keyof Classes;
+
+type BlockElementModifier<K extends string> = K extends `${string}__${string}--${string}` ? K : never;
+type BlockElement<K extends string> = K extends `${string}__${string}` ? (K extends `${string}--${string}` ? never : K) : never;
+type BlockModifier<K extends string> = K extends `${string}--${string}` ? (K extends `${string}__${string}` ? never : K) : never;
+type Block<K extends string> = K extends `${string}__${string}` | `${string}--${string}` ? never : K;
+
+type BEMBlocks = Extract<ValidClassName, Block<ValidClassName>>;
+type BEMBlockModifiers = Extract<ValidClassName, BlockModifier<ValidClassName>>;
+type BEMBlockElements = Extract<ValidClassName, BlockElement<ValidClassName>>;
+type BEMBlockElementModifiers = Extract<ValidClassName, BlockElementModifier<ValidClassName>>;
+
+type SplitBlockElement<K extends string> = K extends `${infer Block}__${infer Element}` ? [Block, Element] : never;
+type ValidElementPairs = SplitBlockElement<BEMBlockElements>;
+type ElementForBlock<B extends BEMBlocks> = Extract<ValidElementPairs, [B, any]>[1];
+
+type SplitBlockModifier<K extends string> = K extends `${infer Block}--${infer Modifier}` ? [Block, Modifier] : never;
+type SplitBlockElementModifier<K extends string> = K extends `${infer Block}__${infer Element}--${infer Modifier}` ? [Block, Element, Modifier] : never;
+
+type ValidBlockModifiers = SplitBlockModifier<BEMBlockModifiers>;
+type ValidBlockElementModifiers = SplitBlockElementModifier<BEMBlockElementModifiers>;
+
+type ModifiersForBlock<B extends BEMBlocks> = Extract<ValidBlockModifiers, [B, any]>[1];
+type ModifiersForBlockElement<B extends BEMBlocks, E extends ElementForBlock<B>> = Extract<ValidBlockElementModifiers, [B, E, any]>[2];
+type ModifierRecord<M extends string> = [M] extends [never] ? never : Partial<Record<M, boolean>>; // To avoid 'Record<never, boolean>' which is an empty object
+
+const applyModifiers = <M extends string>(joiner: string, base: string, modifiers: ModifierRecord<M>): string => {
+  const modifierClasses = Arr.filter(Obj.mapToArray(modifiers, (v, k) => v ? `${base}--${k}` : ''), Strings.isNotEmpty);
+  return [ base, ...modifierClasses ].join(joiner);
+};
+
+/**
+ * Creates a BEM block class name string.
+ *
+ * @example
+ * Bem.block('tox-button', { 'active': true, 'naked': false });
+ * // Returns: 'tox-button tox-button--active'
+ * @param block The BEM block name
+ * @param modifiers Optional modifiers for the block
+ * @returns The BEM block class name string
+ */
+export const block = <B extends BEMBlocks, M extends ModifiersForBlock<B> = never>(
+  block: B,
+  modifiers?: ModifierRecord<M>
+): string => Type.isUndefined(modifiers) ? block : applyModifiers(' ', block, modifiers);
+
+/**
+ * Creates a BEM element class name string.
+ *
+ * @example
+ * Bem.element('tox-form', 'group', { error: true, inline: false });
+ * // Returns: 'tox-form__group tox-form__group--error'
+ * @param block The BEM block name
+ * @param element The BEM element name
+ * @param modifiers Optional modifiers for the element
+ * @returns The BEM element class name string
+ */
+export const element = <B extends BEMBlocks, E extends ElementForBlock<B>, M extends ModifiersForBlockElement<B, E> = never>(
+  block: B,
+  element: E,
+  modifiers?: ModifierRecord<M>
+): string => {
+  const base = `${block}__${element}`;
+  return Type.isUndefined(modifiers) ? base : applyModifiers(' ', base, modifiers);
+};
+
+/**
+ * Creates a BEM block selector string.
+ *
+ * @example
+ * Bem.blockSelector('tox-button', { 'active': true, 'disabled': false });
+ * // Returns: '.tox-button.tox-button--active'
+ * @param block The BEM block name
+ * @param modifiers Optional modifiers for the block
+ * @returns The BEM block selector string
+ */
+export const blockSelector = <B extends BEMBlocks, M extends ModifiersForBlock<B> = never>(
+  block: B,
+  modifiers?: ModifierRecord<M>
+): string => {
+  const base = `.${block}`;
+  return Type.isUndefined(modifiers) ? base : applyModifiers('', base, modifiers);
+};
+
+/**
+ * Creates a BEM element selector string.
+ *
+ * @example
+ * Bem.elementSelector('tox-form', 'group', { error: true, inline: false });
+ * // Returns: '.tox-form__group.tox-form__group--error'
+ * @param block The BEM block name
+ * @param element The BEM element name
+ * @param modifiers Optional modifiers for the element
+ * @returns The BEM element selector string
+ */
+export const elementSelector = <B extends BEMBlocks, E extends ElementForBlock<B>, M extends ModifiersForBlockElement<B, E> = never>(
+  block: B,
+  element: E,
+  modifiers?: ModifierRecord<M>
+): string => {
+  const base = `.${block}__${element}`;
+  return Type.isUndefined(modifiers) ? base : applyModifiers('', base, modifiers);
+};

--- a/modules/oxide/package.json
+++ b/modules/oxide/package.json
@@ -22,6 +22,7 @@
   "sideEffects": false,
   "exports": {
     "./skins/ui/default/skin.ts": "./build/skins/ui/default/skin.ts",
+    "./skins/ui/default/content.ts": "./build/skins/ui/default/content.ts",
     "./skins/ui/default/skin.css": "./build/skins/ui/default/skin.css",
     "./build/*": "./build/*",
     "./src/less/*": "./src/less/*"
@@ -30,6 +31,9 @@
     "*": {
       "./skins/ui/default/skin.ts": [
         "./build/skins/ui/default/skin.ts"
+      ],
+      "./skins/ui/default/content.ts": [
+        "./build/skins/ui/default/content.ts"
       ],
       "./skins/ui/default/skin.css": [
         "./build/skins/ui/default/skin.css"

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -65,10 +65,26 @@
     max-width: 100%;
   }
 
+  .tox-ai__response__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .tox-ai__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .tox-ai__response-sources {
     display: flex;
     flex-direction: column;
     gap: 8px;
+  }
+
+  .tox-ai__response-sources-header {
+    display: block;
   }
 
   .tox-ai__response-sources-list {

--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -20,6 +20,16 @@
   @tinymceai-selected-box-shadow
 );
 
+.tox-tinymceai {
+  // Block class for tinymceai preview - required for Bem type generation
+  display: contents;
+}
+
+.tox-tinymceai__annotation {
+  // Base class for annotations - styling handled by modifier classes
+  display: contents;
+}
+
 div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"] {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
# Add support for content classes in Bem utility

Related Ticket: TINY-13600

Description of Changes:
* Added `ContentClasses` type import from Oxide content.ts
* Extended `ValidClassName` type to include both UI and content class names
* Updated package.json to export content.ts file
* Enhanced AI chat component styling with new header and icon elements
* Added base classes for tinymceai preview in content styles

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced styling for AI chat response headers and icons
  * Added styling support for AI content preview components

* **Chores**
  * Updated module exports for improved content UI functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->