### PR TITLE
TINY-13645: Fix annotation base display: use display: revert instead of contents

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -27,7 +27,7 @@
 
 .tox-tinymceai__annotation {
   // Base class for annotations - styling handled by modifier classes
-  display: contents;
+  display: revert;
 }
 
 div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"] {


### PR DESCRIPTION
Related Ticket: TINY-13645

Description of Changes:
* Fix annotation base display, use display: revert instead of contents

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout behavior of AI preview annotations to improve visual presentation and alignment with default rendering behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->