### PR TITLE
TINY-13479: Expose HashMap and HashSet

### DIFF
--- a/modules/katamari/src/main/ts/ephox/katamari/api/Main.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Main.ts
@@ -7,6 +7,8 @@ import { Future } from './Future';
 import { FutureResult } from './FutureResult';
 import * as Futures from './Futures';
 import { Global } from './Global';
+import * as HashMap from './HashMap';
+import * as HashSet from './HashSet';
 import * as Id from './Id';
 import * as Jam from './Jam';
 import { LazyValue } from './LazyValue';
@@ -47,6 +49,8 @@ export {
   FutureResult,
   Futures,
   Global,
+  HashMap,
+  HashSet,
   Id,
   Jam,
   LazyValue,


### PR DESCRIPTION
Related Ticket: TINY-13479

Description of Changes:
* We forgot to expose the new HashMap and HashSet though the libraries api main entry point.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HashMap and HashSet are now publicly available for use.
  * These collections provide efficient keyed lookup and set operations to simplify in-memory data management and enable more flexible collection handling in applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->