### PR TITLE
TINY-13027: Removed NaN from float prop gen

### DIFF
--- a/modules/sugar/src/test/ts/atomic/DimensionParseTest.ts
+++ b/modules/sugar/src/test/ts/atomic/DimensionParseTest.ts
@@ -8,7 +8,7 @@ describe('atomic.sugar.DimensionParseTest', () => {
   it('All valid floats are valid', () => {
     fc.assert(fc.property(fc.oneof(
       // small to medium floats
-      fc.float(),
+      fc.float({ noNaN: true, noDefaultInfinity: true }),
       // big floats
       fc.tuple(
         fc.float({ noNaN: true, noDefaultInfinity: true }),


### PR DESCRIPTION
Related Ticket: TINY-13027

Description of Changes:
* When bumping fast check NaN started to become a number that would be some times generated by property tests so this removed the NaN. The specific change was to add this `fc.float({ noNaN: true, noDefaultInfinity: true }),`
* Also updated the test to use BDD style.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test framework and validation for dimension parsing, with enhanced edge case handling to ensure greater robustness and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->