### PR TITLE
TINY-13108: Changed link removal.

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13108-2026-01-29.yaml
+++ b/.changes/unreleased/tinymce-TINY-13108-2026-01-29.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Attempting to remove a link after a `contentEditable="false"` element would not be possible.
+time: 2026-01-29T09:37:10.594557+01:00
+custom:
+    Issue: TINY-13108

--- a/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Actions.ts
@@ -1,4 +1,4 @@
-import { Arr, Optional, Obj, Type } from '@ephox/katamari';
+import { Arr, Obj, Optional, Type } from '@ephox/katamari';
 
 import type DOMUtils from 'tinymce/core/api/dom/DOMUtils';
 import type Editor from 'tinymce/core/api/Editor';
@@ -125,8 +125,8 @@ const linkDomMutation = (editor: Editor, attachState: AttachState, data: LinkDia
 
 const unlinkSelection = (editor: Editor): void => {
   const dom = editor.dom, selection = editor.selection;
-  const bookmark = selection.getBookmark();
   const rng = selection.getRng().cloneRange();
+  const bookmark = selection.getBookmark();
 
   // Extend the selection out to the entire anchor element
   const startAnchorElm = dom.getParent(rng.startContainer, 'a[href]', editor.getBody());

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -48,6 +48,61 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
   });
 
+  context('Near other CET/CEF elements', () => {
+    it('TINY-13108: CET element before link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><span data-keep-span="YES">Content</span><a href="Link">Link</a></p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
+      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
+    });
+
+    it('TINY-13108: CEF element before link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><span data-keep-span="YES" contenteditable="false">Content</span><a href="Link">Link</a></p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
+      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
+    });
+
+    it('TINY-13108: CEF NBSP element before link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><span data-keep-span="YES" contenteditable="false">&nbsp;</span><a href="Link">Link</a></p>');
+      TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
+      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
+    });
+    it('TINY-13108: CET element after link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="Link">Link</a><span data-keep-span="YES">Content</span></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
+      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    });
+
+    it('TINY-13108: CEF element after link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="Link">Link</a><span data-keep-span="YES" contenteditable="false">Content</span></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
+      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    });
+
+    it('TINY-13108: CEF NBSP element after link', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="Link">Link</a><span data-keep-span="YES" contenteditable="false">&nbsp;</span></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
+      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
+    });
+  });
+
   context('Block links', () => {
     it('TINY-9172: Removing root level link should convert it to regular text block', () => {
       const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: TINY-13108

Description of Changes:
The issue is caused by the getBookmark-call changing the selection in the process in an attempt to normalize it and move it to a fitting place. When the link is immediately preceded by a CEF element this moves the selection into it, causing problems.

I am not sure if this is generally unwanted behavior for the getBookmark, nor even where the behavior would be going wrong or how to change it without breaking a lot of other things as interacting with CEF elements seems to be its main purpose.

As simply switching the order of those two lines also work I thought it'd be the better choice to just do that.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where removing a link positioned after a non-editable element was not possible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->