### PR TITLE
TINY-13665: Add styles needed for resuming a conversation

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
@@ -21,6 +21,7 @@ interface NonLinkTagProps {
 interface LinkTagProps {
   readonly link: true;
   readonly href: string;
+  readonly target?: string;
 }
 
 interface NonClosableProps {
@@ -40,6 +41,8 @@ export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((pro
   const { label, icon, closeable, ariaLabel, link, ...rest } = props;
   const disabled = closeable && props.disabled === true;
   const href = link ? props.href : undefined;
+  const target = link ? (props.target ?? '_blank') : undefined;
+  const rel = link && target === '_blank' ? 'noopener noreferrer' : undefined;
 
   const content = (
     <>
@@ -54,7 +57,14 @@ export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((pro
   );
 
   return link ? (
-    <a className={Bem.block('tox-tag')} href={href} ref={ref as React.Ref<HTMLAnchorElement>} {...rest}>
+    <a
+      className={Bem.block('tox-tag')}
+      href={href}
+      target={target}
+      rel={rel}
+      ref={ref as React.Ref<HTMLAnchorElement>}
+      {...rest}
+    >
       {content}
     </a>
   ) : (

--- a/modules/oxide-components/src/main/ts/components/icon/Icon.tsx
+++ b/modules/oxide-components/src/main/ts/components/icon/Icon.tsx
@@ -1,5 +1,4 @@
-import { useUniverse } from 'oxide-components/main';
-
+import { useUniverse } from '../../contexts/UniverseContext/Universe';
 import { classes } from '../../utils/Styles';
 
 import type { IconProps } from './IconTypes';

--- a/modules/oxide/src/less/theme/components/tag/tag.less
+++ b/modules/oxide/src/less/theme/components/tag/tag.less
@@ -1,4 +1,7 @@
 .tox {
+  a.tox-tag {
+    cursor: pointer;
+  }
   .tox-tag {
     width: fit-content;
     display: flex;


### PR DESCRIPTION
Related Ticket: TINY-13665

Description of Changes:

- Added cursor: pointer style to anchor tags with the tox-tag class within the AI chat component
- Add support for target prop in Tag when it is used as a link
- Fix circular dependency warning

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizable link targets in tags, allowing links to open in new windows or tabs.

* **Style**
  * Tag links now display a pointer cursor on hover for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->