### PR TITLE
TINY-13601: Add stop icon to default oxide icons

### DIFF
--- a/modules/oxide-icons-default/src/svg/stop.svg
+++ b/modules/oxide-icons-default/src/svg/stop.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m19 17a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2-2v-10a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" fill="#222f3e"/></svg>


### PR DESCRIPTION
Related Ticket: [TINY-13601](https://ephocks.atlassian.net/browse/TINY-13601)

Description of Changes:
* Added a new "stop" icon to the oxide default icons

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13601]: https://ephocks.atlassian.net/browse/TINY-13601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ