### PR TITLE
TINY-13425: improve active menu item state management

### DIFF
--- a/modules/oxide-components/src/main/ts/components/menu/Menu.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.stories.tsx
@@ -76,7 +76,6 @@ const menu: JSX.Element = (
     <Menu.Item
       key={Id.generate('menu-item')}
       icon={<Icon icon='item'></Icon>}
-      autoFocus={true}
       // eslint-disable-next-line no-console
       onAction= {() => console.log('Clicked Menu item 1')}
     >
@@ -99,7 +98,6 @@ const menu: JSX.Element = (
       submenuContent={
         <Menu.Root>
           <Menu.Item
-            autoFocus={true}
             key={Id.generate('menu-item')}
             icon={'item'}
             // eslint-disable-next-line no-console
@@ -125,7 +123,6 @@ const menu: JSX.Element = (
             submenuContent={
               <Menu.Root>
                 <Menu.Item
-                  autoFocus={true}
                   key={Id.generate('menu-item')}
                   icon={'item'}
                   // eslint-disable-next-line no-console

--- a/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
@@ -1,4 +1,6 @@
-import { useRef, type FC, type PropsWithChildren } from 'react';
+import { Optional } from '@ephox/katamari';
+import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
+import { useEffect, useRef, type FC, type PropsWithChildren } from 'react';
 
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
 import * as Bem from '../../utils/Bem';
@@ -7,15 +9,26 @@ import { Item } from './components/Item';
 import { SubmenuItem } from './components/SubmenuItem';
 import { ToggleItem } from './components/ToggleItem';
 
+const ENABLED_ITEM_SELECTOR = `${Bem.elementSelector('tox-collection', 'item')}:not([aria-disabled="true"])`;
+
+const focusFirstEnabledMenuItem = (container: Element | null): void =>
+  Optional.from(container).each((element) =>
+    SelectorFind.descendant<HTMLElement>(SugarElement.fromDom(element), ENABLED_ITEM_SELECTOR).each(Focus.focus)
+  );
+
 const Root: FC<PropsWithChildren> = ({ children }) => {
   const ref = useRef<HTMLDivElement>(null);
 
   KeyboardNavigationHooks.useFlowKeyNavigation({
     containerRef: ref,
-    selector: '.tox-collection__item:not([aria-disabled="true"])',
+    selector: ENABLED_ITEM_SELECTOR,
     allowHorizontal: false,
     cycles: false
   });
+
+  useEffect(() => {
+    focusFirstEnabledMenuItem(ref.current);
+  }, []);
 
   return (
     <div ref={ref} role='menu' className={[ Bem.block('tox-menu'), Bem.block('tox-collection', { list: true }) ].join(' ')}>
@@ -32,7 +45,3 @@ export {
   SubmenuItem,
   ToggleItem
 };
-
-// TODO: improve managing active state #TINY-13425
-// Currently, items receive active class on both hover and focus. When mixing mouse movement and navigating with keyboard it sometimes results in two 'active' elements
-// Look at the tinymce menus for correct behavior

--- a/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
@@ -5,11 +5,10 @@ import * as Bem from '../../../utils/Bem';
 import { Icon } from '../../icon/Icon';
 import type { CommonMenuItemInstanceApi, MenuItemProps } from '../internals/Types';
 
-export const Item = forwardRef<HTMLButtonElement, MenuItemProps>(({ autoFocus = false, enabled = true, onSetup, icon, shortcut, onAction, children }, ref) => {
+export const Item = forwardRef<HTMLButtonElement, MenuItemProps>(({ enabled = true, onSetup, icon, shortcut, onAction, children }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     focused: false,
-    hovered: false,
   });
   const id = useId();
   const stateRef = useRef(state);
@@ -49,16 +48,18 @@ export const Item = forwardRef<HTMLButtonElement, MenuItemProps>(({ autoFocus = 
       aria-disabled={!state.enabled}
       disabled={!state.enabled}
       onFocus={() => setState({ ...state, focused: true })}
-      onPointerEnter={() => setState({ ...state, hovered: true })}
-      onPointerLeave={() => setState({ ...state, hovered: false })}
+      onPointerMove={(e) => {
+        if (state.enabled) {
+          e.currentTarget.focus();
+        }
+      }}
       onBlur={() => setState({ ...state, focused: false })}
       onClick={() => onAction(api)}
       className={Bem.element('tox-collection', 'item', {
-        'active': state.focused || state.hovered,
+        'active': state.focused,
         'state-disabled': !state.enabled,
       })}
       ref={ref}
-      autoFocus={autoFocus}
       aria-keyshortcuts={shortcut}
     >
       {itemIcon && <div className={Bem.element('tox-collection', 'item-icon')}>{itemIcon}</div>}

--- a/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
@@ -1,16 +1,34 @@
-import { Fun, Type } from '@ephox/katamari';
-import { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Fun, Optional, Optionals, Type } from '@ephox/katamari';
+import { Compare, SelectorFind, SugarElement } from '@ephox/sugar';
+import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import * as Bem from '../../../utils/Bem';
 import * as Dropdown from '../../dropdown/Dropdown';
 import { Icon } from '../../icon/Icon';
 import type { CommonMenuItemInstanceApi, SubmenuProps } from '../internals/Types';
 
-export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ autoFocus = false, enabled = true, icon, onSetup, children, submenusSide = 'right', submenuContent }, ref) => {
+const isSiblingMenuItemInSameGroup = (relatedTarget: Element | null, currentTarget: Element): boolean => {
+  const groupSelector = Bem.elementSelector('tox-collection', 'group');
+  const getGroup = (el: Element) => SelectorFind.closest(SugarElement.fromDom(el), groupSelector);
+
+  return Optional.from(relatedTarget).exists((target) =>
+    Optionals.equals(getGroup(currentTarget), getGroup(target), Compare.eq)
+  );
+};
+
+const isMenuItemOutsideContainer = (relatedTarget: Element | null, container: Element): boolean => {
+  return Optional.from(relatedTarget).exists((target) => {
+    const targetElement = SugarElement.fromDom(target);
+    return !Compare.contains(SugarElement.fromDom(container), targetElement);
+  });
+};
+
+export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ enabled = true, icon, onSetup, children, submenusSide = 'right', submenuContent }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     focused: false,
-    hovered: false,
+    isSubmenuOpen: false,
+    focusMovedToOtherMenuItem: false,
   });
   const id = useId();
   const stateRef = useRef(state);
@@ -42,8 +60,19 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ autoFo
     ? <Icon icon={icon} />
     : icon;
 
+  const handleOpenChange = useCallback((isOpen: boolean) => {
+    setState((prev) => ({
+      ...prev,
+      isSubmenuOpen: isOpen
+    }));
+  }, []);
+
   return (
-    <Dropdown.Root side={submenusSide} align={'start'} triggerEvents={[ 'click', 'hover' ]}>
+    <Dropdown.Root
+      side={submenusSide}
+      align={'start'}
+      triggerEvents={[ 'click', 'hover' ]}
+    >
       <Dropdown.Trigger>
         <button
           id={id}
@@ -54,15 +83,24 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ autoFo
           aria-haspopup={'true'}
           aria-disabled={!state.enabled}
           disabled={!state.enabled}
-          onFocus={() => setState({ ...state, focused: true })}
-          onPointerEnter={() => setState({ ...state, hovered: true })}
-          onPointerLeave={() => setState({ ...state, hovered: false })}
-          onBlur={() => setState({ ...state, focused: false })}
+          onFocus={() => setState((prev) => ({ ...prev, focused: true, focusMovedToOtherMenuItem: false }))}
+          onPointerMove={(e) => {
+            if (state.enabled) {
+              e.currentTarget.focus();
+            }
+          }}
+          onBlur={(e) => {
+            const relatedTarget = e.relatedTarget;
+            setState((prev) => ({
+              ...prev,
+              focused: false,
+              focusMovedToOtherMenuItem: isSiblingMenuItemInSameGroup(relatedTarget, e.target)
+            }));
+          }}
           className={Bem.element('tox-collection', 'item', {
-            'active': state.focused || state.hovered,
+            'active': state.focused || (state.isSubmenuOpen && !state.focusMovedToOtherMenuItem),
             'state-disabled': !state.enabled,
           })}
-          autoFocus={autoFocus}
         >
           {itemIcon && <div className={Bem.element('tox-collection', 'item-icon')}>{itemIcon}</div>}
           <div className={Bem.element('tox-collection', 'item-label')}>{children}</div>
@@ -71,8 +109,17 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ autoFo
           </div>
         </button>
       </Dropdown.Trigger>
-      <Dropdown.Content>
-        {submenuContent}
+      <Dropdown.Content onOpenChange={handleOpenChange}>
+        <div
+          onBlur={(e) => {
+            const relatedTarget = e.relatedTarget;
+            if (isMenuItemOutsideContainer(relatedTarget, e.target)) {
+              setState((prev) => ({ ...prev, focusMovedToOtherMenuItem: true }));
+            }
+          }}
+        >
+          {submenuContent}
+        </div>
       </Dropdown.Content>
     </Dropdown.Root>
   );

--- a/modules/oxide-components/src/main/ts/components/menu/components/ToggleItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/ToggleItem.tsx
@@ -5,12 +5,11 @@ import * as Bem from '../../../utils/Bem';
 import { Icon } from '../../icon/Icon';
 import type { ToggleMenuItemInstanceApi, ToggleMenuItemProps } from '../internals/Types';
 
-export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ autoFocus = false, enabled = true, onSetup, icon, active = false, shortcut, onAction, children }, ref) => {
+export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ enabled = true, onSetup, icon, active = false, shortcut, onAction, children }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     active,
     focused: false,
-    hovered: false,
   });
   const id = useId();
   const stateRef = useRef(state);
@@ -56,17 +55,19 @@ export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ 
       disabled={!state.enabled}
       aria-selected={state.active}
       onFocus={() => setState({ ...state, focused: true })}
-      onPointerEnter={() => setState({ ...state, hovered: true })}
-      onPointerLeave={() => setState({ ...state, hovered: false })}
+      onPointerMove={(e) => {
+        if (state.enabled) {
+          e.currentTarget.focus();
+        }
+      }}
       onBlur={() => setState({ ...state, focused: false })}
       onClick={() => onAction(api)}
       className={Bem.element('tox-collection', 'item', {
         'enabled': state.active,
-        'active': state.focused || state.hovered,
+        'active': state.focused,
         'state-disabled': !state.enabled,
       })}
       ref={ref}
-      autoFocus={autoFocus}
       aria-keyshortcuts={shortcut}
     >
       {itemIcon && <div className={Bem.element('tox-collection', 'item-icon')}>{itemIcon}</div>}

--- a/modules/oxide-components/src/main/ts/components/menu/internals/Types.ts
+++ b/modules/oxide-components/src/main/ts/components/menu/internals/Types.ts
@@ -13,7 +13,6 @@ export interface ToggleMenuItemInstanceApi extends CommonMenuItemInstanceApi {
 
 // Item components Props
 export interface ToggleMenuItemProps extends PropsWithChildren {
-  autoFocus?: boolean;
   readonly icon?: string | JSX.Element;
   readonly enabled?: boolean;
   readonly active?: boolean;
@@ -23,7 +22,6 @@ export interface ToggleMenuItemProps extends PropsWithChildren {
 }
 
 export interface MenuItemProps extends PropsWithChildren {
-  autoFocus?: boolean;
   readonly icon?: string | JSX.Element;
   readonly enabled?: boolean;
   readonly shortcut?: string;
@@ -32,7 +30,6 @@ export interface MenuItemProps extends PropsWithChildren {
 }
 
 export interface SubmenuProps extends PropsWithChildren {
-  autoFocus?: boolean;
   readonly submenusSide?: 'left' | 'right';
   readonly icon?: string | JSX.Element;
   readonly enabled?: boolean;

--- a/modules/oxide-components/src/test/ts/browser/components/Menu.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Menu.spec.tsx
@@ -75,7 +75,6 @@ describe('browser.MenuTest', () => {
         <UniverseProvider resources={mockUniverse}>
           <Menu.Root>
             <Menu.Item
-              autoFocus={true}
               // eslint-disable-next-line no-console
               onAction= {() => console.log('Clicked Menu item 1')}
             >{'Menu item 1'}</Menu.Item>
@@ -90,7 +89,6 @@ describe('browser.MenuTest', () => {
               icon={'item'}
               submenuContent={<Menu.Root>
                 <Menu.Item
-                  autoFocus={true}
                   // eslint-disable-next-line no-console
                   onAction= {() => console.log('Clicked nested menu item 1')}
                 >
@@ -192,7 +190,7 @@ describe('browser.MenuTest', () => {
         return (
           <UniverseProvider resources={mockUniverse}>
             <Menu.Root>
-              <Menu.Item onAction={vi.fn()} autoFocus={true}>Item 1</Menu.Item>
+              <Menu.Item onAction={vi.fn()}>Item 1</Menu.Item>
               <Menu.Item onAction={vi.fn()}>Item 2</Menu.Item>
               <Menu.Item onAction={vi.fn()}>Item 3</Menu.Item>
             </Menu.Root>
@@ -223,7 +221,7 @@ describe('browser.MenuTest', () => {
         return (
           <UniverseProvider resources={mockUniverse}>
             <Menu.Root>
-              <Menu.Item onAction={vi.fn()} autoFocus={true}>Item 1</Menu.Item>
+              <Menu.Item onAction={vi.fn()}>Item 1</Menu.Item>
               <Menu.Item enabled={false} onAction={vi.fn()}>Item 2</Menu.Item>
               <Menu.Item onAction={vi.fn()}>Item 3</Menu.Item>
             </Menu.Root>

--- a/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
+++ b/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
@@ -366,99 +366,101 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
           popover="auto"
           style="opacity: 1;"
         >
-          <div
-            class="tox-menu tox-collection tox-collection--list"
-            role="menu"
-          >
+          <div>
             <div
-              class="tox-collection__group"
+              class="tox-menu tox-collection tox-collection--list"
+              role="menu"
             >
-              <button
-                aria-disabled="false"
-                aria-haspopup="false"
-                class="tox-collection__item tox-collection__item--active"
-                id=":r3:"
-                role="menuitem"
-                tabindex="-1"
+              <div
+                class="tox-collection__group"
               >
-                <div
-                  class="tox-collection__item-label"
+                <button
+                  aria-disabled="false"
+                  aria-haspopup="false"
+                  class="tox-collection__item tox-collection__item--active"
+                  id=":r3:"
+                  role="menuitem"
+                  tabindex="-1"
                 >
-                  Nested menu item 1
-                </div>
-              </button>
-              <button
-                aria-disabled="true"
-                aria-haspopup="false"
-                aria-selected="false"
-                class="tox-collection__item tox-collection__item--state-disabled"
-                disabled=""
-                id=":r4:"
-                role="menuitemcheckbox"
-                tabindex="-1"
-              >
-                <div
-                  class="tox-collection__item-label"
-                >
-                  Nested menu item 2
-                </div>
-                <div
-                  class="tox-collection__item-checkmark"
-                >
-                  <span
-                    class="tox-icon"
+                  <div
+                    class="tox-collection__item-label"
                   >
-                    <!--?xml version="1.0" encoding="UTF-8"?-->
-                    
-
-                    <svg
-                      height="24px"
-                      version="1.1"
-                      viewBox="0 0 24 24"
-                      width="24px"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    Nested menu item 1
+                  </div>
+                </button>
+                <button
+                  aria-disabled="true"
+                  aria-haspopup="false"
+                  aria-selected="false"
+                  class="tox-collection__item tox-collection__item--state-disabled"
+                  disabled=""
+                  id=":r4:"
+                  role="menuitemcheckbox"
+                  tabindex="-1"
+                >
+                  <div
+                    class="tox-collection__item-label"
+                  >
+                    Nested menu item 2
+                  </div>
+                  <div
+                    class="tox-collection__item-checkmark"
+                  >
+                    <span
+                      class="tox-icon"
                     >
+                      <!--?xml version="1.0" encoding="UTF-8"?-->
                       
-    
-                      <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-                      
-    
-                      <title>
-                        icon-checkmark
-                      </title>
-                      
-    
-                      <desc>
-                        Created with Sketch.
-                      </desc>
-                      
-    
-                      <defs />
-                      
-    
-                      <g
-                        fill="none"
-                        fill-rule="evenodd"
-                        stroke="none"
-                        stroke-width="1"
+
+                      <svg
+                        height="24px"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        width="24px"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
                       >
                         
-        
-                        <path
-                          d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
-                          fill="#000000"
-                          fill-rule="nonzero"
-                        />
+    
+                        <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
                         
     
-                      </g>
-                      
+                        <title>
+                          icon-checkmark
+                        </title>
+                        
+    
+                        <desc>
+                          Created with Sketch.
+                        </desc>
+                        
+    
+                        <defs />
+                        
+    
+                        <g
+                          fill="none"
+                          fill-rule="evenodd"
+                          stroke="none"
+                          stroke-width="1"
+                        >
+                          
+        
+                          <path
+                            d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
+                            fill="#000000"
+                            fill-rule="nonzero"
+                          />
+                          
+    
+                        </g>
+                        
 
-                    </svg>
-                  </span>
-                </div>
-              </button>
+                      </svg>
+                    </span>
+                  </div>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -820,98 +822,100 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
           popover="auto"
           style="opacity: 1;"
         >
-          <div
-            class="tox-menu tox-collection tox-collection--list"
-            role="menu"
-          >
+          <div>
             <div
-              class="tox-collection__group"
+              class="tox-menu tox-collection tox-collection--list"
+              role="menu"
             >
-              <button
-                aria-disabled="false"
-                aria-haspopup="false"
-                class="tox-collection__item tox-collection__item--active"
-                id=":r8:"
-                role="menuitem"
-                tabindex="-1"
+              <div
+                class="tox-collection__group"
               >
-                <div
-                  class="tox-collection__item-label"
+                <button
+                  aria-disabled="false"
+                  aria-haspopup="false"
+                  class="tox-collection__item"
+                  id=":r8:"
+                  role="menuitem"
+                  tabindex="-1"
                 >
-                  Nested menu item 1
-                </div>
-              </button>
-              <button
-                aria-disabled="false"
-                aria-haspopup="false"
-                aria-selected="false"
-                class="tox-collection__item"
-                id=":r9:"
-                role="menuitemcheckbox"
-                tabindex="-1"
-              >
-                <div
-                  class="tox-collection__item-label"
-                >
-                  Nested menu item 2
-                </div>
-                <div
-                  class="tox-collection__item-checkmark"
-                >
-                  <span
-                    class="tox-icon"
+                  <div
+                    class="tox-collection__item-label"
                   >
-                    <!--?xml version="1.0" encoding="UTF-8"?-->
-                    
-
-                    <svg
-                      height="24px"
-                      version="1.1"
-                      viewBox="0 0 24 24"
-                      width="24px"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    Nested menu item 1
+                  </div>
+                </button>
+                <button
+                  aria-disabled="false"
+                  aria-haspopup="false"
+                  aria-selected="false"
+                  class="tox-collection__item"
+                  id=":r9:"
+                  role="menuitemcheckbox"
+                  tabindex="-1"
+                >
+                  <div
+                    class="tox-collection__item-label"
+                  >
+                    Nested menu item 2
+                  </div>
+                  <div
+                    class="tox-collection__item-checkmark"
+                  >
+                    <span
+                      class="tox-icon"
                     >
+                      <!--?xml version="1.0" encoding="UTF-8"?-->
                       
-    
-                      <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-                      
-    
-                      <title>
-                        icon-checkmark
-                      </title>
-                      
-    
-                      <desc>
-                        Created with Sketch.
-                      </desc>
-                      
-    
-                      <defs />
-                      
-    
-                      <g
-                        fill="none"
-                        fill-rule="evenodd"
-                        stroke="none"
-                        stroke-width="1"
+
+                      <svg
+                        height="24px"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        width="24px"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
                       >
                         
-        
-                        <path
-                          d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
-                          fill="#000000"
-                          fill-rule="nonzero"
-                        />
+    
+                        <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
                         
     
-                      </g>
-                      
+                        <title>
+                          icon-checkmark
+                        </title>
+                        
+    
+                        <desc>
+                          Created with Sketch.
+                        </desc>
+                        
+    
+                        <defs />
+                        
+    
+                        <g
+                          fill="none"
+                          fill-rule="evenodd"
+                          stroke="none"
+                          stroke-width="1"
+                        >
+                          
+        
+                          <path
+                            d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
+                            fill="#000000"
+                            fill-rule="nonzero"
+                          />
+                          
+    
+                        </g>
+                        
 
-                    </svg>
-                  </span>
-                </div>
-              </button>
+                      </svg>
+                    </span>
+                  </div>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/modules/oxide/src/less/theme/components/dropdown/dropdown.less
+++ b/modules/oxide/src/less/theme/components/dropdown/dropdown.less
@@ -13,6 +13,7 @@
     // Make menu fill dropdown width
     .tox-menu {
       width: 100%;
+      box-sizing: border-box;
     }
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-13425

Description of Changes:
* Fixed focus management in Dropdown component to prevent stealing focus from other elements
* Improved Menu component to automatically focus the first enabled item on mount
* Removed `autoFocus` prop from menu items in favor of automatic focus management
* Enhanced SubmenuItem to maintain active state when submenu is open
* Fixed hover/focus behavior in menu items to prevent multiple active items
* Added `onOpenChange` callback to Dropdown component
* Fixed menu width styling in dropdown

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdown exposes onOpenChange to notify when it opens or closes.

* **Bug Fixes**
  * Closing a dropdown no longer steals focus; trigger is refocused only when appropriate.
  * Menus focus the first enabled item on open for improved keyboard navigation.
  * Dropdown sizing includes padding/borders.
  * Menu items now focus on pointer movement instead of hover.

* **Breaking Changes**
  * Removed autoFocus prop from menu item APIs; stories and tests updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->