### PR TITLE
TINY-13705: add class for footer note

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -224,7 +224,7 @@
 
   .tox-ai__footer-note {
     align-items: center;
-    color: rgba(from var(--tox-private-color-black, @color-black) r g b / 0.70);
+    color: var(--tox-private-text-color-muted, @text-color-muted);
     display: flex;
     font-size: @font-size-sm;
     height: 24px;


### PR DESCRIPTION
Related Ticket: TINY-13705

Description of Changes:
add class to style the footer note, I left the padding bottom to `0px` since it already has the one from `.tox-ai__footer`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the AI chat footer note styling to improve layout and visual presentation: centered alignment, muted color, consistent spacing, 24px height, and refined typography for clearer, more readable footer content across the chat interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->