### PR TITLE
TINY-13671: Only show border on Accordion once expanded

### DIFF
--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -51,13 +51,13 @@
 
   .tox-accordion__item {
     background-color: var(--tox-private-background-color, @accordion-background-color);
-    border: 1px solid var(--tox-private-border-color, @accordion-border-color);
     border-radius: @control-border-radius;
     position: relative;
 
     &.tox-accordion__item--expanded {
       background-color: var(--tox-private-accordion-item-background-color, @accordion-item-background-color);
-    
+      border: 1px solid var(--tox-private-border-color, @accordion-border-color);
+
       .tox-accordion__header {
         padding-bottom: @pad-xs;
       }


### PR DESCRIPTION
Related Ticket: [TINY-13671](https://ephocks.atlassian.net/browse/TINY-13671)

Description of Changes:
* The border should only be visible once expanded.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13671]: https://ephocks.atlassian.net/browse/TINY-13671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated accordion component styling to display borders only when items are expanded, providing a cleaner visual appearance for collapsed accordion items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->