### PR TITLE
TINY-13681: more context sources dropdown changes

### DIFF
--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -86,15 +86,20 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
   }, [ isOpen, updatePosition, children ]);
 
   useEffect(() => {
-    const onScrollAndResize = () => {
+    const onResize = () => {
       contentRef.current?.hidePopover();
     };
-    window.addEventListener('scroll', onScrollAndResize, true);
-    window.addEventListener('resize', onScrollAndResize);
+    const onOutsideScroll = (e: Event) => {
+      if (!(e.target instanceof Node) || !isInDropdownContent(contentRef, e.target)) {
+        contentRef.current?.hidePopover();
+      }
+    };
+    window.addEventListener('scroll', onOutsideScroll, true);
+    window.addEventListener('resize', onResize);
 
     return () => {
-      window.removeEventListener('scroll', onScrollAndResize, true);
-      window.removeEventListener('resize', onScrollAndResize);
+      window.removeEventListener('scroll', onOutsideScroll, true);
+      window.removeEventListener('resize', onResize);
     };
   }, [ updatePosition, triggerRef, contentRef ]);
 

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -210,6 +210,21 @@
     display: flex;
     gap: var(--tox-private-pad-sm, @pad-sm);
     flex-wrap: wrap;
+    max-height: calc(
+      ( 2 *
+        (2 * var(--tox-private-pad-xs, @pad-xs) + var(--tox-private-base-value, @base-value)) 
+      ) +
+      var(--tox-private-pad-sm, @pad-sm)
+    ); // Two rows of tags + the gap between them. Height of the tag is calculated from padding top and bottom + line height 
+    overflow: auto;
+  }
+
+  .tox-ai__context-more {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tox-private-pad-sm, @pad-sm);
+    padding: var(--tox-private-pad-sm, @pad-sm);
+    overflow: auto;
   }
 
   .tox-ai__footer-actions {

--- a/modules/oxide/src/less/theme/components/tag/tag.less
+++ b/modules/oxide/src/less/theme/components/tag/tag.less
@@ -5,9 +5,9 @@
   .tox-tag {
     width: fit-content;
     display: flex;
-    padding: 4px 6px;
+    padding: var(--tox-private-pad-xs, @pad-xs) 6px;
     align-items: center;
-    gap: 4px;
+    gap: var(--tox-private-pad-xs, @pad-xs);
     border-radius: 3px;
     background: linear-gradient(0deg,color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 0%, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 100%),  var(--tox-private-color-tint, @color-tint);
     line-height: var(--tox-private-base-value, @base-value);


### PR DESCRIPTION
Related Ticket: TINY-13681

Description of Changes:

- Added max-height and overflow properties to the AI chat context tags container to limit it to two rows
- Created a new `.tox-ai__context-more` class with styling for a collapsible section that displays additional context information
- Added inside scroll possibility to dropdown

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown popover stays open when scrolling inside its content; it now only closes on outside scroll or window resize.

* **New Features**
  * AI chat context area constrained to show two tag rows with scrollable overflow and a dedicated "more" area for additional items.

* **Style**
  * Tag spacing updated to use configurable CSS variables for consistent padding and gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->