### PR TITLE
TINY-13541: Add keyboard navigation inside the prompt area

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.stories.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: [ 'autodocs', 'skip-visual-testing' ],
+  tags: [ 'autodocs' ],
 } satisfies Meta<typeof Tag>;
 
 export default meta;
@@ -35,4 +35,20 @@ export const ClosableTag: Story = {
       <Tag {...args} />
     </UniverseProvider>
   )
+};
+
+export const FocusedClosableTag: Story = {
+  args: {
+    closeable: true,
+    link: false,
+    label: 'Value',
+    onClose: Fun.noop
+  },
+  render: (args) => {
+    return (
+      <UniverseProvider resources={resources}>
+        <Tag ref={(el) => el?.focus()} {...args} />
+      </UniverseProvider>
+    );
+  }
 };

--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
@@ -1,3 +1,4 @@
+import { Type } from '@ephox/katamari';
 import { IconButton } from 'oxide-components/main';
 import { forwardRef } from 'react';
 
@@ -12,6 +13,7 @@ interface BaseTagProps {
   readonly onBlur?: (event: React.FocusEvent<HTMLElement>) => void;
   readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   readonly ariaLabel?: string;
+  readonly focusable?: boolean;
 }
 
 interface NonLinkTagProps {
@@ -38,11 +40,21 @@ export type TagProps = (NonLinkTagProps | LinkTagProps) & (NonClosableProps | Cl
 
 // Tag is here in reference to a tagging/labeling context, not a HTML tag.
 export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((props, ref) => {
-  const { label, icon, closeable, ariaLabel, link, ...rest } = props;
+  const { label, icon, closeable, ariaLabel, link, focusable: focusableProp, ...rest } = props;
   const disabled = closeable && props.disabled === true;
   const href = link ? props.href : undefined;
   const target = link ? (props.target ?? '_blank') : undefined;
   const rel = link && target === '_blank' ? 'noopener noreferrer' : undefined;
+  const focusable = Type.isNullable(focusableProp) || closeable ? true : props.focusable;
+  const sharedAttrs = {
+    className: Bem.block('tox-tag'),
+    onKeyUp: (e: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>) => {
+      if (closeable && [ 'Backspace', 'Delete' ].includes(e.key) && !disabled) {
+        props.onClose();
+      }
+    },
+    ...(focusable ? { tabIndex: -1 } : {})
+  };
 
   const content = (
     <>
@@ -58,17 +70,21 @@ export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((pro
 
   return link ? (
     <a
-      className={Bem.block('tox-tag')}
+      {...rest}
+      {...sharedAttrs}
       href={href}
       target={target}
       rel={rel}
       ref={ref as React.Ref<HTMLAnchorElement>}
-      {...rest}
     >
       {content}
     </a>
   ) : (
-    <div className={Bem.block('tox-tag')} ref={ref as React.Ref<HTMLDivElement>} {...rest}>
+    <div
+      {...rest}
+      {...sharedAttrs}
+      ref={ref as React.Ref<HTMLDivElement>}
+    >
       {content}
     </div>
   );

--- a/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.tsx
+++ b/modules/oxide-components/src/main/ts/components/floatingsidebar/FloatingSidebar.tsx
@@ -1,9 +1,10 @@
+import { Type } from '@ephox/katamari';
 import type { Property } from 'csstype';
-import type { CSSProperties, FC, PropsWithChildren } from 'react';
+import { forwardRef, useCallback, type CSSProperties, type PropsWithChildren } from 'react';
 
 import * as Bem from '../../utils/Bem';
-import { classes } from '../../utils/Styles';
 import * as Draggable from '../draggable/Draggable';
+
 import '../../module/css';
 export interface FloatingSidebarProps extends PropsWithChildren {
   isOpen?: boolean;
@@ -15,7 +16,7 @@ export interface FloatingSidebarProps extends PropsWithChildren {
 }
 interface HeaderProps extends PropsWithChildren {};
 
-const Root: FC<FloatingSidebarProps> = ({ isOpen = true, children, style, origin = 'top-right', initialPosition = { x: 0, y: 0 }, onDragStart, onDragEnd }) => {
+const Root = forwardRef<HTMLDivElement, FloatingSidebarProps>(({ isOpen = true, children, style, origin = 'top-right', initialPosition = { x: 0, y: 0 }, onDragStart, onDragEnd }, ref) => {
   return (
     <Draggable.Root
       className={Bem.block('tox-floating-sidebar', { open: isOpen })}
@@ -26,20 +27,31 @@ const Root: FC<FloatingSidebarProps> = ({ isOpen = true, children, style, origin
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       style={style}
+      ref={ref}
     >
-      <aside className={classes([ 'tox-floating-sidebar__content-wrapper' ])}>
-        { children }
+      <aside className={Bem.element('tox-floating-sidebar', 'content-wrapper')}>
+        {children}
       </aside>
     </Draggable.Root>
   );
-};
+});
 
-const Header: FC<HeaderProps> = ({ children }) => {
+const Header = forwardRef<HTMLDivElement, HeaderProps>(({ children }, ref) => {
+  const refCallback = useCallback((node: HTMLDivElement | null) => {
+    if (ref) {
+      if (Type.isFunction(ref)) {
+        ref(node);
+      } else {
+        ref.current = node;
+      }
+    }
+  }, [ ref ]);
+
   return (
     <Draggable.Handle>
-      <header className={classes([ 'tox-sidebar-content__header', 'tox-floating-sidebar__header' ])}>{ children }</header>
+      <header ref={refCallback} className={`${Bem.element('tox-sidebar-content', 'header')} ${Bem.element('tox-floating-sidebar', 'header')}`}>{ children }</header>
     </Draggable.Handle>
   );
-};
+});
 
-export { Root, Header };
+export { Header, Root };

--- a/modules/oxide-components/src/test/ts/browser/bespoke/tinymceai/Tag.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/bespoke/tinymceai/Tag.spec.tsx
@@ -1,0 +1,38 @@
+import { Fun } from '@ephox/katamari';
+import { Bem, Tag, UniverseProvider, type UniverseResources } from 'oxide-components/main';
+import { describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+
+const resources: UniverseResources = {
+  getIcon: Fun.constant(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
+    <path fill="#222F3E" fill-rule="evenodd" d="M11.723 5.62 9.356 8l2.367 2.38a.95.95 0 0 1-1.343 1.343L8 9.356l-2.38 2.367a.95.95 0 0 1-1.343-1.343L6.644 8 4.277 5.62A.95.95 0 0 1 5.62 4.277L8 6.644l2.38-2.367a.95.95 0 0 1 1.343 1.343Z"/>
+  </svg>
+`),
+};
+
+describe('browser.bespoke.tinymceai.Tag', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <div className={Bem.block('tox')}>
+        {children}
+      </div>
+    );
+  };
+
+  it('TINY-13541: should call the onClose callback when the backspace/delete key is pressed', async () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <UniverseProvider resources={resources}>
+        <Tag data-testid="tag" ref={(el) => el?.focus()} closeable link={false} label="Test Tag" onClose={onClose} />
+      </UniverseProvider>,
+      { wrapper }
+    );
+    const tag = getByTestId('tag');
+    await expect.element(tag).toHaveFocus();
+    await userEvent.keyboard('{Backspace}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await userEvent.keyboard('{Delete}');
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--closable-tag-desktop-chrome-linux-desktop-chrome-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--closable-tag-desktop-chrome-linux-desktop-chrome-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab1df36078f27fa6bc52d11aecc27c14b253479fba56e02f3a810247311d9943
+size 5649

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--closable-tag-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--closable-tag-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:062eb60d2145b02ffef506c2db8e9d9dd59574624ff9a419c74960cc7cc76e1a
+size 19297

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--closable-tag-desktop-safari-linux-desktop-safari-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--closable-tag-desktop-safari-linux-desktop-safari-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2060bd9b1b7be0517d5a3f5b305838f10783b80265bc57b51fd10b82334a4454
+size 6613

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--focused-closable-tag-desktop-chrome-linux-desktop-chrome-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--focused-closable-tag-desktop-chrome-linux-desktop-chrome-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0134820b30f4459e529b9ba015b00de2feb0f76be628826c68d51916c475ed5
+size 6202

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--focused-closable-tag-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--focused-closable-tag-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce5664b63d1104319bf5be4e3b25271f305453ddb59c1856daca3c02d9e6b224
+size 20634

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--focused-closable-tag-desktop-safari-linux-desktop-safari-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/bespoke-tinymceai-tag--focused-closable-tag-desktop-safari-linux-desktop-safari-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57f0c5f7706005094599ca41fead960d933892e93b12b245180efdf24ff55047
+size 7209

--- a/modules/oxide/src/less/theme/components/tag/tag.less
+++ b/modules/oxide/src/less/theme/components/tag/tag.less
@@ -1,4 +1,13 @@
+@tag-border-width: 1px;
+@tag-focus-outline: inset 0 0 0 1px @color-white, 0 0 0 2px @color-tint;
+
 .tox {
+
+  .tox-tag when (@custom-properties-enabled = true) {
+    --tox-private-tag-border-width: 1px;
+    --tox-private-tag-focus-outline: inset 0 0 0 1px var(--tox-private-color-white), 0 0 0 2px var(--tox-private-color-tint);
+  }
+
   a.tox-tag {
     cursor: pointer;
   }
@@ -6,12 +15,32 @@
     width: fit-content;
     display: flex;
     padding: var(--tox-private-pad-xs, @pad-xs) 6px;
+    position: relative;
     align-items: center;
     gap: var(--tox-private-pad-xs, @pad-xs);
     border-radius: 3px;
     background: linear-gradient(0deg,color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 0%, color-mix(in srgb, var(--tox-private-color-white, @color-white) 90%, transparent) 100%),  var(--tox-private-color-tint, @color-tint);
     line-height: var(--tox-private-base-value, @base-value);
     font-size: var(--tox-private-font-size-xs, @font-size-xs);
+
+    &::before {
+      border-radius: var(--tox-private-control-border-radius, @control-border-radius);
+      bottom: calc(-1 * var(--tox-private-tag-border-width, @tag-border-width));
+      box-shadow: var(--tox-private-tag-focus-outline, @tag-focus-outline);
+      content: '';
+      left: calc(-1 * var(--tox-private-tag-border-width, @tag-border-width));
+      opacity: 0;
+      pointer-events: none;
+      position: absolute;
+      right: calc(-1 * var(--tox-private-tag-border-width, @tag-border-width));
+      top: calc(-1 * var(--tox-private-tag-border-width, @tag-border-width));
+    }
+
+    &:focus:not(:disabled) {
+      &::before {
+        opacity: 1;
+      }
+    }
 
     .tox-icon {
       height: var(--tox-private-base-value, @base-value);


### PR DESCRIPTION
# Enhanced Tag Component and FloatingSidebar with Improved Accessibility

Related Ticket: TINY-13541

Description of Changes:

- Added `focusable` prop to Tag component to control tabIndex
- Implemented keyboard support for Tag component (Backspace key for closeable tags)
- Added focus styling for Tag component with outline
- Enhanced FloatingSidebar with forwardRef support
- Made Header component in FloatingSidebar forward refs properly
- Added CSS variables for tag styling when custom properties are enabled

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Tags can be keyboard-focusable (tab stop) and, when closeable, can be dismissed with Backspace or Delete.
    - Added a story showing a focused, closable tag.
- **Refactor**
    - Floating sidebar components now forward refs (header included) and exports ordering updated.
- **Style**
    - New theme variables and a visible focus outline for tags.
- **Tests**
    - Browser test added validating focus and closing via Backspace/Delete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->