### PR TITLE
TINY-13360: Disable pointer events on empty preview host

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
@@ -40,4 +40,8 @@
       }
     }
   }
+
+  .tox-ai__preview-host:empty {
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION
Related Ticket: TINY-13360

Description of Changes:
* Setting position: relative on the host element make it impossible to click though into the iframe under it this CSS workaround passes those events though if the element is empty. We may come up with a better solution later.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed pointer event handling for empty AI preview elements to prevent unwanted interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->