### PR TITLE
TINY-13786: fix disable state background for `tox-ai-model-selection-button`

### DIFF
--- a/modules/oxide/src/less/theme/components/button/button-naked.less
+++ b/modules/oxide/src/less/theme/components/button/button-naked.less
@@ -13,7 +13,7 @@
 @button-naked-hover-box-shadow: unset;
 @button-naked-hover-icon-color: @button-naked-icon-color;
 
-@button-naked-disabled-background-color: @button-naked-hover-background-color;
+@button-naked-disabled-background-color: transparent;
 @button-naked-disabled-border-color: transparent;
 @button-naked-disabled-box-shadow: unset;
 @button-naked-disabled-icon-color: fade(@button-naked-icon-color, 50%);
@@ -121,7 +121,7 @@
     color: var(--tox-private-button-naked-text-color, @button-naked-icon-color);
 
     &[disabled] {
-      background-color: transparent;
+      background-color: @button-naked-disabled-background-color;
       border-color: @button-naked-disabled-border-color;
       color: var(--tox-private-button-naked-disabled-text-color, @button-naked-disabled-icon-color);
       cursor: not-allowed;


### PR DESCRIPTION
Related Ticket: TINY-13786

Description of Changes:
fix disable state background for `tox-ai-model-selection-button`

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Disabled "naked" buttons now render with a transparent background instead of the previous shaded background.
  * This makes disabled naked buttons visually lighter and avoids inheriting hover background tones, improving clarity of disabled state across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->