### PR TITLE
TINY-13700: deprecate `exportpdf_converter_options`

### DIFF
--- a/modules/tinymce/src/core/main/ts/Deprecations.ts
+++ b/modules/tinymce/src/core/main/ts/Deprecations.ts
@@ -18,7 +18,7 @@ const removedOptions = (
   'template_cdate_classes,template_mdate_classes,template_selected_content_classes,template_preview_replace_values,template_replace_values,templates,template_cdate_format,template_mdate_format'
 ).split(',');
 
-const deprecatedOptions: string[] = [ 'content_css_cors' ];
+const deprecatedOptions: string[] = [ 'content_css_cors', 'exportpdf_converter_options' ];
 
 const removedPlugins = 'bbcode,colorpicker,contextmenu,fullpage,legacyoutput,spellchecker,template,textcolor,rtc'.split(',');
 


### PR DESCRIPTION
Related Ticket: TINY-13700

Description of Changes:
deprecation for TINY-13700, is the changelog is needed or should be included in the premium change?

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked the 'exportpdf_converter_options' configuration option as deprecated. Users will receive warnings when using this option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->