### PR TITLE
TINY-13854: add prevent default on closing a tag

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
@@ -62,7 +62,10 @@ export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((pro
       <span className={Bem.element('tox-tag', 'label')}>{label}</span>
       {closeable && (
         <span className={Bem.element('tox-tag', 'close')}>
-          <IconButton icon='source-close' variant='naked' disabled={disabled} onClick={props.onClose} aria-label={ariaLabel} />
+          <IconButton icon='source-close' variant='naked' disabled={disabled} aria-label={ariaLabel} onClick={(e) => {
+            e.preventDefault();
+            props.onClose();
+          }} />
         </span>
       )}
     </>


### PR DESCRIPTION
Related Ticket: TINY-13854

Description of Changes:
* Added preventDefault() call to the Tag component's close button click handler to prevent triggering href opening 

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag close button behavior to prevent unintended default actions when closing tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->