### PR TITLE
TINY-13870: Add highlight to doc review preview mode

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -30,6 +30,12 @@
   display: revert;
 }
 
+.tox-tinymceai__annotation--added__highlight,
+.tox-tinymceai__annotation--modified__highlight,
+.tox-tinymceai__annotation--removed__highlight {
+  cursor: pointer;
+}
+
 div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"] {
   position: relative;
   z-index: 1;
@@ -46,5 +52,37 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
 .tox-tinymceai__preview-body {
   position: relative;
   min-height: 100%;
+}
+
+.tox-tinymceai__preview-body--show-preview {
+  .tox-tinymceai__annotation--added,
+  .tox-tinymceai__annotation--modified {
+    border-bottom: 2px solid @color-tint;
+    cursor: pointer;
+  }
+
+  .tox-tinymceai__annotation--added__selected,
+  .tox-tinymceai__annotation--modified__selected {
+    background-color: fade(@color-tint, 20%);
+    border-top: 2px solid @color-tint;
+    border-bottom: 2px solid @color-tint;
+    box-shadow: none;
+    text-decoration: none;
+  }
+
+  img, video, iframe {
+    &.tox-tinymceai__annotation--added,
+    &.tox-tinymceai__annotation--modified {
+      outline: 0.25em solid fade(@color-tint, 20%);
+      padding: 0.25em;
+    }
+
+    &.tox-tinymceai__annotation--added__selected,
+    &.tox-tinymceai__annotation--modified__selected {
+      border: 0.25em solid fade(@color-tint, 20%);
+      outline: 0.125em solid @color-tint;
+      padding: 0em;
+    }
+  }
 }
 


### PR DESCRIPTION
Related Ticket: 
TINY-13870

Description of Changes:
- Add highlight to doc review preview mode
- Change cursor to pointer when hover on top of change

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for AI content annotations and previews with new highlight modifier states for added, modified, and removed content variants.
  * Improved styling for media elements (images, video, iframes) within preview contexts with outlines and padding adjustments.
  * Added interactive cursor feedback and visual selection indicators for annotation interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->