### PR TITLE
TINY-13871: Expose ref from SegmentedControl.Option component

### DIFF
--- a/modules/oxide-components/src/main/ts/components/segmentedcontrol/SegmentedControl.tsx
+++ b/modules/oxide-components/src/main/ts/components/segmentedcontrol/SegmentedControl.tsx
@@ -2,9 +2,7 @@ import { Optional, Type } from '@ephox/katamari';
 import { Attribute, type SugarElement } from '@ephox/sugar';
 import {
   createContext,
-  forwardRef,
-  type FunctionComponent,
-  type HTMLAttributes,
+  forwardRef, type HTMLAttributes,
   type PropsWithChildren,
   useContext,
   useEffect,
@@ -100,11 +98,14 @@ const Root = forwardRef<HTMLDivElement, SegmentedControlRootProps>(
   }
 );
 
-const Option: FunctionComponent<SegmentedControlOptionProps> = ({
-  value: optionValue,
-  disabled: optionDisabled,
-  children
-}) => {
+const Option = forwardRef<HTMLSpanElement, SegmentedControlOptionProps>((
+  {
+    value: optionValue,
+    disabled: optionDisabled,
+    children
+  },
+  ref
+) => {
   const {
     value: selectedValue,
     onChange,
@@ -129,6 +130,7 @@ const Option: FunctionComponent<SegmentedControlOptionProps> = ({
 
   return (
     <span
+      ref={ref}
       className={Bem.element('tox-segmented-control', 'segment', { active: isActive })}
       role="radio"
       aria-checked={isActive}
@@ -140,7 +142,7 @@ const Option: FunctionComponent<SegmentedControlOptionProps> = ({
       {children}
     </span>
   );
-};
+});
 
 export {
   Root,


### PR DESCRIPTION
Related Ticket: TINY-13871

Description of Changes:

- Expose ref from `SegmentedControl.Option` component, to be able to imperatively focus one of the options. 

Pre-checks:

~~- [ ] Changelog entry added~~
~~- [ ] Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

~~- [ ] Milestone set~~
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced SegmentedControl.Option component with improved ref support for better React integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->