### PR TITLE
TINY-13797: open submenus using arrows

### DIFF
--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { Throttler, Type, Obj } from '@ephox/katamari';
-import { Children, cloneElement, forwardRef, isValidElement, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type FC, type HTMLAttributes, type MouseEvent, type PropsWithChildren, type ReactElement } from 'react';
+import { Children, cloneElement, forwardRef, isValidElement, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type FC, type HTMLAttributes, type MouseEvent, type PropsWithChildren, type ReactElement, type KeyboardEvent } from 'react';
 
 import { Bem } from '../../main';
 
@@ -103,6 +103,32 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
     };
   }, [ updatePosition, triggerRef, contentRef ]);
 
+  const onHoverTriggerProps = {
+    onMouseLeave: (e: MouseEvent<HTMLDivElement>) => {
+      props.onMouseLeave?.(e);
+      debouncedHideHoverablePopover.throttle(e);
+    },
+    onMouseEnter: (e: MouseEvent<HTMLDivElement>) => {
+      props.onMouseEnter?.(e);
+      debouncedHideHoverablePopover.cancel();
+    }
+  };
+
+  const onArrowTriggerProps = {
+    onKeyUp: (e: KeyboardEvent<HTMLDivElement>) => {
+      props.onKeyUp?.(e);
+      if (e.key === 'ArrowLeft') {
+        e.stopPropagation();
+        contentRef.current?.hidePopover();
+      }
+    }
+  };
+
+  const contentProps = {
+    ...props,
+    ...triggerEvents.includes('hover') && onHoverTriggerProps,
+    ...triggerEvents.includes('arrows') && onArrowTriggerProps
+  };
   return <div
     // @ts-expect-error - TODO: Remove this expect error once we've upgraded to React 19+
     popover='auto'
@@ -116,11 +142,7 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
       }
     }}
     style={{ ...positioningStyles }}
-    { ...(triggerEvents.includes('hover')) && {
-      onMouseLeave: debouncedHideHoverablePopover.throttle,
-      onMouseEnter: () => debouncedHideHoverablePopover.cancel()
-    }}
-    { ...props }
+    { ...contentProps }
   >
     {isOpen && children}
   </div>;
@@ -169,6 +191,15 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
     }
   };
 
+  const onArrowTriggerProps = {
+    onKeyUp: (e: KeyboardEvent) => {
+      child.props.onKeyUp?.(e);
+      if (e.key === 'ArrowRight') {
+        contentRef.current?.showPopover();
+      }
+    }
+  };
+
   return cloneElement(child, {
     ...props,
     ref: (el: HTMLElement) => {
@@ -186,6 +217,7 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
     },
     ...triggerEvents.includes('click') && onClickTriggerProps,
     ...triggerEvents.includes('hover') && onHoverTriggerProps,
+    ...triggerEvents.includes('arrows') && onArrowTriggerProps
   });
 });
 
@@ -198,7 +230,7 @@ export interface DropdownProps extends PropsWithChildren {
   readonly align?: 'start' | 'center' | 'end';
   // margin/gap between the trigger button and anchored container
   readonly gap?: number;
-  readonly triggerEvents?: Array<'click' | 'hover'>;
+  readonly triggerEvents?: Array<'click' | 'hover' | 'arrows'>;
 }
 
 const Root: FC<DropdownProps> = ({ children, side = 'top', align = 'start', gap = 8, triggerEvents = [ 'click' ] }) => {

--- a/modules/oxide-components/src/main/ts/components/dropdown/internals/Context.ts
+++ b/modules/oxide-components/src/main/ts/components/dropdown/internals/Context.ts
@@ -8,7 +8,7 @@ export interface DropdownState {
   readonly align: 'start' | 'center' | 'end';
   // margin/gap between the trigger button and anchored container
   readonly gap: number;
-  readonly triggerEvents: Array<'click' | 'hover'>;
+  readonly triggerEvents: Array<'click' | 'hover' | 'arrows'>;
   readonly debouncedHideHoverablePopover: Throttler.Throttler<[e: MouseEvent]>;
   readonly isOpen: boolean;
   readonly setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
@@ -79,7 +79,7 @@ export const SubmenuItem = forwardRef<HTMLDivElement, SubmenuProps>(({ enabled =
     <Dropdown.Root
       side={submenusSide}
       align={'start'}
-      triggerEvents={state.enabled ? [ 'click', 'hover' ] : []}
+      triggerEvents={state.enabled ? [ 'click', 'hover', 'arrows' ] : []}
     >
       <Dropdown.Trigger>
         <div


### PR DESCRIPTION
Related Ticket: TINY-13797

Description of Changes:
* Added arrow key navigation support to dropdown components
* Refactored event prop handling in dropdown content for better organization
* Enabled arrow key navigation for submenu items by adding 'arrows' to triggerEvents array

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdowns support arrow-key navigation: Right Arrow opens from the trigger, Left Arrow closes from the content.
  * Dropdown configuration accepts an "arrows" trigger option to enable this behavior.

* **Improvements**
  * Keyboard interactions are more consistent between triggers and content for smoother navigation and clearer event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->