### PR TITLE
TINY-13606: Fix combining Dropdown and Tooltip would only show the tooltip and not open the dropdown

### DIFF
--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -126,7 +126,9 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
   </div>;
 });
 
-const Trigger: FC<PropsWithChildren> = ({ children }) => {
+interface TriggerInternalProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {}
+
+const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
   const { triggerRef, contentRef, triggerEvents, debouncedHideHoverablePopover, isOpen } = useDropdown();
 
   let child = Children.toArray(children)[0];
@@ -136,41 +138,60 @@ const Trigger: FC<PropsWithChildren> = ({ children }) => {
   child = child as ReactElement;
 
   const onHoverTriggerProps = {
-    onMouseEnter: (e: MouseEvent) => {
-      child.props.onMouseEnter?.(e);
-      debouncedHideHoverablePopover.cancel();
-      contentRef.current?.showPopover();
+    onMouseEnter: (e: MouseEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        child.props.onMouseEnter?.(e);
+        props.onMouseEnter?.(e);
+        debouncedHideHoverablePopover.cancel();
+        contentRef.current?.showPopover();
+      }
     },
-    onMouseLeave: (e: MouseEvent) => {
-      child.props.onMouseLeave?.(e);
-      debouncedHideHoverablePopover.throttle(e);
+    onMouseLeave: (e: MouseEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        child.props.onMouseLeave?.(e);
+        props.onMouseLeave?.(e);
+        debouncedHideHoverablePopover.throttle(e);
+      }
     }
   };
 
   const onClickTriggerProps = {
-    onClick: (e: MouseEvent) => {
-      child.props.onClick?.(e);
-      if (isOpen) {
-        contentRef.current?.hidePopover();
-      } else {
-        contentRef.current?.showPopover();
+    onClick: (e: MouseEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        child.props.onClick?.(e);
+        props.onClick?.(e);
+        if (isOpen) {
+          contentRef.current?.hidePopover();
+        } else {
+          contentRef.current?.showPopover();
+        }
       }
     }
   };
 
   return cloneElement(child, {
+    ...props,
     ref: (el: HTMLElement) => {
       triggerRef.current = el;
-      if (Type.isFunction(child.props.ref )) {
+      if (Type.isFunction(child.props.ref)) {
         child.props.ref(el);
       } else if (Type.isNonNullable(child.props.ref)) {
         child.props.ref.current = el;
+      }
+      if (Type.isFunction(ref)) {
+        ref(el);
+      } else if (Type.isNonNullable(ref)) {
+        ref.current = el;
       }
     },
     ...triggerEvents.includes('click') && onClickTriggerProps,
     ...triggerEvents.includes('hover') && onHoverTriggerProps,
   });
-};
+});
+
+const Trigger: React.ForwardRefExoticComponent<
+  PropsWithChildren & React.RefAttributes<HTMLElement>
+> = TriggerImpl;
 
 export interface DropdownProps extends PropsWithChildren {
   readonly side?: 'top' | 'bottom' | 'left' | 'right';

--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -1,13 +1,13 @@
 import { Fun, Type } from '@ephox/katamari';
 import { Bem } from 'oxide-components/main';
-import { Children, cloneElement, createContext, isValidElement, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState, type FC, type PropsWithChildren, type ReactNode } from 'react';
+import { Children, cloneElement, createContext, forwardRef, isValidElement, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState, type FC, type HTMLAttributes, type PropsWithChildren, type ReactNode } from 'react';
 
 interface TooltipState {
   readonly isOpen: boolean;
   readonly delayForShow: number;
   readonly delayForHide: number;
   readonly setIsOpen: (isOpen: boolean) => void;
-  readonly contentRef: React.RefObject<HTMLDivElement | null>;
+  readonly contentRef: React.MutableRefObject<HTMLDivElement | null>;
   readonly triggerRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
@@ -22,19 +22,10 @@ const defaultState: TooltipState = {
 
 const TooltipContext = createContext<TooltipState>(defaultState);
 
-const Trigger: FC<PropsWithChildren> = ({ children }) => {
+interface TriggerInternalProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {}
+
+const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
   const { setIsOpen, triggerRef } = useContext(TooltipContext);
-
-  const onMouseEnter = useCallback(() => {
-    setIsOpen(true);
-  }, [ setIsOpen ]);
-
-  const onMouseLeave = useCallback(() => {
-    setIsOpen(false);
-  }, [ setIsOpen ]);
-
-  const onFocus = onMouseEnter;
-  const onBlur = onMouseLeave;
 
   const count = Children.count(children);
   if (count === 0) {
@@ -47,8 +38,9 @@ const Trigger: FC<PropsWithChildren> = ({ children }) => {
   }
 
   return cloneElement(theChild, {
+    ...props,
     ref: (el: HTMLDivElement | null) => {
-      // Only forward non-null values to preserve the child's ref during React's cleanup phase
+      // Only forward non-null values to internal refs to preserve state during React's cleanup phase
       if (el !== null) {
         triggerRef.current = el;
         // TODO: Remove this cast weirdness once we migrate to react 19
@@ -59,19 +51,53 @@ const Trigger: FC<PropsWithChildren> = ({ children }) => {
           childWithRef.ref.current = el;
         }
       }
+      // Always forward to the consumer's ref, including null for proper cleanup
+      if (Type.isFunction(ref)) {
+        ref(el);
+      } else if (Type.isNonNullable(ref)) {
+        ref.current = el;
+      }
     },
-    onMouseEnter,
-    onMouseLeave,
-    onFocus,
-    onBlur,
+    onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        theChild.props.onMouseEnter?.(e);
+        props.onMouseEnter?.(e);
+        setIsOpen(true);
+      }
+    },
+    onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        theChild.props.onMouseLeave?.(e);
+        props.onMouseLeave?.(e);
+        setIsOpen(false);
+      }
+    },
+    onFocus: (e: React.FocusEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        theChild.props.onFocus?.(e);
+        props.onFocus?.(e);
+        setIsOpen(true);
+      }
+    },
+    onBlur: (e: React.FocusEvent<HTMLElement>) => {
+      if (!e.isDefaultPrevented()) {
+        theChild.props.onBlur?.(e);
+        props.onBlur?.(e);
+        setIsOpen(false);
+      }
+    },
   });
-};
+});
+
+const Trigger: React.ForwardRefExoticComponent<
+  PropsWithChildren & React.RefAttributes<HTMLElement>
+> = TriggerImpl;
 
 interface ContentProps {
   readonly text: string;
 }
 
-const Content: FC<ContentProps> = ({ text }) => {
+const Content = forwardRef<HTMLDivElement, ContentProps>(({ text }, ref) => {
   const { isOpen, contentRef, triggerRef, delayForShow, delayForHide } = useContext(TooltipContext);
 
   const updatePosition = useCallback(() => {
@@ -117,14 +143,22 @@ const Content: FC<ContentProps> = ({ text }) => {
   }, [ isOpen, contentRef, updatePosition, delayForShow, delayForHide ]);
 
   return (
-    // @ts-expect-error - TODO: Remove this expect error once we've upgraded to React 19+
-    <div ref={contentRef} popover='hint' className={Bem.block('tox-tooltip', {
-      up: true
-    })}>
+    <div ref={(el: HTMLDivElement) => {
+      contentRef.current = el;
+      if (Type.isFunction(ref)) {
+        ref(el);
+      } else if (Type.isNonNullable(ref)) {
+        ref.current = el;
+      }
+    }}
+    // @ts-expect-error We should remove this expect error once we've migrated to React 19 and can use the new popover API types
+    popover='hint'
+    className={Bem.block('tox-tooltip', { up: true })}
+    >
       <div className={Bem.element('tox-tooltip', 'body')}>{text}</div>
     </div>
   );
-};
+});
 
 const Root: FC<PropsWithChildren> = ({ children }) => {
   const [ state, setState ] = useState({

--- a/modules/oxide-components/src/test/ts/browser/components/Dropdown.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Dropdown.spec.tsx
@@ -1,0 +1,188 @@
+import { Button } from 'oxide-components/components/button/Button';
+import * as Dropdown from 'oxide-components/components/dropdown/Dropdown';
+import * as Tooltip from 'oxide-components/components/tooltip/Tooltip';
+import * as Bem from 'oxide-components/utils/Bem';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+
+describe('browser.DropdownTest', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <div className={Bem.block('tox')}>
+        {children}
+      </div>
+    );
+  };
+
+  describe('Ref forwarding', () => {
+    it('Dropdown.Trigger should forward ref to the child element', async () => {
+      const triggerRef = createRef<HTMLElement>();
+
+      render(
+        <Dropdown.Root>
+          <Dropdown.Trigger ref={triggerRef}>
+            <button>Trigger</button>
+          </Dropdown.Trigger>
+          <Dropdown.Content>
+            <div>Content</div>
+          </Dropdown.Content>
+        </Dropdown.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => triggerRef.current).not.toBeNull();
+      expect(triggerRef.current?.tagName).toBe('BUTTON');
+    });
+
+    it('Dropdown.Trigger should forward ref through Tooltip.Trigger to the leaf element', async () => {
+      const dropdownTriggerRef = createRef<HTMLElement>();
+
+      render(
+        <Tooltip.Root>
+          <Dropdown.Root>
+            <Dropdown.Trigger ref={dropdownTriggerRef}>
+              <Tooltip.Trigger>
+                <button>Trigger</button>
+              </Tooltip.Trigger>
+            </Dropdown.Trigger>
+            <Dropdown.Content>
+              <div>Dropdown Content</div>
+            </Dropdown.Content>
+          </Dropdown.Root>
+          <Tooltip.Content text='Tooltip text' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => dropdownTriggerRef.current).not.toBeNull();
+      expect(dropdownTriggerRef.current?.tagName).toBe('BUTTON');
+    });
+
+    it('Dropdown.Trigger should forward ref to the same element as a forwardRef child', async () => {
+      const triggerRef = createRef<HTMLElement>();
+
+      const { getByText } = render(
+        <Dropdown.Root>
+          <Dropdown.Trigger ref={triggerRef}>
+            <Button variant='secondary'>Click me</Button>
+          </Dropdown.Trigger>
+          <Dropdown.Content>
+            <div>Content</div>
+          </Dropdown.Content>
+        </Dropdown.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => triggerRef.current).not.toBeNull();
+      expect(triggerRef.current).toBe(getByText('Click me').element());
+    });
+  });
+
+  describe('Event handler forwarding', () => {
+    it('Dropdown.Trigger should invoke onClick on the child and open the dropdown', async () => {
+      const childOnClick = vi.fn();
+
+      const { getByText } = render(
+        <Dropdown.Root>
+          <Dropdown.Trigger>
+            <button onClick={childOnClick}>Trigger</button>
+          </Dropdown.Trigger>
+          <Dropdown.Content>
+            <div>Dropdown Content</div>
+          </Dropdown.Content>
+        </Dropdown.Root>,
+        { wrapper }
+      );
+
+      await userEvent.click(getByText('Trigger'));
+      expect(childOnClick).toHaveBeenCalledOnce();
+      await expect.poll(() => document.querySelector('[popover]:popover-open'))
+        .toHaveTextContent('Dropdown Content');
+    });
+
+  });
+
+  describe('Dropdown + Tooltip composition', () => {
+    it('Should open dropdown on click when Tooltip.Trigger wraps the child', async () => {
+      const { getByText } = render(
+        <Tooltip.Root>
+          <Dropdown.Root side='bottom' align='start'>
+            <Dropdown.Trigger>
+              <Tooltip.Trigger>
+                <Button variant='secondary'>Trigger</Button>
+              </Tooltip.Trigger>
+            </Dropdown.Trigger>
+            <Dropdown.Content>
+              <div>Dropdown Content</div>
+            </Dropdown.Content>
+          </Dropdown.Root>
+          <Tooltip.Content text='Tooltip text' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await userEvent.click(getByText('Trigger'));
+      await expect.poll(() => document.querySelector('[popover]:popover-open'))
+        .toHaveTextContent('Dropdown Content');
+    });
+
+    it('Should chain all three refs when Dropdown.Trigger wraps Tooltip.Trigger wraps Button', async () => {
+      const outerRef = createRef<HTMLElement>();
+      const buttonRef = createRef<HTMLButtonElement>();
+
+      render(
+        <Tooltip.Root>
+          <Dropdown.Root>
+            <Dropdown.Trigger ref={outerRef}>
+              <Tooltip.Trigger>
+                <Button ref={buttonRef} variant='secondary'>Trigger</Button>
+              </Tooltip.Trigger>
+            </Dropdown.Trigger>
+            <Dropdown.Content>
+              <div>Content</div>
+            </Dropdown.Content>
+          </Dropdown.Root>
+          <Tooltip.Content text='Tip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => outerRef.current).not.toBeNull();
+      expect(outerRef.current).toBe(buttonRef.current);
+      expect(outerRef.current?.textContent).toBe('Trigger');
+    });
+
+    it('Should fire both dropdown click and tooltip mouse handlers on the composed trigger', async () => {
+      const { getByText } = render(
+        <Tooltip.Root>
+          <Dropdown.Root side='bottom' align='start'>
+            <Dropdown.Trigger>
+              <Tooltip.Trigger>
+                <Button variant='secondary'>Trigger</Button>
+              </Tooltip.Trigger>
+            </Dropdown.Trigger>
+            <Dropdown.Content>
+              <div>Dropdown Content</div>
+            </Dropdown.Content>
+          </Dropdown.Root>
+          <Tooltip.Content text='Tooltip text' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      // Hover should open tooltip (after delay)
+      await userEvent.hover(getByText('Trigger'));
+      await expect.poll(
+        () => document.querySelector(Bem.blockSelector('tox-tooltip')),
+        { timeout: 1000 }
+      ).toHaveTextContent('Tooltip text');
+
+      // Click should open dropdown
+      await userEvent.click(getByText('Trigger'));
+      await expect.poll(() => document.querySelector('[popover]:popover-open'))
+        .toHaveTextContent('Dropdown Content');
+    });
+  });
+});

--- a/modules/oxide-components/src/test/ts/browser/components/Tooltip.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Tooltip.spec.tsx
@@ -1,0 +1,75 @@
+import * as Tooltip from 'oxide-components/components/tooltip/Tooltip';
+import * as Bem from 'oxide-components/utils/Bem';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+
+describe('browser.TooltipTest', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <div className={Bem.block('tox')}>
+        {children}
+      </div>
+    );
+  };
+
+  describe('Ref forwarding', () => {
+    it('Tooltip.Trigger should forward ref to the child element', async () => {
+      const triggerRef = createRef<HTMLElement>();
+
+      render(
+        <Tooltip.Root>
+          <Tooltip.Trigger ref={triggerRef}>
+            <button>Hover me</button>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => triggerRef.current).not.toBeNull();
+      expect(triggerRef.current?.tagName).toBe('BUTTON');
+    });
+
+    it('Tooltip.Content should forward ref to the popover element', async () => {
+      const contentRef = createRef<HTMLDivElement>();
+
+      render(
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button>Hover me</button>
+          </Tooltip.Trigger>
+          <Tooltip.Content ref={contentRef} text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => contentRef.current).not.toBeNull();
+      expect(contentRef.current?.tagName).toBe('DIV');
+    });
+  });
+
+  describe('Event handler forwarding', () => {
+    it('Tooltip.Trigger should preserve child mouse event handlers', async () => {
+      const childOnMouseEnter = vi.fn();
+      const childOnMouseLeave = vi.fn();
+
+      const { getByText } = render(
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button onMouseEnter={childOnMouseEnter} onMouseLeave={childOnMouseLeave}>Hover me</button>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await userEvent.hover(getByText('Hover me'));
+      expect(childOnMouseEnter).toHaveBeenCalledOnce();
+
+      await userEvent.unhover(getByText('Hover me'));
+      expect(childOnMouseLeave).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-13606

Description of Changes:
* Enhanced Dropdown.Trigger and Tooltip.Trigger components to use forwardRef for proper ref forwarding
* Added support for HTML attributes and event handler forwarding in both trigger components
* Improved ref chaining to work correctly when components are composed together
* Updated Storybook example to demonstrate Dropdown and Tooltip composition
* Added browser tests covering ref forwarding, event handler preservation, and component composition scenarios

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Dropdown and Tooltip components now forward refs and consumer props through Triggers and Content, improving nested composition and interoperability.
  * Event propagation refined so external mouse, focus, and click handlers are preserved and reliably toggle tooltip/dropdown behavior.
  * Content elements expose DOM refs to consumers for more reliable positioning and integration.

* **Tests**
  * Added browser tests covering ref forwarding, event propagation, nested composition, and combined tooltip+dropdown interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->