### PR TITLE
TINY-13603: Add missed review mode inline styles to oxide

### DIFF
--- a/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
+++ b/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
@@ -9,4 +9,33 @@
     @selected-outline-color,
     @selected-box-shadow
   );
+
+  .tox-ai__scroll {
+    .tox-ai__review-sidebar-container {
+      scrollbar-gutter: stable;
+      width: 100%;
+      height: 100%;
+
+      .tox-ai__review-initializing {
+        padding: var(--tox-private-pad-md, @pad-md);
+      }
+
+      .tox-ai__review-description {
+        padding-bottom: var(--tox-private-pad-sm, @pad-sm);
+        font-size: var(--tox-private-font-size-sm, @font-size-sm);
+      }
+
+      .tox-ai__review-input-container {
+        margin-bottom: 12px;
+
+        .tox-ai__review-input-button {
+          width: 100%;
+          background-color: var(--tox-private-background-color, @background-color);
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Related Ticket: [TINY-13603](https://ephocks.atlassian.net/browse/TINY-13603)

Description of Changes:
* Added some classes to address some inline styles we have at the plugin level.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13603]: https://ephocks.atlassian.net/browse/TINY-13603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual presentation of the AI review interface with refined layout spacing, enhanced typography for better readability, and optimized input area styling for a more polished and intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->