### PR TITLE
TINY-13847: align ai footer note to center

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -323,7 +323,7 @@
     height: 24px;
     justify-content: center;
     letter-spacing: 0px;
-    padding-top: @pad-sm;
+    padding-top: var(--tox-private-pad-sm, @pad-sm);
     width: 100%;
   }
 


### PR DESCRIPTION
Related Ticket: TINY-13847

Description of Changes:
padding left and right were no needed and since they overflow the text was not aligned to center

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted padding in the AI chat footer to refine vertical spacing and visual alignment, improving consistency of footer layout across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->