### PR TITLE
TINY-13726: Change menu item from button to div

### DIFF
--- a/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
@@ -5,7 +5,7 @@ import * as Bem from '../../../utils/Bem';
 import { Icon } from '../../icon/Icon';
 import type { CommonMenuItemInstanceApi, MenuItemProps } from '../internals/Types';
 
-export const Item = forwardRef<HTMLButtonElement, MenuItemProps>(({ enabled = true, onSetup, icon, shortcut, onAction, children }, ref) => {
+export const Item = forwardRef<HTMLDivElement, MenuItemProps>(({ enabled = true, onSetup, icon, shortcut, onAction, children }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     focused: false,
@@ -40,13 +40,12 @@ export const Item = forwardRef<HTMLButtonElement, MenuItemProps>(({ enabled = tr
     : icon;
 
   return (
-    <button
+    <div
       id={id}
       tabIndex={-1}
       role='menuitem'
       aria-haspopup={false}
       aria-disabled={!state.enabled}
-      disabled={!state.enabled}
       onFocus={() => setState({ ...state, focused: true })}
       onPointerMove={(e) => {
         if (state.enabled) {
@@ -65,6 +64,6 @@ export const Item = forwardRef<HTMLButtonElement, MenuItemProps>(({ enabled = tr
       {itemIcon && <div className={Bem.element('tox-collection', 'item-icon')}>{itemIcon}</div>}
       <div className={Bem.element('tox-collection', 'item-label')}>{children}</div>
       {shortcut && <div className={Bem.element('tox-collection', 'item-accessory')}>{shortcut}</div>}
-    </button>
+    </div>
   );
 });

--- a/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
+++ b/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 1. Before open sub
       <div
         class="tox-collection__group"
       >
-        <button
+        <div
           aria-disabled="false"
           aria-haspopup="false"
           class="tox-collection__item tox-collection__item--active"
@@ -25,7 +25,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 1. Before open sub
           >
             Menu item 1
           </div>
-        </button>
+        </div>
         <button
           aria-disabled="false"
           aria-haspopup="false"
@@ -198,7 +198,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
       <div
         class="tox-collection__group"
       >
-        <button
+        <div
           aria-disabled="false"
           aria-haspopup="false"
           class="tox-collection__item"
@@ -211,7 +211,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
           >
             Menu item 1
           </div>
-        </button>
+        </div>
         <button
           aria-disabled="false"
           aria-haspopup="false"
@@ -374,7 +374,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
               <div
                 class="tox-collection__group"
               >
-                <button
+                <div
                   aria-disabled="false"
                   aria-haspopup="false"
                   class="tox-collection__item tox-collection__item--active"
@@ -387,7 +387,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
                   >
                     Nested menu item 1
                   </div>
-                </button>
+                </div>
                 <button
                   aria-disabled="true"
                   aria-haspopup="false"
@@ -482,7 +482,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 1. Bef
       <div
         class="tox-collection__group"
       >
-        <button
+        <div
           aria-disabled="false"
           aria-haspopup="false"
           class="tox-collection__item tox-collection__item--active"
@@ -495,7 +495,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 1. Bef
           >
             Menu item 1
           </div>
-        </button>
+        </div>
         <button
           aria-disabled="false"
           aria-haspopup="false"
@@ -661,7 +661,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
       <div
         class="tox-collection__group"
       >
-        <button
+        <div
           aria-disabled="false"
           aria-haspopup="false"
           class="tox-collection__item"
@@ -674,7 +674,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
           >
             Menu item 1
           </div>
-        </button>
+        </div>
         <button
           aria-disabled="false"
           aria-haspopup="false"
@@ -830,7 +830,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
               <div
                 class="tox-collection__group"
               >
-                <button
+                <div
                   aria-disabled="false"
                   aria-haspopup="false"
                   class="tox-collection__item"
@@ -843,7 +843,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
                   >
                     Nested menu item 1
                   </div>
-                </button>
+                </div>
                 <button
                   aria-disabled="false"
                   aria-haspopup="false"


### PR DESCRIPTION
Related Ticket: TINY-13726

Description of Changes:
* Changed menu Item component from `<button>` to `<div>` element
* Updated forwardRef type from `HTMLButtonElement` to `HTMLDivElement`
* Removed `disabled` attribute as it's not valid on div elements
* Retained `aria-disabled` attribute for accessibility compliance

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched the underlying menu item element while preserving interactive behavior, disabled-state handling, keyboard navigation, focus management, and accessibility attributes. No visible changes to the UI or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->