### PR TITLE
TINY-13726:  Change submenu item and toggle item to div instead of button

### DIFF
--- a/modules/oxide-components/src/main/ts/components/menu/Menu.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.stories.tsx
@@ -194,4 +194,3 @@ export const MenuInADropdown: Story = {
     </>);
   }
 };
-

--- a/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
@@ -53,7 +53,11 @@ export const Item = forwardRef<HTMLDivElement, MenuItemProps>(({ enabled = true,
         }
       }}
       onBlur={() => setState({ ...state, focused: false })}
-      onClick={() => onAction(api)}
+      onClick={() => {
+        if (state.enabled) {
+          onAction(api);
+        }
+      }}
       className={Bem.element('tox-collection', 'item', {
         'active': state.focused,
         'state-disabled': !state.enabled,

--- a/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
@@ -23,7 +23,7 @@ const isMenuItemOutsideContainer = (relatedTarget: Element | null, container: El
   });
 };
 
-export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ enabled = true, icon, onSetup, children, submenusSide = 'right', submenuContent }, ref) => {
+export const SubmenuItem = forwardRef<HTMLDivElement, SubmenuProps>(({ enabled = true, icon, onSetup, children, submenusSide = 'right', submenuContent }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     focused: false,
@@ -56,6 +56,14 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ enable
     return Fun.noop;
   }, [ onSetup, api ]);
 
+  const submenuContentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!state.enabled) {
+      submenuContentRef.current?.hidePopover();
+    }
+  }, [ state.enabled ]);
+
   const itemIcon = Type.isString(icon)
     ? <Icon icon={icon} />
     : icon;
@@ -71,10 +79,10 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ enable
     <Dropdown.Root
       side={submenusSide}
       align={'start'}
-      triggerEvents={[ 'click', 'hover' ]}
+      triggerEvents={state.enabled ? [ 'click', 'hover' ] : []}
     >
       <Dropdown.Trigger>
-        <button
+        <div
           id={id}
           ref={ref}
           style={{ boxSizing: 'border-box', width: '100%' }}
@@ -82,7 +90,6 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ enable
           role='menuitem'
           aria-haspopup={'true'}
           aria-disabled={!state.enabled}
-          disabled={!state.enabled}
           onFocus={() => setState((prev) => ({ ...prev, focused: true, focusMovedToOtherMenuItem: false }))}
           onPointerMove={(e) => {
             if (state.enabled) {
@@ -107,9 +114,9 @@ export const SubmenuItem = forwardRef<HTMLButtonElement, SubmenuProps>(({ enable
           <div className={Bem.element('tox-collection', 'item-caret')}>
             <Icon icon={'chevron-right'} />
           </div>
-        </button>
+        </div>
       </Dropdown.Trigger>
-      <Dropdown.Content onOpenChange={handleOpenChange}>
+      <Dropdown.Content ref={submenuContentRef} onOpenChange={handleOpenChange}>
         <div
           onBlur={(e) => {
             const relatedTarget = e.relatedTarget;

--- a/modules/oxide-components/src/main/ts/components/menu/components/ToggleItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/ToggleItem.tsx
@@ -5,7 +5,7 @@ import * as Bem from '../../../utils/Bem';
 import { Icon } from '../../icon/Icon';
 import type { ToggleMenuItemInstanceApi, ToggleMenuItemProps } from '../internals/Types';
 
-export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ enabled = true, onSetup, icon, active = false, shortcut, onAction, children }, ref) => {
+export const ToggleItem = forwardRef<HTMLDivElement, ToggleMenuItemProps>(({ enabled = true, onSetup, icon, active = false, shortcut, onAction, children }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     active,
@@ -46,14 +46,13 @@ export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ 
     : icon;
 
   return (
-    <button
+    <div
       id={id}
       tabIndex={-1}
       role='menuitemcheckbox'
       aria-haspopup={false}
       aria-disabled={!state.enabled}
-      disabled={!state.enabled}
-      aria-selected={state.active}
+      aria-checked={state.active}
       onFocus={() => setState({ ...state, focused: true })}
       onPointerMove={(e) => {
         if (state.enabled) {
@@ -61,7 +60,11 @@ export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ 
         }
       }}
       onBlur={() => setState({ ...state, focused: false })}
-      onClick={() => onAction(api)}
+      onClick={() => {
+        if (state.enabled) {
+          onAction(api);
+        }
+      }}
       className={Bem.element('tox-collection', 'item', {
         'enabled': state.active,
         'active': state.focused,
@@ -76,6 +79,6 @@ export const ToggleItem = forwardRef<HTMLButtonElement, ToggleMenuItemProps>(({ 
       <div className={Bem.element('tox-collection', 'item-checkmark')} >
         <Icon icon={'checkmark'} />
       </div>
-    </button>
+    </div>
   );
 });

--- a/modules/oxide-components/src/test/ts/browser/components/MenuItem.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/MenuItem.spec.tsx
@@ -110,4 +110,76 @@ describe('browser.MenuItemTest', () => {
       expect(apiRef.isEnabled()).toBe(true);
     }
   });
+
+  it('Should render with aria-disabled and disabled class when enabled={false}', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.Item enabled={false} onAction={vi.fn()}>Disabled Item</Menu.Item>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Disabled Item');
+
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+    expect(item.className).toContain('tox-collection__item--state-disabled');
+  });
+
+  it('Should not trigger onAction when clicked while disabled', async () => {
+    const onActionSpy = vi.fn();
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.Item enabled={false} onAction={onActionSpy}>Disabled Item</Menu.Item>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Disabled Item');
+
+    await userEvent.click(getByText('Disabled Item'));
+    expect(onActionSpy).not.toHaveBeenCalled();
+  });
+
+  it('Should not trigger onAction when disabled via API', async () => {
+    let apiRef: CommonMenuItemInstanceApi | undefined;
+    const onActionSpy = vi.fn();
+    const onSetupSpy = vi.fn((api: CommonMenuItemInstanceApi) => {
+      apiRef = api;
+      return vi.fn();
+    });
+
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.Item onSetup={onSetupSpy} onAction={onActionSpy}>Test Item</Menu.Item>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Test Item');
+
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+
+    expect(apiRef).toBeDefined();
+    if (apiRef) {
+      apiRef.setEnabled(false);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('true');
+
+      await userEvent.click(getByText('Test Item'));
+      expect(onActionSpy).not.toHaveBeenCalled();
+    }
+  });
 });

--- a/modules/oxide-components/src/test/ts/browser/components/MenuToggleItem.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/MenuToggleItem.spec.tsx
@@ -70,13 +70,13 @@ describe('browser.MenuToggleItemTest', () => {
 
     const item = container.querySelector('[role="menuitemcheckbox"]') as HTMLElement;
 
-    expect(item.getAttribute('aria-selected')).toBe('false');
+    expect(item.getAttribute('aria-checked')).toBe('false');
 
     await userEvent.click(item);
-    await expect.poll(() => item.getAttribute('aria-selected')).toBe('true');
+    await expect.poll(() => item.getAttribute('aria-checked')).toBe('true');
 
     await userEvent.click(item);
-    await expect.poll(() => item.getAttribute('aria-selected')).toBe('false');
+    await expect.poll(() => item.getAttribute('aria-checked')).toBe('false');
   });
 
   it('Should respect initial active state', async () => {
@@ -95,7 +95,7 @@ describe('browser.MenuToggleItemTest', () => {
 
     const item = container.querySelector('[role="menuitemcheckbox"]') as HTMLElement;
 
-    expect(item.getAttribute('aria-selected')).toBe('true');
+    expect(item.getAttribute('aria-checked')).toBe('true');
     expect(item.className).toContain('tox-collection__item--enabled');
   });
 
@@ -124,11 +124,122 @@ describe('browser.MenuToggleItemTest', () => {
     expect(apiRef).toBeDefined();
     if (apiRef) {
       expect(apiRef.isActive()).toBe(false);
-      expect(item.getAttribute('aria-selected')).toBe('false');
+      expect(item.getAttribute('aria-checked')).toBe('false');
 
       apiRef.setActive(true);
-      await expect.poll(() => item.getAttribute('aria-selected')).toBe('true');
+      await expect.poll(() => item.getAttribute('aria-checked')).toBe('true');
       expect(apiRef.isActive()).toBe(true);
+    }
+  });
+
+  it('Should render with aria-disabled and disabled class when enabled={false}', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.ToggleItem enabled={false} onAction={vi.fn()}>Disabled Toggle</Menu.ToggleItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Disabled Toggle');
+
+    const item = container.querySelector('[role="menuitemcheckbox"]') as HTMLElement;
+
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+    expect(item.className).toContain('tox-collection__item--state-disabled');
+  });
+
+  it('Should not trigger onAction when clicked while disabled', async () => {
+    const onActionSpy = vi.fn();
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.ToggleItem enabled={false} onAction={onActionSpy}>Disabled Toggle</Menu.ToggleItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Disabled Toggle');
+
+    await userEvent.click(getByText('Disabled Toggle'));
+    expect(onActionSpy).not.toHaveBeenCalled();
+  });
+
+  it('Should not trigger onAction when disabled via API', async () => {
+    let apiRef: ToggleMenuItemInstanceApi | undefined;
+    const onActionSpy = vi.fn();
+    const onSetupSpy = vi.fn((api: ToggleMenuItemInstanceApi) => {
+      apiRef = api;
+      return vi.fn();
+    });
+
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.ToggleItem onSetup={onSetupSpy} onAction={onActionSpy}>Toggle Item</Menu.ToggleItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Toggle Item');
+
+    const item = container.querySelector('[role="menuitemcheckbox"]') as HTMLElement;
+
+    expect(apiRef).toBeDefined();
+    if (apiRef) {
+      apiRef.setEnabled(false);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('true');
+
+      await userEvent.click(getByText('Toggle Item'));
+      expect(onActionSpy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('Should update enabled state via API', async () => {
+    let apiRef: ToggleMenuItemInstanceApi | undefined;
+    const onSetupSpy = vi.fn((api: ToggleMenuItemInstanceApi) => {
+      apiRef = api;
+      return vi.fn();
+    });
+
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.ToggleItem onSetup={onSetupSpy} onAction={vi.fn()}>Toggle Item</Menu.ToggleItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Toggle Item');
+
+    const item = container.querySelector('[role="menuitemcheckbox"]') as HTMLElement;
+
+    expect(item.getAttribute('aria-disabled')).toBe('false');
+    expect(apiRef).toBeDefined();
+
+    if (apiRef) {
+      expect(apiRef.isEnabled()).toBe(true);
+
+      apiRef.setEnabled(false);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('true');
+      expect(apiRef.isEnabled()).toBe(false);
+      expect(item.className).toContain('tox-collection__item--state-disabled');
+
+      apiRef.setEnabled(true);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('false');
+      expect(apiRef.isEnabled()).toBe(true);
     }
   });
 
@@ -151,16 +262,15 @@ describe('browser.MenuToggleItemTest', () => {
     const toggle1 = menuItems[0] as HTMLElement;
     const toggle2 = menuItems[1] as HTMLElement;
 
-    expect(toggle1.getAttribute('aria-selected')).toBe('false');
-    expect(toggle2.getAttribute('aria-selected')).toBe('false');
+    expect(toggle1.getAttribute('aria-checked')).toBe('false');
+    expect(toggle2.getAttribute('aria-checked')).toBe('false');
 
     await userEvent.click(toggle1);
-    await expect.poll(() => toggle1.getAttribute('aria-selected')).toBe('true');
-    expect(toggle2.getAttribute('aria-selected')).toBe('false');
+    await expect.poll(() => toggle1.getAttribute('aria-checked')).toBe('true');
+    expect(toggle2.getAttribute('aria-checked')).toBe('false');
 
     await userEvent.click(toggle2);
-    await expect.poll(() => toggle2.getAttribute('aria-selected')).toBe('true');
-    expect(toggle1.getAttribute('aria-selected')).toBe('true');
+    await expect.poll(() => toggle2.getAttribute('aria-checked')).toBe('true');
+    expect(toggle1.getAttribute('aria-checked')).toBe('true');
   });
 });
-

--- a/modules/oxide-components/src/test/ts/browser/components/SubmenuItem.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/SubmenuItem.spec.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+import type { CommonMenuItemInstanceApi } from 'oxide-components/components/menu/internals/Types';
 import * as Menu from 'oxide-components/components/menu/Menu';
 import { UniverseProvider } from 'oxide-components/contexts/UniverseContext/UniverseProvider';
 import * as Bem from 'oxide-components/utils/Bem';
@@ -119,7 +120,7 @@ describe('browser.SubmenuItemTest', () => {
     expect(getByText('Deeply Nested Item').element()).toBeVisible();
   });
 
-  it('Should not open submenu when disabled', async () => {
+  it('Should not open submenu on hover when disabled', async () => {
     const TestComponent = () => {
       return (
         <UniverseProvider resources={mockUniverse}>
@@ -147,5 +148,155 @@ describe('browser.SubmenuItemTest', () => {
     await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(getByText('Nested Item').query()).toBeNull();
+  });
+
+  it('Should not open submenu on click when disabled', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.SubmenuItem
+              enabled={false}
+              submenuContent={
+                <Menu.Root>
+                  <Menu.Item onAction={vi.fn()}>Nested Item</Menu.Item>
+                </Menu.Root>
+              }
+            >
+              Submenu
+            </Menu.SubmenuItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Submenu');
+
+    await userEvent.click(getByText('Submenu'));
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(getByText('Nested Item').query()).toBeNull();
+  });
+
+  it('Should render with aria-disabled and disabled class when enabled={false}', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.SubmenuItem
+              enabled={false}
+              submenuContent={
+                <Menu.Root>
+                  <Menu.Item onAction={vi.fn()}>Nested Item</Menu.Item>
+                </Menu.Root>
+              }
+            >
+              Disabled Submenu
+            </Menu.SubmenuItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Disabled Submenu');
+
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+    expect(item.className).toContain('tox-collection__item--state-disabled');
+  });
+
+  it('Should update enabled state via API', async () => {
+    let apiRef: CommonMenuItemInstanceApi | undefined;
+    const onSetupSpy = vi.fn((api: CommonMenuItemInstanceApi) => {
+      apiRef = api;
+      return vi.fn();
+    });
+
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.SubmenuItem
+              onSetup={onSetupSpy}
+              submenuContent={
+                <Menu.Root>
+                  <Menu.Item onAction={vi.fn()}>Nested Item</Menu.Item>
+                </Menu.Root>
+              }
+            >
+              Submenu
+            </Menu.SubmenuItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Submenu');
+
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+
+    expect(item.getAttribute('aria-disabled')).toBe('false');
+    expect(apiRef).toBeDefined();
+
+    if (apiRef) {
+      expect(apiRef.isEnabled()).toBe(true);
+
+      apiRef.setEnabled(false);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('true');
+      expect(apiRef.isEnabled()).toBe(false);
+      expect(item.className).toContain('tox-collection__item--state-disabled');
+
+      apiRef.setEnabled(true);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('false');
+      expect(apiRef.isEnabled()).toBe(true);
+    }
+  });
+
+  it('Should not open submenu on hover after being disabled via API', async () => {
+    let apiRef: CommonMenuItemInstanceApi | undefined;
+    const onSetupSpy = vi.fn((api: CommonMenuItemInstanceApi) => {
+      apiRef = api;
+      return vi.fn();
+    });
+
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.SubmenuItem
+              onSetup={onSetupSpy}
+              submenuContent={
+                <Menu.Root>
+                  <Menu.Item onAction={vi.fn()}>Nested Item</Menu.Item>
+                </Menu.Root>
+              }
+            >
+              Submenu
+            </Menu.SubmenuItem>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText, container } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Submenu');
+
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+
+    expect(apiRef).toBeDefined();
+    if (apiRef) {
+      apiRef.setEnabled(false);
+      await expect.poll(() => item.getAttribute('aria-disabled')).toBe('true');
+
+      await userEvent.hover(getByText('Submenu'));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(getByText('Nested Item').query()).toBeNull();
+    }
   });
 });

--- a/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
+++ b/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
@@ -26,10 +26,10 @@ exports[`browser.MenuTest > Should be able to open submenus > 1. Before open sub
             Menu item 1
           </div>
         </div>
-        <button
+        <div
+          aria-checked="false"
           aria-disabled="false"
           aria-haspopup="false"
-          aria-selected="false"
           class="tox-collection__item"
           id=":r1:"
           role="menuitemcheckbox"
@@ -96,8 +96,8 @@ exports[`browser.MenuTest > Should be able to open submenus > 1. Before open sub
               </svg>
             </span>
           </div>
-        </button>
-        <button
+        </div>
+        <div
           aria-disabled="false"
           aria-haspopup="true"
           class="tox-collection__item"
@@ -174,7 +174,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 1. Before open sub
               </svg>
             </span>
           </div>
-        </button>
+        </div>
         <div
           class="tox-dropdown-content"
           popover="auto"
@@ -212,10 +212,10 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
             Menu item 1
           </div>
         </div>
-        <button
+        <div
+          aria-checked="false"
           aria-disabled="false"
           aria-haspopup="false"
-          aria-selected="false"
           class="tox-collection__item"
           id=":r1:"
           role="menuitemcheckbox"
@@ -282,8 +282,8 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
               </svg>
             </span>
           </div>
-        </button>
-        <button
+        </div>
+        <div
           aria-disabled="false"
           aria-haspopup="true"
           class="tox-collection__item tox-collection__item--active"
@@ -360,7 +360,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
               </svg>
             </span>
           </div>
-        </button>
+        </div>
         <div
           class="tox-dropdown-content"
           popover="auto"
@@ -388,12 +388,11 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
                     Nested menu item 1
                   </div>
                 </div>
-                <button
+                <div
+                  aria-checked="false"
                   aria-disabled="true"
                   aria-haspopup="false"
-                  aria-selected="false"
                   class="tox-collection__item tox-collection__item--state-disabled"
-                  disabled=""
                   id=":r4:"
                   role="menuitemcheckbox"
                   tabindex="-1"
@@ -459,7 +458,7 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
                       </svg>
                     </span>
                   </div>
-                </button>
+                </div>
               </div>
             </div>
           </div>
@@ -496,10 +495,10 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 1. Bef
             Menu item 1
           </div>
         </div>
-        <button
+        <div
+          aria-checked="false"
           aria-disabled="false"
           aria-haspopup="false"
-          aria-selected="false"
           class="tox-collection__item"
           id=":r6:"
           role="menuitemcheckbox"
@@ -566,8 +565,8 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 1. Bef
               </svg>
             </span>
           </div>
-        </button>
-        <button
+        </div>
+        <div
           aria-disabled="false"
           aria-haspopup="true"
           class="tox-collection__item"
@@ -637,7 +636,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 1. Bef
               </svg>
             </span>
           </div>
-        </button>
+        </div>
         <div
           class="tox-dropdown-content"
           popover="auto"
@@ -675,10 +674,10 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
             Menu item 1
           </div>
         </div>
-        <button
+        <div
+          aria-checked="false"
           aria-disabled="false"
           aria-haspopup="false"
-          aria-selected="false"
           class="tox-collection__item"
           id=":r6:"
           role="menuitemcheckbox"
@@ -745,8 +744,8 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
               </svg>
             </span>
           </div>
-        </button>
-        <button
+        </div>
+        <div
           aria-disabled="false"
           aria-haspopup="true"
           class="tox-collection__item tox-collection__item--active"
@@ -816,7 +815,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
               </svg>
             </span>
           </div>
-        </button>
+        </div>
         <div
           class="tox-dropdown-content"
           popover="auto"
@@ -844,10 +843,10 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
                     Nested menu item 1
                   </div>
                 </div>
-                <button
+                <div
+                  aria-checked="false"
                   aria-disabled="false"
                   aria-haspopup="false"
-                  aria-selected="false"
                   class="tox-collection__item"
                   id=":r9:"
                   role="menuitemcheckbox"
@@ -914,7 +913,7 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
                       </svg>
                     </span>
                   </div>
-                </button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Related Ticket: TINY-13726

Description of Changes:
* Changed SubmenuItem and ToggleItem components from `<button>` elements to `<div>` elements
* Updated TypeScript ref types from `HTMLButtonElement` to `HTMLDivElement` for both components
* Removed `disabled` attribute from both components (keeping `aria-disabled` for accessibility)
* Updated test snapshots to reflect the HTML element changes

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu items (including toggle and submenu triggers) now use non-button root elements while preserving aria-disabled for accessibility and focus behavior.
* **Bug Fixes**
  * Disabled items no longer invoke actions or open submenus; submenus hide when an item is disabled and trigger behavior respects enabled state.
* **Tests**
  * Added browser tests covering aria-disabled, disabled styling, API-driven enable/disable, and interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->