### PR TITLE
TINY-13730: add color underline to highlighted annotation

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13730-2026-03-05.yaml
+++ b/.changes/unreleased/tinymce-TINY-13730-2026-03-05.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Improved visual styling of inline diff highlights in Suggested Edits plugin.
+time: 2026-03-05T13:48:35.026001+01:00
+custom:
+    Issue: TINY-13730

--- a/modules/oxide/src/less/theme/content/diff/diff.less
+++ b/modules/oxide/src/less/theme/content/diff/diff.less
@@ -22,7 +22,7 @@
 
   .tox-@{pluginName}__annotation--added__highlight {
     background-color: @added-bg;
-    text-decoration: underline;
+    box-shadow: 0 -2px 0 0 @color-success inset;
   }
 
   .tox-@{pluginName}__annotation--added__selected {
@@ -45,6 +45,7 @@
   .tox-@{pluginName}__annotation--removed__highlight {
     background-color: @removed-bg;
     text-decoration: line-through;
+    box-shadow: 0 -2px 0 0 @color-error inset;
   }
 
   .tox-@{pluginName}__annotation--removed__selected {


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Replace underline text decoration with colored box-shadow for added diff annotations
- Add colored box-shadow to removed diff annotations while preserving line-through decoration

Pre-checks:

- [x] Changelog entry added
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual styling of inline diff/annotation highlights: additions now use inset shadow emphasis (replacing underline) and removals gain an error-colored inset shadow alongside their background to improve contrast and clarity in Suggested Edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->