### PR TITLE
TINY-13942: Add suffix to preview highlight styles

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -55,8 +55,8 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
 }
 
 .tox-tinymceai__preview-body--show-preview {
-  .tox-tinymceai__annotation--added__preview-highlight,
-  .tox-tinymceai__annotation--modified__preview-highlight {
+  .tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
+  .tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
     border-bottom: 2px solid @color-tint;
     cursor: pointer;
   }
@@ -71,8 +71,8 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
   }
 
   img, video, iframe {
-    &.tox-tinymceai__annotation--added__preview-highlight,
-    &.tox-tinymceai__annotation--modified__preview-highlight {
+    &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
+    &.tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
       outline: 0.25em solid fade(@color-tint, 20%);
       padding: 0.25em;
     }
@@ -85,4 +85,3 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
     }
   }
 }
-


### PR DESCRIPTION
Related Ticket: TINY-13942

Description of Changes:
* Adds suffix to preview highlight styles for the new `__preview-highlight` annotation classes (only for ai preview)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined visual styling for AI-generated content previews: preview highlights now behave more consistently and only apply when explicitly highlighted.
  * Improved highlight behavior for embedded media (images, video, iframes) so annotations display correctly in media previews.
  * Adjusted spacing for selected annotations for a cleaner, tighter appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->