### PR TITLE
TINY-13809 TINY-13922: Add gap between chat history list items. Fix focus styles to only show on keyboard navigation

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat-html-content.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat-html-content.less
@@ -28,7 +28,7 @@
     line-height: var(--tox-private-line-height-base, @line-height-base);
     overflow-x: auto;
 
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        outline: 2px solid var(--tox-private-color-tint, @color-tint);
        outline-offset: var(--tox-private-tinymceai-html-content-border-width, @tinymceai-html-content-border-width);
        box-shadow: 0 0 0 1px var(--tox-private-color-white, @color-white);

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -11,7 +11,7 @@
 .tox .tox-ai {
 
   .tox-expandable-box {
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        outline: 2px solid var(--tox-private-color-tint, @color-tint);
        outline-offset: var(--tox-private-tinymceai-border-width, @tinymceai-border-width);
        box-shadow: 0 0 0 1px var(--tox-private-color-white, @color-white);
@@ -23,7 +23,7 @@
     border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-background-color, @background-color);
     padding: calc(var(--tox-private-pad-sm, @pad-sm) - var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width)) calc(12px - var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width));
 
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-color-tint, @color-tint);
        border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     }
@@ -36,7 +36,7 @@
     white-space: nowrap;
     margin-right: auto;
 
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        outline: 2px solid var(--tox-private-color-tint, @color-tint);
        outline-offset: var(--tox-private-tinymceai-border-width, @tinymceai-border-width);
        box-shadow: 0 0 0 1px var(--tox-private-color-white, @color-white);
@@ -89,7 +89,7 @@
     align-self: flex-end;
     color: var(--tox-private-text-color, @text-color);
 
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        outline: 2px solid var(--tox-private-color-tint, @color-tint);
        outline-offset: var(--tox-private-tinymceai-border-width, @tinymceai-border-width);
        box-shadow: 0 0 0 1px var(--tox-private-color-white, @color-white);
@@ -110,7 +110,7 @@
     align-self: stretch;
     border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-background-color, @background-color);
 
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-color-tint, @color-tint);
        border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     }
@@ -277,7 +277,7 @@
     border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-background-color, @background-color);
     border-top: 1px solid var(--tox-private-neutral-20, darken(@background-color, 11%));
 
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
        border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-color-tint, @color-tint);
        border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     }
@@ -392,7 +392,7 @@
   .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
     .tox-ai__models-menu__item__description__content {
       .tox-ai__models-menu__item__description__ability {
-        color: inherit;
+        color: var(--tox-private-color-white, @color-white);
       }
       .tox-ai__models-menu__item__description__content_body {
         color: rgba(from var(--tox-private-color-white, @color-white) r g b / 0.7);
@@ -420,6 +420,10 @@
     gap: var(--tox-private-pad-sm, @pad-sm);
     padding-top: var(--tox-private-pad-xs, @pad-xs);
     width: 100%;
+
+    .tox-collection__group {
+      gap: var(--tox-private-pad-sm, @pad-sm);
+    }
   }
 
   .tox-ai-chat-history-list__title {
@@ -438,7 +442,7 @@
     border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     cursor: pointer;
 
-    &:hover, &:focus {
+    &:hover, &:focus-visible {
       background-color: var(--tox-private-background-secondary, darken(@background-color, 6%));
     }
     &.tox-ai-chat-history-list__item-edit-title {


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Replace `:focus` pseudo-class with `:focus-visible` for AI chat components to improve keyboard navigation accessibility
* Update color inheritance for active model menu item descriptions to use explicit white color
* Add gap styling to collection groups in AI chat history list
* Change focus styling for chat history list items from `:focus` to `:focus-visible`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced keyboard focus indicators for improved navigation visibility
  * Refined visual styling with improved spacing in the AI chat interface
  * Updated component colors for enhanced consistency and appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->