### PR TITLE
TINY-13980: fix `description__ability` color

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -391,6 +391,7 @@
 
   .tox-collection__item--active:not(.tox-collection__item--state-disabled) {
     .tox-ai__models-menu__item__description__content {
+      color: inherit;
       .tox-ai__models-menu__item__description__ability {
         color: inherit;
       }


### PR DESCRIPTION
Related Ticket: TINY-13980

Description of Changes:
the problem was that the `color` got overwritten by `.tox-ai__models-menu__item__description__content` so I added `color: inherit;` for `active` status, I'm not sure is the best solution

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling in AI chat models menu item descriptions to inherit color properties instead of using a muted color variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->