### PR TITLE
TINY-13808: Fix styles of focused chat history item

### DIFF
--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -209,6 +209,16 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
       } else if (Type.isNonNullable(child.props.ref)) {
         child.props.ref.current = el;
       }
+      // TODO: This needs to changes once we upgrade to react 19
+      // @ts-expect-error This is needed because preact sets the ref on the child object not on its props
+      if (Type.isFunction(child.ref)) {
+        // @ts-expect-error This is needed because preact sets the ref on the child object not on its props
+        child.ref(el);
+        // @ts-expect-error This is needed because preact sets the ref on the child object not on its props
+      } else if (Type.isNonNullable(child.ref)) {
+        // @ts-expect-error This is needed because preact sets the ref on the child object not on its props
+        child.ref.current = el;
+      }
       if (Type.isFunction(ref)) {
         ref(el);
       } else if (Type.isNonNullable(ref)) {

--- a/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
@@ -1,6 +1,6 @@
-import { Optional } from '@ephox/katamari';
+import { Optional, Type } from '@ephox/katamari';
 import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
-import { useEffect, useRef, type FC, type PropsWithChildren } from 'react';
+import { forwardRef, useEffect, useRef, type MutableRefObject, type PropsWithChildren } from 'react';
 
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
 import * as Bem from '../../utils/Bem';
@@ -16,32 +16,44 @@ const focusFirstEnabledMenuItem = (container: Element | null): void =>
     SelectorFind.descendant<HTMLElement>(SugarElement.fromDom(element), ENABLED_ITEM_SELECTOR).each(Focus.focus)
   );
 
-const Root: FC<PropsWithChildren> = ({ children }) => {
-  const ref = useRef<HTMLDivElement>(null);
+const Root = forwardRef<HTMLDivElement, PropsWithChildren<unknown>>(({ children }, ref) => {
+
+  const internalRef: MutableRefObject<HTMLDivElement | null> = useRef<HTMLDivElement>(null);
 
   KeyboardNavigationHooks.useFlowKeyNavigation({
-    containerRef: ref,
+    containerRef: internalRef,
     selector: ENABLED_ITEM_SELECTOR,
     allowHorizontal: false,
     cycles: false
   });
 
   useEffect(() => {
-    focusFirstEnabledMenuItem(ref.current);
+    focusFirstEnabledMenuItem(internalRef.current);
   }, []);
 
+  const refCb = (element: HTMLDivElement | null) => {
+    internalRef.current = element;
+    if (Type.isNonNullable(ref)) {
+      if (Type.isFunction(ref)) {
+        ref(element);
+      } else {
+        ref.current = element;
+      }
+    }
+  };
+
   return (
-    <div ref={ref} role='menu' className={[ Bem.block('tox-menu'), Bem.block('tox-collection', { list: true }) ].join(' ')}>
+    <div ref={refCb} role='menu' className={[ Bem.block('tox-menu'), Bem.block('tox-collection', { list: true }) ].join(' ')}>
       <div className={Bem.element('tox-collection', 'group')}>
         {children}
       </div>
     </div>
   );
-};
+});
 
 export {
-  Root,
   Item,
+  Root,
   SubmenuItem,
   ToggleItem
 };

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -459,7 +459,10 @@
     border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     cursor: pointer;
 
-    &:hover, &:focus-visible {
+    &.tox-ai-chat-history-list__item--active {
+      background-color: var(--tox-private-background-secondary, darken(@background-color, 6%));
+    }
+    &:focus, &:focus-visible {
       background-color: var(--tox-private-background-secondary, darken(@background-color, 6%));
     }
     &.tox-ai-chat-history-list__item-edit-title {


### PR DESCRIPTION
Related Ticket: TINY-13808

Description of Changes:
* Added Preact compatibility for ref handling in Dropdown component with TODO note for React 19 upgrade
* Converted Menu Root component from functional component to forwardRef to properly handle ref forwarding
* Added ref callback function in Menu component to manage both internal and external refs
* Updated AI chat history list item styling to include active state and changed hover to focus state

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menu component now supports React ref forwarding, allowing direct access to the DOM element.

* **Bug Fixes**
  * Improved ref handling in dropdown components to properly forward refs to nested child elements.

* **Style**
  * Updated AI chat history list item styling with enhanced active state display for better visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->