### PR TITLE
TINY-13696: Fix accordion expanded header padding and button border-radius

### DIFF
--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -58,9 +58,6 @@
       background-color: var(--tox-private-accordion-item-background-color, @accordion-item-background-color);
       border: 1px solid var(--tox-private-border-color, @accordion-border-color);
 
-      .tox-accordion__header {
-        padding-bottom: @pad-xs;
-      }
       
       .tox-accordion__content--expanded .tox-accordion__content-inner {
         padding-top: @pad-xs;
@@ -239,6 +236,7 @@
     }
 
     .tox-accordion__model-button {
+      border-radius: @accordion-border-radius;
       align-items: center;
       appearance: none;
       background: none;


### PR DESCRIPTION
Related Ticket: TINY-13696

Description of Changes:
* Remove expanded accordion header `padding-bottom: @pad-xs` override that was causing incorrect spacing
* Add `border-radius: @accordion-border-radius` to `.tox-accordion__model-button`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing in expanded accordion headers.
  * Added rounded corners to accordion buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->