### PR TITLE
TINY-13929: Increase accordion content inner bottom padding

### DIFF
--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -217,7 +217,7 @@
   }
 
   .tox-accordion__content-inner {
-    padding: @accordion-content-padding-y @accordion-content-padding-x;
+    padding: @accordion-content-padding-y @accordion-content-padding-x (@pad-sm + @pad-xs);
 
     .tox-form__group {
       &:last-child {


### PR DESCRIPTION
Related Ticket: TINY-13929

Description of Changes:
* Increase the bottom padding of `.tox-accordion__content-inner` from `8px` to `12px` (`8px + 4px`) for better visual spacing between content and the accordion border

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted accordion component padding to improve visual spacing and content presentation within accordion sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->