### PR TITLE
TINY-13931: Remove border from expanded accordion

### DIFF
--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -56,7 +56,6 @@
 
     &.tox-accordion__item--expanded {
       background-color: var(--tox-private-accordion-item-background-color, @accordion-item-background-color);
-      border: 1px solid var(--tox-private-border-color, @accordion-border-color);
 
       .tox-accordion__header {
         padding-bottom: @pad-xs;


### PR DESCRIPTION
Related Ticket: TINY-13931

Description of Changes:
* Remove the `1px solid` border that was applied to `.tox-accordion__item--expanded`, so the expanded state no longer has a visible border outline

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed border styling from expanded accordion items for a cleaner visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->