### PR TITLE
TINY-13934: Update card border for has-decision unselected state

### DIFF
--- a/modules/oxide/src/less/theme/components/card/card.less
+++ b/modules/oxide/src/less/theme/components/card/card.less
@@ -48,6 +48,7 @@
       background-color: darken(@background-color, 6%);
 
       &:not(.tox-card--selected) {
+        border-width: 1px;
         border-color: @text-color-muted;
       }
 


### PR DESCRIPTION
Related Ticket: TINY-13934

Description of Changes:
* Reduce the `border-width` of unselected `--has-decision` cards from the default `2px` to `1px`
* Set `border-color` to `@text-color-muted` for the unselected `--has-decision` state
* This matches the design spec: expanded card with decision should have `1px solid` border in `@text-color-muted`

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed card component border rendering to ensure borders display correctly when cards have decision indicators and are not in selected states. This improves visual consistency and provides clearer visual feedback, enhancing component usability and interface clarity for a better overall user experience when working with cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->