### PR TITLE
TINY-13935: Add card header font-size in has-decision state

### DIFF
--- a/modules/oxide/src/less/theme/components/card/card.less
+++ b/modules/oxide/src/less/theme/components/card/card.less
@@ -51,6 +51,10 @@
         border-color: @text-color-muted;
       }
 
+      .tox-card__header {
+        font-size: @font-size-xs;
+      }
+
       .tox-card__body {
         color: @text-color-muted;
       }


### PR DESCRIPTION
Related Ticket: TINY-13935

Description of Changes:
* Add `font-size: @font-size-xs` to `.tox-card__header` within `--has-decision` cards
* This reduces the header text size in decision cards to match the design

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated card header text sizing in a specific variant state for improved visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->