### PR TITLE
TINY-13956: Fix floating sidebar background color

### DIFF
--- a/modules/oxide/src/less/theme/components/floating-sidebar/floating-sidebar.less
+++ b/modules/oxide/src/less/theme/components/floating-sidebar/floating-sidebar.less
@@ -1,5 +1,6 @@
 .tox-floating-sidebar when (@custom-properties-enabled = true) {
   --tox-private-floating-sidebar-box-shadow: 0 0 40px 1px hsl( from var(--tox-private-color-black) h s l / 15%), 0 16px 16px -10px hsl( from var(--tox-private-color-black) h s l / 15%);
+  --tox-private-floating-sidebar-background-color: light-dark(hsl( from var(--tox-private-background-color) h s calc(l - 6)), hsl( from var(--tox-private-background-color) h s calc(l + 10)));
 }
 
 .tox {
@@ -13,7 +14,7 @@
     box-shadow: var(--tox-private-floating-sidebar-box-shadow, 0 0 40px 1px fade(@color-black, 15%), 0 16px 16px -10px fade(@color-black, 15%));
     width: var(--tox-private-floating-sidebar-width);
     height: var(--tox-private-floating-sidebar-height);
-    background-color: var(--tox-private-background-color, @background-color);
+    background-color: var(--tox-private-floating-sidebar-background-color, @sidebar-background-color);
     border-radius: 12px;
     overflow: hidden;
 
@@ -35,5 +36,9 @@
 
   .tox-floating-sidebar__header {
     position: relative;
+  }
+
+  .tox-floating-sidebar .tox-ai__scroll:has(.tox-card-list) {
+    background-color: inherit;
   }
 }


### PR DESCRIPTION
Related Ticket: TINY-13956

Description of Changes:
* Define a new CSS custom property `--tox-private-floating-sidebar-background-color` using `light-dark()` for dark mode support
* Change the floating sidebar `background-color` fallback from `@background-color` (white) to `@sidebar-background-color` (theme-aware gray), matching the docked sidebar
* The floating sidebar is `position: fixed` and not a child of `.tox-sidebar`, so it needs its own CSS custom property definition rather than inheriting from the sidebar container
* Add a scoped override so `.tox-ai__scroll` inherits the gray background when displaying the review card list (via `:has(.tox-card-list)`), preventing the default white scroll background from covering the floating sidebar gray

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency of the floating sidebar background color styling.
  * Enhanced styling for the scroll container within the floating sidebar for better visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->