### PR TITLE
TINY-13884: Update bedrock to remove sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@ephox/bedrock-client": "^16.0.0",
-    "@ephox/bedrock-server": "^16.0.0",
+    "@ephox/bedrock-server": "^16.1.0",
     "@ephox/oxide-icons-tools": "^4.0.0",
     "@ephox/swag": "^4.6.0",
     "@rspack/cli": "^1.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,10 +1202,10 @@
     jquery "^3.4.1"
     querystringify "^2.1.1"
 
-"@ephox/bedrock-server@^16.0.0":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@ephox/bedrock-server/-/bedrock-server-16.0.0.tgz#2d14c3b17748765b1d1051ded5f10a5cf246d577"
-  integrity sha512-lFIEBMPFJ2h8JYCahpZXhBWWCTUEpHWu3F8+vcvlIp3QEWvX6xKKf8ROJOA+Vy20rsLTT/3IQn7k8f7MlIoRQg==
+"@ephox/bedrock-server@^16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@ephox/bedrock-server/-/bedrock-server-16.1.0.tgz#840127335c011ffccaf359dedbbd23eaf1f30fc5"
+  integrity sha512-7nl9x1NNNFI2OOuMHUDiKkAw/FIX6stkBsdgggrV8mnyelGJriiGRcrc+wnQ7ArDDgdW97z5Rsz2aW9q+YBobg==
   dependencies:
     "@aws-sdk/client-device-farm" "^3.354.0"
     "@ephox/bedrock-client" "^16.0.0"


### PR DESCRIPTION
Related Ticket: TINY-13884

Description of Changes:
* Update bedrock to remove sourcemaps in bedrock-auto

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency versions for maintenance purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->