### PR TITLE
TINY-14030: Show deleted annotations on card click in Review preview

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -70,6 +70,18 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
     text-decoration: none;
   }
 
+  // TEMP: Show deleted content when its review card is selected.
+  // Makes deletions visible and scrollable in preview mode.
+  // TODO: Replace with a proper visual marker that doesn't reveal full deleted content.
+  .tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
+    display: inline;
+    background-color: fade(@color-error, 20%);
+    border-top: 3px solid @color-error;
+    border-bottom: 3px solid @color-error;
+    box-shadow: none;
+    text-decoration: line-through;
+  }
+
   img, video, iframe {
     &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
     &.tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
@@ -81,6 +93,13 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
     &.tox-tinymceai__annotation--modified__selected {
       border: 0.25em solid fade(@color-tint, 20%);
       outline: 0.125em solid @color-tint;
+      padding: 0;
+    }
+
+    &.tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
+      display: inline;
+      border: 0.25em solid fade(@color-error, 20%);
+      outline: 0.125em solid @color-error;
       padding: 0;
     }
   }


### PR DESCRIPTION
Related Ticket: TINY-14030

Description of Changes:
* Add CSS styles for `__removed__selected` annotations in the AI preview body so deleted content becomes visible when its review card is selected
* Includes rules for both inline text elements (error-colored background, borders, line-through) and block-level media (img, video, iframe with error-colored outline)

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for removed annotations in preview mode. Deleted content now displays with distinct color-coded backgrounds, borders, and text formatting to clearly differentiate removed content. Styling applies consistently across all content types, including text and embedded media elements, improving visibility of deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->