### PR TITLE
TINY-14025: Remove border-color from skeleton loader cards

### DIFF
--- a/modules/oxide/src/less/theme/components/card/card.less
+++ b/modules/oxide/src/less/theme/components/card/card.less
@@ -151,7 +151,6 @@
     &.tox-skeleton {
       cursor: default;
       pointer-events: none;
-      border-color: @border-color;
       box-shadow: none;
 
       &:hover {


### PR DESCRIPTION
Related Ticket: TINY-14025

Description of Changes:
* Remove `border-color: @border-color` override from `.tox-skeleton` in `card.less`
* The base `.tox-card` already has transparent borders; this override was adding an unwanted visible border to skeleton loader cards

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted skeleton card styling by removing a border color property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->