### PR TITLE
TINY-14027: Reduce card gap in review sidebar to 8px

### DIFF
--- a/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
+++ b/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
@@ -19,6 +19,10 @@
       flex-direction: column;
       gap: 12px;
 
+      .tox-card-list {
+        gap: @pad-sm;
+      }
+
       .tox-ai__review-initializing {
         padding: var(--tox-private-pad-md, @pad-md);
       }


### PR DESCRIPTION
Related Ticket: TINY-14027

Description of Changes:
* Add scoped `.tox-card-list { gap: @pad-sm; }` inside `.tox-ai__review-sidebar-container` in `ai-review.less`
* Reduces card-to-card gap from 12px to 8px, matching review list item spacing
* Scoped to review sidebar only; other `.tox-card-list` usages (e.g. floating sidebar) are unaffected

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the AI review interface for better visual layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->