### PR TITLE
TINY-13832: add `tox-sidebar-content__loader` class

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -41,7 +41,7 @@
     position: absolute;
     top: 0;
     width: 100%;
-    z-index: @z-index-loading
+    z-index: @z-index-loading;
   }
 
   .tox-sidebar-content__title {


### PR DESCRIPTION
Related Ticket: TINY-13832

Description of Changes:
add `tox-sidebar-content__loader` class

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a full-overlay loading state for the AI chat sidebar: a centered loader with a translucent, theme-aware backdrop and appropriate stacking order to ensure it covers content while preserving accessibility and visual clarity during load times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->