### PR TITLE
TINY-14028: dark mode fixes

### DIFF
--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-alert-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-alert-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03a25657d2cada1480e806062bfdab62a187d1edbabaeea37af4e5cc7232a1b5
+oid sha256:00ed6717dbc951209e1a7657fc738b4eac6d6a1f7c2db15f7bfa136d5f830517
 size 28416

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-removable-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-removable-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a454ee976022d971d59c7fc26c566f3aeca0f638b6d3e0f2ff622db8d9edee4
-size 28732
+oid sha256:54641f79514fac1a0a952a34f00e536f294af073f78a99731551eba6113a3d9c
+size 28739

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-removable-with-action-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-removable-with-action-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddf19107fd53166d3b8522524a560610ac3a3a2cafa0074c166170e93940fa57
-size 30129
+oid sha256:707ef3c234043f8038e1846edb8cce794aa85a4a9a0b8a159406be0cb70d3e15
+size 30130

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-removable-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-removable-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab81662f2839050b2b113c53d9786a3dab52fb46bc879f395f8fb64d58776224
-size 31443
+oid sha256:dcc101b33dad35fad41f348aa3fc6795387703d9d7d6e58d0a341375f734d9f7
+size 31440

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-with-action-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-with-action-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:911b1f66bcaa98827d372fd58f531f248b0fcf2ed43654b42640578dbd1172c9
-size 29818
+oid sha256:4be627b13b6d15e3ea34e94d9f045c3f4080495990d5a7eb792a89499c59af7e
+size 29817

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--error-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:895f7debbaffd600a2f89b1f51bbf8f02df07b47dc32b53e9aafb80937e41629
-size 31129
+oid sha256:bd4220db9072c81662c940b15ccd79fd12b60acc02a4c93d8c5f6168c68e23c7
+size 31127

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a802e858687a6e59b3fc2eacc671ca8cbf217e63c6426b2044361044d51ff0a8
+oid sha256:61adfd1f4d65adc4982262b2761897d9e82548bea523325818a689c69131ee84
 size 28566

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-removable-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-removable-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c707f36cbd67a28d763102b4d8bcacd3c7bb3c59c899b9765ccbefcc4129569
+oid sha256:f60e5cb5f09d23d2da6d65a26fa3750d9bc96d2376b3f85d6df45a2beaf1ff7d
 size 28899

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-removable-with-action-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-removable-with-action-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5f0321235b36e6789a7330d891c8177cd6ea342f828f4cc8cefe52e39d7dd66
-size 30274
+oid sha256:832d5fbfc42072636deefa32f9e2a83e4561b8dfabbeabbec1366714ff0b09c7
+size 30275

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-removable-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-removable-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2a00e055569b829c6c8ef05fd2f3e414e7839603fee5c6d4371d9922a5369b6
-size 31386
+oid sha256:ace81cc028931c8c04379440e362e0c51a2d310702b006d8fd29ba9ffe0472c9
+size 31385

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-with-action-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-with-action-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf23b20b4271b431cc5de208b1e6d6c51b82685ef3fd2b710c5316fb882f1c81
+oid sha256:65391d8d479d938dbaa4e8b38f8354402a8c54c11e0ec0707c6d382684e8440e
 size 29945

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-alert--warning-with-actions-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8fbd2d47110d2190fde2c5abbaa4985a7078c5ee155ee9b180b643b25ac8cd7a
+oid sha256:192542e94629a844a6f45cddb75da7a3ef089d190a5ac61b2cc8ec1d8bbd915e
 size 31053

--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -2,31 +2,6 @@
 // Accordion
 //
 
-@accordion-border-radius: @control-border-radius; // 6px
-@accordion-border-color: @border-color;
-@accordion-background-color: @background-color;
-
-@accordion-item-background-color: darken(@background-color, 3%);
-@accordion-item-margin-bottom: @pad-sm;
-
-@accordion-header-padding: @pad-sm + @pad-xs;
-@accordion-header-font-size: @font-size-md;
-@accordion-header-font-weight: @font-weight-bold;
-@accordion-header-text-color: @text-color;
-@accordion-header-background-color: transparent;
-@accordion-header-hover-background-color: darken(@accordion-item-background-color, 5%);
-
-@accordion-icon-size: @base-value * 1.5;
-@accordion-icon-color: @text-color;
-@accordion-icon-margin: @pad-sm;
-
-@accordion-content-padding-x: @pad-sm + @pad-xs;
-@accordion-content-padding-y: @pad-sm;
-@accordion-content-background-color: transparent;
-
-@accordion-header-disabled-opacity: 0.5;
-@accordion-header-disabled-cursor: not-allowed;
-
 .tox when (@custom-properties-enabled = true) {
   .tox-accordion {
     --tox-private-accordion-item-background-color: light-dark(
@@ -35,37 +10,36 @@
     --tox-private-accordion-header-hover-background-color: light-dark(
       hsl(from var(--tox-private-accordion-item-background-color, @accordion-item-background-color) h s calc(l - 5)),
       hsl(from var(--tox-private-accordion-item-background-color, @accordion-item-background-color) h s calc(l + 5)));
-
-    --tox-private-accordion-icon-color: var(--tox-private-text-color);
-
-    --tox-private-accordion-header-focus-outline: 0 0 0 var(--tox-private-keyboard-focus-outline-width) var(--tox-private-keyboard-focus-outline-color);
   }
 }
+
+@accordion-item-background-color: darken(@background-color, 3%);
+@accordion-header-hover-background-color: darken(@accordion-item-background-color, 5%);
 
 .tox {
   .tox-accordion {
     display: flex;
     flex-direction: column;
-    gap: @accordion-item-margin-bottom;
+    gap: var(--tox-private-pad-sm, @pad-sm);
   }
 
   .tox-accordion__item {
-    background-color: var(--tox-private-background-color, @accordion-background-color);
-    border-radius: @control-border-radius;
+    background-color: var(--tox-private-background-color, @background-color);
+    color: var(--tox-private-text-color, @text-color);
+    border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     position: relative;
 
     &.tox-accordion__item--expanded {
       background-color: var(--tox-private-accordion-item-background-color, @accordion-item-background-color);
 
-      
       .tox-accordion__content--expanded .tox-accordion__content-inner {
-        padding-top: @pad-xs;
-      }    
+        padding-top: var(--tox-private-pad-xs, @pad-xs);
+      }
     }
 
     &::after {
-      border-radius: @control-border-radius;
-      box-shadow: var(--tox-private-accordion-header-focus-outline, 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color);
+      border-radius: var(--tox-private-control-border-radius, @control-border-radius);
+      box-shadow: 0 0 0 var(--tox-private-keyboard-focus-outline-width, @keyboard-focus-outline-width) var(--tox-private-keyboard-focus-outline-color, @keyboard-focus-outline-color);
       content: '';
       inset: 0;
       opacity: 0;
@@ -98,27 +72,26 @@
 
   .tox-accordion__header {
     align-items: center;
-    background-color: @accordion-header-background-color;
     border: none;
-    border-radius: @control-border-radius;
+    border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     box-sizing: border-box;
-    color: var(--tox-private-text-color, @accordion-header-text-color);
+    color: var(--tox-private-text-color, @text-color);
     cursor: pointer;
     display: flex;
-    font-family: @font-stack;
-    font-size: @accordion-header-font-size;
-    font-weight: @accordion-header-font-weight;
-    line-height: @line-height-base;
+    font-family: var(--tox-private-font-stack, @font-stack);
+    font-size: var(--tox-private-font-size-md, @font-size-md);
+    font-weight: var(--tox-private-font-weight-bold, @font-weight-bold);
+    line-height: var(--tox-private-line-height-base, @line-height-base);
     outline: none;
-    padding: @accordion-header-padding;
+    padding: calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs));
     text-align: left;
     width: 100%;
 
     // Add pseudo-element for focus outline (following toolbar-button.less pattern)
     &::after {
-      border-radius: @control-border-radius;
+      border-radius: var(--tox-private-control-border-radius, @control-border-radius);
       bottom: 0;
-      box-shadow: var(--tox-private-accordion-header-focus-outline, 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color);
+      box-shadow: 0 0 0 var(--tox-private-keyboard-focus-outline-width, @keyboard-focus-outline-width) var(--tox-private-keyboard-focus-outline-color, @keyboard-focus-outline-color);
       content: '';
       left: 0;
       opacity: 0;
@@ -146,40 +119,40 @@
     }
 
     &.tox-accordion__header--disabled {
-      cursor: @accordion-header-disabled-cursor;
-      opacity: @accordion-header-disabled-opacity;
+      cursor: not-allowed;
+      opacity: 0.5;
     }
 
     &.tox-accordion__header--icon-end {
-      padding-right: @accordion-header-padding;
+      padding-right: calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs));
     }
   }
 
   .tox-accordion__content--expanded .tox-accordion__content-inner {
-    padding-top: calc(@accordion-content-padding-y + 1px);
+    padding-top: calc(var(--tox-private-pad-sm, @pad-sm) + 1px);
   }
 
   .tox-accordion__header-icon {
     align-items: center;
-    color: var(--tox-private-accordion-icon-color, @accordion-icon-color);
+    color: var(--tox-private-text-color, @text-color);
     display: flex;
     flex-shrink: 0;
-    height: @accordion-icon-size;
+    height: calc(var(--tox-private-base-value, @base-value) * 1.5);
     justify-content: center;
-    width: @accordion-icon-size;
+    width: calc(var(--tox-private-base-value, @base-value) * 1.5);
 
     svg {
       display: block;
       fill: currentColor;
       height: 100%;
       width: 100%;
-      max-height: @accordion-icon-size;
-      max-width: @accordion-icon-size;
+      max-height: calc(var(--tox-private-base-value, @base-value) * 1.5);
+      max-width: calc(var(--tox-private-base-value, @base-value) * 1.5);
     }
   }
 
   .tox-accordion__header:not(.tox-accordion__header--icon-end) .tox-accordion__header-icon {
-    margin-right: @accordion-icon-margin;
+    margin-right: var(--tox-private-pad-sm, @pad-sm);
     margin-left: 0;
   }
 
@@ -197,11 +170,11 @@
 
   .tox-accordion__header--icon-end .tox-accordion__header-text {
     flex: 0 1 auto;
-    margin-right: @accordion-icon-margin;
+    margin-right: var(--tox-private-pad-sm, @pad-sm);
   }
 
   .tox-accordion__content {
-    border-radius: @control-border-radius;
+    border-radius: var(--tox-private-control-border-radius, @control-border-radius);
 
     &.tox-accordion__content--collapsed {
       display: none;
@@ -213,7 +186,7 @@
   }
 
   .tox-accordion__content-inner {
-    padding: @accordion-content-padding-y @accordion-content-padding-x (@pad-sm + @pad-xs);
+    padding: var(--tox-private-pad-sm, @pad-sm) calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs)) calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs));
 
     .tox-form__group {
       &:last-child {
@@ -221,7 +194,7 @@
       }
 
       > *:not(:first-child) {
-        margin-top: @pad-sm + @pad-xs;
+        margin-top: calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs));
       }
 
       > .tox-dropdown-content {
@@ -231,11 +204,11 @@
 
     .tox-button-group {
       display: flex;
-      gap: @pad-sm;
+      gap: var(--tox-private-pad-sm, @pad-sm);
     }
 
     .tox-accordion__model-button {
-      border-radius: @accordion-border-radius;
+      border-radius: var(--tox-private-control-border-radius, @control-border-radius);
       align-items: center;
       appearance: none;
       background: none;
@@ -245,16 +218,16 @@
       display: flex;
       font-family: inherit;
       font-size: inherit;
-      gap: @pad-xs;
+      gap: var(--tox-private-pad-xs, @pad-xs);
       margin: 0;
       outline: none;
-      padding: 6px (@pad-sm + @pad-xs);
+      padding: 6px calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs));
       position: relative;
 
       &::after {
-        border-radius: @accordion-border-radius;
+        border-radius: var(--tox-private-control-border-radius, @control-border-radius);
         bottom: 0;
-        box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color;
+        box-shadow: 0 0 0 var(--tox-private-keyboard-focus-outline-width, @keyboard-focus-outline-width) var(--tox-private-keyboard-focus-outline-color, @keyboard-focus-outline-color);
         content: '';
         left: 0;
         opacity: 0;
@@ -280,9 +253,9 @@
 
   .tox-accordion .tox-selectfield {
     align-items: center;
-    background-color: @accordion-background-color;
-    border: 1px solid @accordion-border-color;
-    border-radius: @accordion-border-radius;
+    background-color: var(--tox-private-background-color, @background-color);
+    border: 1px solid var(--tox-private-border-color, @border-color);
+    border-radius: var(--tox-private-control-border-radius, @control-border-radius);
     box-sizing: border-box;
     display: flex;
     height: 34px;
@@ -291,7 +264,7 @@
     width: 100%;
 
     &:focus-within {
-      box-shadow: 0 0 0 @keyboard-focus-outline-width @keyboard-focus-outline-color;
+      box-shadow: 0 0 0 var(--tox-private-keyboard-focus-outline-width, @keyboard-focus-outline-width) var(--tox-private-keyboard-focus-outline-color, @keyboard-focus-outline-color);
       z-index: 1;
 
       @media (forced-colors: active) {
@@ -323,8 +296,8 @@
       pointer-events: none;
 
       svg {
-        height: @base-value;
-        width: @base-value;
+        height: var(--tox-private-base-value, @base-value);
+        width: var(--tox-private-base-value, @base-value);
       }
     }
   }
@@ -336,7 +309,7 @@
   }
 
   .tox-accordion__header:not(.tox-accordion__header--icon-end) .tox-accordion__header-icon {
-    margin-left: @accordion-icon-margin;
+    margin-left: var(--tox-private-pad-sm, @pad-sm);
     margin-right: 0;
   }
 
@@ -346,7 +319,7 @@
   }
 
   .tox-accordion__header--icon-end .tox-accordion__header-text {
-    margin-left: @accordion-icon-margin;
+    margin-left: var(--tox-private-pad-sm, @pad-sm);
     margin-right: 0;
   }
 }

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -24,6 +24,7 @@
   .tox-sidebar-content__header {
     border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-background-color, @background-color);
     padding: calc(var(--tox-private-pad-sm, @pad-sm) - var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width)) calc(12px - var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width));
+    border-bottom: 1px solid var(--tox-private-separator-color, @tinymce-separator-color);
 
     &:focus-visible:not(:disabled) {
        border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-color-tint, @color-tint);
@@ -204,7 +205,7 @@
     flex-wrap: wrap;
 
     .tox-tag {
-      border: 1px solid var(--tox-private-border-color, @border-color);
+      border: 1px solid var(--tox-private-separator-color, @tinymce-separator-color);
       background-color: transparent;
       max-width: 132px;
       max-height: 24px;
@@ -257,7 +258,12 @@
   .tox-ai-error {
     border-radius: var(--tox-private-panel-border-radius, @panel-border-radius);
     border: 1px solid var(--tox-private-color-error, @color-error);
-    background: linear-gradient(0deg, rgba(from var(--tox-private-color-white, @color-white) r g b / 0.9) 0%,  rgba(from var(--tox-private-color-white, @color-white) r g b / 0.9) 100%), var(--tox-private-color-error, @color-error);
+    background: linear-gradient(
+        0deg,
+        rgba(from var(--tox-private-background-color, @background-color) r g b / 0.9) 0%,
+        rgba(from var(--tox-private-background-color, @background-color) r g b / 0.9) 100%
+      ),
+      var(--tox-private-color-error, @color-error);
     padding: var(--tox-private-pad-sm, @pad-sm);
     width: 100%;
     display: flex;
@@ -282,7 +288,7 @@
     flex-direction: column;
 
     border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-background-color, @background-color);
-    border-top: 1px solid var(--tox-private-neutral-20, darken(@background-color, 11%));
+    border-top: 1px solid var(--tox-private-separator-color, @tinymce-separator-color);
 
     &:focus-visible:not(:disabled) {
        border: var(--tox-private-tinymceai-focus-border-width, @tinymceai-focus-border-width) solid var(--tox-private-color-tint, @color-tint);

--- a/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
@@ -30,8 +30,8 @@
 
     .tox-ai__preview-footer {
       flex: 0 0 auto;
-      background: @color-white;
-      border-top: 1px solid hsl(from var(--tox-color-white, @color-white) h s calc(l - 11));
+      background: var(--tox-private-background-color, @background-color);
+      border-top: 1px solid @border-color-light;
 
 
       .tox-ai__preview-footer-toolbar {

--- a/modules/oxide/src/less/theme/components/ai-preview/ai-previewloader.less
+++ b/modules/oxide/src/less/theme/components/ai-preview/ai-previewloader.less
@@ -11,6 +11,7 @@
     border-radius: var(--tox-private-panel-border-radius, @panel-border-radius);
     box-shadow: var(--tox-private-ai-preview-loader-box-shadow, 0 0 40px 1px fade(@color-black, 15%), 0 16px 16px -10px fade(@color-black, 15%));
     background-color: var(--tox-private-background-color, @background-color);
+    color: var(--tox-private-text-color, @text-color);
     pointer-events: auto;
 
     &__content {

--- a/modules/oxide/src/less/theme/components/alert/alert.less
+++ b/modules/oxide/src/less/theme/components/alert/alert.less
@@ -2,74 +2,44 @@
 // Alert
 //
 
-@alert-border-width: 1px;
-@alert-border-radius: @panel-border-radius;
-@alert-padding-y: @pad-xs;
-@alert-padding-x: @pad-sm;
-@alert-font-size: @font-size-sm;
-@alert-font-weight: @font-weight-normal;
-@alert-line-height: 18px;
-@alert-text-color: @text-color;
-@alert-error-color: @color-error;
-@alert-warning-color: @color-warning;
-@alert-overlay-color: rgba(from @color-white r g b / 0.8);
-@alert-content-padding-y: @pad-sm;
-@alert-content-gap: @pad-sm;
-@alert-actions-gap: @pad-xs;
-@alert-gap: 4px;
-
-.tox when (@custom-properties-enabled = true) {
-  .tox-alert {
-    --tox-private-alert-border-radius: var(--tox-private-panel-border-radius);
-    --tox-private-alert-font-size: var(--tox-private-font-size-sm);
-    --tox-private-alert-font-weight: var(--tox-private-font-weight-normal);
-    --tox-private-alert-text-color: var(--tox-private-text-color);
-    --tox-private-alert-error-color: var(--tox-private-color-error);
-    --tox-private-alert-warning-color: var(--tox-private-color-warning);
-    --tox-private-alert-overlay-color: rgba(from var(--tox-private-color-white) r g b / 0.8);
-    --tox-private-alert-content-padding-y: var(--tox-private-pad-sm);
-    --tox-private-alert-content-gap: var(--tox-private-pad-sm);
-    --tox-private-alert-actions-gap: var(--tox-private-pad-xs);
-    --tox-private-alert-gap: 4px;
-  }
-}
-
 .tox {
   .tox-alert {
     align-items: flex-start;
     align-self: stretch;
-    border-radius: var(--tox-private-alert-border-radius, @alert-border-radius);
+    border-radius: var(--tox-private-panel-border-radius, @panel-border-radius);
     border-style: solid;
-    border-width: @alert-border-width;
+    border-width: 1px;
     box-sizing: border-box;
-    color: var(--tox-private-alert-text-color, @alert-text-color);
+    color: var(--tox-private-text-color, @text-color);
     display: flex;
-    font-size: var(--tox-private-alert-font-size, @alert-font-size);
-    font-weight: var(--tox-private-alert-font-weight, @alert-font-weight);
-    gap: var(--tox-private-alert-gap, @alert-gap);
-    line-height: @alert-line-height;
-    padding: @alert-padding-y @alert-padding-x;
+    font-size: var(--tox-private-font-size-sm, @font-size-sm);
+    font-weight: var(--tox-private-font-weight-normal, @font-weight-normal);
+    gap: var(--tox-private-pad-xs, @pad-xs);
+    line-height: var(--tox-private-line-height-base, @line-height-base);
+    padding: var(--tox-private-pad-xs, @pad-xs) var(--tox-private-pad-sm, @pad-sm);
     width: 100%;
   }
 
   .tox-alert--error {
-    background: linear-gradient(
-      0deg,
-      var(--tox-private-alert-overlay-color, @alert-overlay-color) 0%,
-      var(--tox-private-alert-overlay-color, @alert-overlay-color) 100%
-    ),
-    var(--tox-private-alert-error-color, @alert-error-color);
-    border-color: var(--tox-private-alert-error-color, @alert-error-color);
+    background:
+      linear-gradient(
+        0deg,
+        rgba(from var(--tox-private-background-color, @background-color) r g b / 0.8) 0%,
+        rgba(from var(--tox-private-background-color, @background-color) r g b / 0.8) 100%
+      ),
+      var(--tox-private-color-error, @color-error);
+    border-color: var(--tox-private-color-error, @color-error);
   }
 
   .tox-alert--warning {
-    background: linear-gradient(
-      0deg,
-      var(--tox-private-alert-overlay-color, @alert-overlay-color) 0%,
-      var(--tox-private-alert-overlay-color, @alert-overlay-color) 100%
-    ),
-    var(--tox-private-alert-warning-color, @alert-warning-color);
-    border-color: var(--tox-private-alert-warning-color, @alert-warning-color);
+    background:
+      linear-gradient(
+        0deg,
+        rgba(from var(--tox-private-background-color, @background-color) r g b / 0.8) 0%,
+        rgba(from var(--tox-private-background-color, @background-color) r g b / 0.8) 100%
+      ),
+      var(--tox-private-color-warning, @color-warning);
+    border-color: var(--tox-private-color-warning, @color-warning);
   }
 
   .tox-alert__body {
@@ -83,8 +53,8 @@
     align-items: center;
     display: flex;
     flex: 1 0 0;
-    gap: var(--tox-private-alert-content-gap, @alert-content-gap);
-    padding: var(--tox-private-alert-content-padding-y, @alert-content-padding-y) 0;
+    gap: var(--tox-private-pad-sm, @pad-sm);
+    padding: var(--tox-private-pad-sm, @pad-sm) 0;
   }
 
   .tox-alert__message {
@@ -96,7 +66,7 @@
     align-items: center;
     display: flex;
     flex-wrap: wrap;
-    gap: var(--tox-private-alert-actions-gap, @alert-actions-gap);
+    gap: var(--tox-private-pad-xs, @pad-xs);
     justify-content: flex-start;
   }
 }

--- a/modules/oxide/src/less/theme/components/button/button-secondary.less
+++ b/modules/oxide/src/less/theme/components/button/button-secondary.less
@@ -47,7 +47,7 @@
 @button-secondary-active-text-color: @button-secondary-text-color;
 
 // Enabled state
-@button-secondary-enabled-background-color: contrast(@background-color, mix(darken(@background-color, 6%), @color-tint, 70%), mix(lighten(@background-color, 15%), @color-tint, 70%));
+@button-secondary-enabled-background-color: multiply(white, contrast(@background-color, fade(@color-tint, 35), fade(@color-tint, 65))); // copied from toolbar button enabled state, we want to match the colors here
 @button-secondary-enabled-background-image: @button-secondary-background-image;
 @button-secondary-enabled-border-color: @button-secondary-enabled-background-color;
 @button-secondary-enabled-box-shadow: @button-secondary-box-shadow;
@@ -113,13 +113,12 @@
     --tox-private-button-secondary-active-text-color: var(--tox-private-button-secondary-text-color);
 
     /* Enabled state 
-      Do we use this button as a toggle that can be enabled? 
-      If not - these variables and enabled state styles should be removed
+      (used in AI chat)
     */
     --tox-private-button-secondary-enabled-background-color: light-dark(
-      mix(darken(@background-color, 6%), @color-tint, 70%),
-      mix(lighten(@background-color, 15%), @color-tint, 70%)
-    );
+      multiply(white, fade(@color-tint, 35)),
+      multiply(white, fade(@color-tint, 65))
+    ); /* blue20 and blue40 from figma - figure out CSS color calculation */
 
     --tox-private-button-secondary-enabled-border-color: var(--tox-private-button-secondary-enabled-background-color);
     --tox-private-button-secondary-enabled-text-color: var(--tox-private-button-secondary-text-color);

--- a/modules/oxide/src/less/theme/components/context-toolbar/context-toolbar.less
+++ b/modules/oxide/src/less/theme/components/context-toolbar/context-toolbar.less
@@ -8,11 +8,15 @@
 
     // Enable automatic flip when toolbar would overflow viewport, very new, not recongnized by stylelint yet
     // stylelint-disable-next-line property-no-unknown -- CSS Anchor Positioning spec (Chrome 125+)
-    position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+    position-try-fallbacks:
+      flip-block,
+      flip-inline,
+      flip-block flip-inline;
     z-index: @z-index-menu;
 
-    background-color: #ffffff;
-    border: 1px solid #e0e0e0;
+    background-color: var(--tox-private-background-color, @background-color);
+    color: var(--tox-private-text-color, @text-color);
+    border: 1px solid @border-color-light;
     border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     padding: 8px;

--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-content.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-content.less
@@ -14,7 +14,7 @@
     min-width: 300px;
     max-width: 300px;
     width: 300px;
-    border-left: 1px solid var(--tox-private-sidebar-border-color, darken(@background-color, 11%));
+    border-left: 1px solid var(--tox-private-separator-color, @tinymce-separator-color);
 
     &--wide {
       min-width: 440px;

--- a/modules/oxide/src/less/theme/components/tag/tag.less
+++ b/modules/oxide/src/less/theme/components/tag/tag.less
@@ -53,6 +53,7 @@
 
     .tox-icon {
       height: var(--tox-private-base-value, @base-value);
+      fill: var(--tox-private-text-color, @text-color);
     }
 
     .tox-tag__label {
@@ -61,6 +62,7 @@
       white-space: nowrap;
       /* If there is not enough space, then shrink the label. */
       flex-shrink: 1;
+      color: var(--tox-private-text-color, @text-color);
     }
 
     .tox-tag__close {
@@ -69,6 +71,7 @@
       .tox-button.tox-button--icon {
         border: 0;
         padding: 0;
+        color: var(--tox-private-text-color-muted, @text-color-muted);
 
         &::before {
           box-shadow: none;


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Replaced new LESS variables with CSS custom properties throughout accordion component styles
* Removed unused accordion-specific LESS variable definitions at the top of the file
* Updated AI chat component to use separator color variables for borders instead of hardcoded colors
* Fixed AI preview component to use theme-aware background and border colors
* Enhanced alert component styling to use background color in gradient overlays instead of white
* Updated button secondary component with improved enabled state colors for better theme consistency
* Added theme-aware colors to context toolbar component
* Updated sidebar content to use separator color variable for borders
* Enhanced tag component with proper text color inheritance for labels, icons, and close buttons

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated many components to CSS variable–driven theming for improved themability and dark-mode consistency.
  * Accordion styling and expanded/collapsed layouts now rely on computed CSS variables for spacing, padding, icons, borders and focus outlines.
  * Alerts, buttons, context toolbar, sidebar, AI preview/AI chat, preview loader, and tags updated to use unified variable-based tokens for colors, borders and typography.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->