### PR TITLE
TINY-14078: Add box-sizing to `tox-ai__review-input-button` class

### DIFF
--- a/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
+++ b/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
@@ -43,6 +43,7 @@
           align-items: center;
           border: 1px solid @border-color;
           border-radius: @control-border-radius;
+          box-sizing: border-box;
         }
       }
     }


### PR DESCRIPTION
Related Ticket: [TINY-14078](https://ephocks.atlassian.net/browse/TINY-14078)

Description of Changes:
* Fixes an issue where an accordion dropdown would overflow its parent container because it wasn't including padding and border size within its width.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-14078]: https://ephocks.atlassian.net/browse/TINY-14078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the AI review input button sizing to properly account for padding and borders in layout calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->