### PR TITLE
TINY-14055: submenus should keep open after mouse out of the menu

### DIFF
--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
       control: 'number',
     },
     triggerEvents: {
-      description: 'Defines trigger element behavior. On default opens a dropdown on click but can be changed to open on hover and close on mouse leave.',
+      description: 'Defines trigger element behavior. By default opens a dropdown on click. Hover opens on mouse enter only (does not close on mouse leave). Arrows opens on arrow key press.',
       value: [ 'click' ],
       options: [[ 'click' ], [ 'hover' ], [ 'click', 'hover' ]]
     }

--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { Throttler, Type } from '@ephox/katamari';
+import { Type } from '@ephox/katamari';
 import { Children, cloneElement, forwardRef, isValidElement, useCallback, useEffect, useMemo, useRef, useState, type FC, type HTMLAttributes, type MouseEvent, type PropsWithChildren, type ReactElement, type KeyboardEvent } from 'react';
 
 import { Bem } from '../../main';
@@ -6,16 +6,12 @@ import { Bem } from '../../main';
 import { DropdownContext, useDropdown } from './internals/Context';
 import * as PositioningUtils from './internals/PositioningUtils';
 
-const isInDropdownContent = (contentRef: React.MutableRefObject<HTMLDivElement | undefined>, node: Node): boolean => {
-  return contentRef.current?.contains(node) ?? false;
-};
-
 interface DropdownContentProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
   readonly onOpenChange?: (isOpen: boolean) => void;
 }
 
 const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, onOpenChange, ...props }, ref) => {
-  const { triggerRef, side, align, gap, contentRef, triggerEvents, debouncedHideHoverablePopover, isOpen, setIsOpen } = useDropdown();
+  const { triggerRef, side, align, gap, contentRef, triggerEvents, isOpen, setIsOpen } = useDropdown();
 
   const updateToggleState = useCallback((event: ToggleEvent) => {
     setIsOpen(event.newState === 'open');
@@ -48,17 +44,6 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
     };
   }, [ contentRef, triggerRef, updateToggleState, onOpenChange ]);
 
-  const onHoverTriggerProps = {
-    onMouseLeave: (e: MouseEvent<HTMLDivElement>) => {
-      props.onMouseLeave?.(e);
-      debouncedHideHoverablePopover.throttle(e);
-    },
-    onMouseEnter: (e: MouseEvent<HTMLDivElement>) => {
-      props.onMouseEnter?.(e);
-      debouncedHideHoverablePopover.cancel();
-    }
-  };
-
   const onArrowTriggerProps = {
     onKeyUp: (e: KeyboardEvent<HTMLDivElement>) => {
       props.onKeyUp?.(e);
@@ -71,7 +56,6 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
 
   const contentProps = {
     ...props,
-    ...triggerEvents.includes('hover') && onHoverTriggerProps,
     ...triggerEvents.includes('arrows') && onArrowTriggerProps,
     onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
       props.onKeyDown?.(e);
@@ -109,7 +93,7 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
 interface TriggerInternalProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {}
 
 const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
-  const { triggerRef, contentRef, triggerEvents, debouncedHideHoverablePopover, isOpen } = useDropdown();
+  const { triggerRef, contentRef, triggerEvents, isOpen } = useDropdown();
 
   let child = Children.toArray(children)[0];
   if (!isValidElement(child)) {
@@ -130,17 +114,9 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
       if (!e.isDefaultPrevented()) {
         child.props.onMouseEnter?.(e);
         props.onMouseEnter?.(e);
-        debouncedHideHoverablePopover.cancel();
         if (!isOpen) {
           showContentPopover();
         }
-      }
-    },
-    onMouseLeave: (e: MouseEvent<HTMLElement>) => {
-      if (!e.isDefaultPrevented()) {
-        child.props.onMouseLeave?.(e);
-        props.onMouseLeave?.(e);
-        debouncedHideHoverablePopover.throttle(e);
       }
     }
   };
@@ -216,17 +192,9 @@ const Root: FC<DropdownProps> = ({ children, side = 'top', align = 'start', gap 
   const contentRef = useRef<HTMLDivElement | undefined>();
   const [ isOpen, setIsOpen ] = useState(false);
 
-  // debounced hide popover function on mouse leave (used when trigger events include hover)
-  const debouncedHideHoverablePopover = useMemo(() => Throttler.last((e: MouseEvent) => {
-    // in the hover mode, the dropdown should close when the cursor is moved outside of the dropdown content, works for nested dropdowns
-    if (!(e.relatedTarget instanceof Node) || !isInDropdownContent(contentRef, e.relatedTarget)) {
-      contentRef.current?.hidePopover();
-    }
-  }, 300), []);
-
   const contextValue = useMemo(() => {
-    return { triggerRef, contentRef, side, align, gap, triggerEvents, debouncedHideHoverablePopover, isOpen, setIsOpen };
-  }, [ triggerRef, contentRef, side, align, gap, triggerEvents, debouncedHideHoverablePopover, isOpen ]);
+    return { triggerRef, contentRef, side, align, gap, triggerEvents, isOpen, setIsOpen };
+  }, [ triggerRef, contentRef, side, align, gap, triggerEvents, isOpen ]);
 
   return <DropdownContext.Provider value={contextValue}>{children}</DropdownContext.Provider>;
 };

--- a/modules/oxide-components/src/main/ts/components/dropdown/internals/Context.ts
+++ b/modules/oxide-components/src/main/ts/components/dropdown/internals/Context.ts
@@ -1,5 +1,4 @@
-import type { Throttler } from '@ephox/katamari';
-import { createContext, useContext, type MouseEvent } from 'react';
+import { createContext, useContext } from 'react';
 
 export interface DropdownState {
   readonly triggerRef: React.MutableRefObject<HTMLElement | undefined>;
@@ -9,7 +8,6 @@ export interface DropdownState {
   // margin/gap between the trigger button and anchored container
   readonly gap: number;
   readonly triggerEvents: Array<'click' | 'hover' | 'arrows'>;
-  readonly debouncedHideHoverablePopover: Throttler.Throttler<[e: MouseEvent]>;
   readonly isOpen: boolean;
   readonly setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
@@ -1,6 +1,6 @@
 import { Optional, Type } from '@ephox/katamari';
 import { Focus, SelectorFind, SugarElement } from '@ephox/sugar';
-import { forwardRef, useEffect, useRef, type MutableRefObject, type PropsWithChildren } from 'react';
+import { forwardRef, useEffect, useRef, useState, type MutableRefObject, type PropsWithChildren } from 'react';
 
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
 import * as Bem from '../../utils/Bem';
@@ -8,6 +8,7 @@ import * as Bem from '../../utils/Bem';
 import { Item } from './components/Item';
 import { SubmenuItem } from './components/SubmenuItem';
 import { ToggleItem } from './components/ToggleItem';
+import { MenuContext } from './internals/Context';
 
 const ENABLED_ITEM_SELECTOR = `${Bem.elementSelector('tox-collection', 'item')}:not([aria-disabled="true"])`;
 
@@ -19,6 +20,7 @@ const focusFirstEnabledMenuItem = (container: Element | null): void =>
 const Root = forwardRef<HTMLDivElement, PropsWithChildren<unknown>>(({ children }, ref) => {
 
   const internalRef: MutableRefObject<HTMLDivElement | null> = useRef<HTMLDivElement>(null);
+  const [ activeItemId, setActiveItemId ] = useState<string | null>(null);
 
   KeyboardNavigationHooks.useFlowKeyNavigation({
     containerRef: internalRef,
@@ -43,11 +45,13 @@ const Root = forwardRef<HTMLDivElement, PropsWithChildren<unknown>>(({ children 
   };
 
   return (
-    <div ref={refCb} role='menu' className={[ Bem.block('tox-menu'), Bem.block('tox-collection', { list: true }) ].join(' ')}>
-      <div className={Bem.element('tox-collection', 'group')}>
-        {children}
+    <MenuContext.Provider value={{ activeItemId, setActiveItemId }}>
+      <div ref={refCb} role='menu' className={[ Bem.block('tox-menu'), Bem.block('tox-collection', { list: true }) ].join(' ')}>
+        <div className={Bem.element('tox-collection', 'group')}>
+          {children}
+        </div>
       </div>
-    </div>
+    </MenuContext.Provider>
   );
 });
 

--- a/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/Item.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import * as Bem from '../../../utils/Bem';
 import { Icon } from '../../icon/Icon';
+import { useMenu } from '../internals/Context';
 import type { CommonMenuItemInstanceApi, MenuItemProps } from '../internals/Types';
 
 export const Item = forwardRef<HTMLDivElement, MenuItemProps>(({ enabled = true, onSetup, icon, shortcut, onAction, children }, ref) => {
@@ -35,6 +36,8 @@ export const Item = forwardRef<HTMLDivElement, MenuItemProps>(({ enabled = true,
     }
   }, [ onSetup, api ]);
 
+  const { setActiveItemId } = useMenu();
+
   const itemIcon = Type.isString(icon)
     ? <Icon icon={icon} />
     : icon;
@@ -46,7 +49,10 @@ export const Item = forwardRef<HTMLDivElement, MenuItemProps>(({ enabled = true,
       role='menuitem'
       aria-haspopup={false}
       aria-disabled={!state.enabled}
-      onFocus={() => setState({ ...state, focused: true })}
+      onFocus={() => {
+        setState({ ...state, focused: true });
+        setActiveItemId(id);
+      }}
       onPointerMove={(e) => {
         if (state.enabled) {
           e.currentTarget.focus();

--- a/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/SubmenuItem.tsx
@@ -1,37 +1,21 @@
-import { Fun, Optional, Optionals, Type } from '@ephox/katamari';
-import { Compare, SelectorFind, SugarElement } from '@ephox/sugar';
-import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Fun, Type } from '@ephox/katamari';
+import { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import * as Bem from '../../../utils/Bem';
 import * as Dropdown from '../../dropdown/Dropdown';
 import { Icon } from '../../icon/Icon';
+import { useMenu } from '../internals/Context';
 import type { CommonMenuItemInstanceApi, SubmenuProps } from '../internals/Types';
-
-const isSiblingMenuItemInSameGroup = (relatedTarget: Element | null, currentTarget: Element): boolean => {
-  const groupSelector = Bem.elementSelector('tox-collection', 'group');
-  const getGroup = (el: Element) => SelectorFind.closest(SugarElement.fromDom(el), groupSelector);
-
-  return Optional.from(relatedTarget).exists((target) =>
-    Optionals.equals(getGroup(currentTarget), getGroup(target), Compare.eq)
-  );
-};
-
-const isMenuItemOutsideContainer = (relatedTarget: Element | null, container: Element): boolean => {
-  return Optional.from(relatedTarget).exists((target) => {
-    const targetElement = SugarElement.fromDom(target);
-    return !Compare.contains(SugarElement.fromDom(container), targetElement);
-  });
-};
 
 export const SubmenuItem = forwardRef<HTMLDivElement, SubmenuProps>(({ enabled = true, icon, onSetup, children, submenusSide = 'right', submenuContent }, ref) => {
   const [ state, setState ] = useState({
     enabled,
     focused: false,
-    isSubmenuOpen: false,
-    focusMovedToOtherMenuItem: false,
+    isActive: false,
   });
   const id = useId();
   const stateRef = useRef(state);
+  const { activeItemId, setActiveItemId } = useMenu();
 
   useEffect(() => {
     stateRef.current = state;
@@ -64,16 +48,17 @@ export const SubmenuItem = forwardRef<HTMLDivElement, SubmenuProps>(({ enabled =
     }
   }, [ state.enabled ]);
 
+  useEffect(() => {
+    const isActive = activeItemId === id;
+    setState((prev) => ({ ...prev, isActive }));
+    if (!isActive && submenuContentRef.current?.matches(':popover-open')) {
+      submenuContentRef.current.hidePopover();
+    }
+  }, [ activeItemId, id ]);
+
   const itemIcon = Type.isString(icon)
     ? <Icon icon={icon} />
     : icon;
-
-  const handleOpenChange = useCallback((isOpen: boolean) => {
-    setState((prev) => ({
-      ...prev,
-      isSubmenuOpen: isOpen
-    }));
-  }, []);
 
   return (
     <Dropdown.Root
@@ -90,22 +75,18 @@ export const SubmenuItem = forwardRef<HTMLDivElement, SubmenuProps>(({ enabled =
           role='menuitem'
           aria-haspopup={'true'}
           aria-disabled={!state.enabled}
-          onFocus={() => setState((prev) => ({ ...prev, focused: true, focusMovedToOtherMenuItem: false }))}
+          onFocus={() => {
+            setState((prev) => ({ ...prev, focused: true }));
+            setActiveItemId(id);
+          }}
           onPointerMove={(e) => {
             if (state.enabled) {
               e.currentTarget.focus();
             }
           }}
-          onBlur={(e) => {
-            const relatedTarget = e.relatedTarget;
-            setState((prev) => ({
-              ...prev,
-              focused: false,
-              focusMovedToOtherMenuItem: isSiblingMenuItemInSameGroup(relatedTarget, e.target)
-            }));
-          }}
+          onBlur={() => setState((prev) => ({ ...prev, focused: false }))}
           className={Bem.element('tox-collection', 'item', {
-            'active': state.focused || (state.isSubmenuOpen && !state.focusMovedToOtherMenuItem),
+            'active': state.focused || state.isActive,
             'state-disabled': !state.enabled,
           })}
         >
@@ -116,17 +97,8 @@ export const SubmenuItem = forwardRef<HTMLDivElement, SubmenuProps>(({ enabled =
           </div>
         </div>
       </Dropdown.Trigger>
-      <Dropdown.Content ref={submenuContentRef} onOpenChange={handleOpenChange}>
-        <div
-          onBlur={(e) => {
-            const relatedTarget = e.relatedTarget;
-            if (isMenuItemOutsideContainer(relatedTarget, e.target)) {
-              setState((prev) => ({ ...prev, focusMovedToOtherMenuItem: true }));
-            }
-          }}
-        >
-          {submenuContent}
-        </div>
+      <Dropdown.Content ref={submenuContentRef}>
+        {submenuContent}
       </Dropdown.Content>
     </Dropdown.Root>
   );

--- a/modules/oxide-components/src/main/ts/components/menu/components/ToggleItem.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/ToggleItem.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import * as Bem from '../../../utils/Bem';
 import { Icon } from '../../icon/Icon';
+import { useMenu } from '../internals/Context';
 import type { ToggleMenuItemInstanceApi, ToggleMenuItemProps } from '../internals/Types';
 
 export const ToggleItem = forwardRef<HTMLDivElement, ToggleMenuItemProps>(({ enabled = true, onSetup, icon, active = false, shortcut, onAction, children }, ref) => {
@@ -41,6 +42,8 @@ export const ToggleItem = forwardRef<HTMLDivElement, ToggleMenuItemProps>(({ ena
     return Fun.noop;
   }, [ onSetup, api ]);
 
+  const { setActiveItemId } = useMenu();
+
   const itemIcon = Type.isString(icon)
     ? <Icon icon={icon} />
     : icon;
@@ -53,7 +56,10 @@ export const ToggleItem = forwardRef<HTMLDivElement, ToggleMenuItemProps>(({ ena
       aria-haspopup={false}
       aria-disabled={!state.enabled}
       aria-checked={state.active}
-      onFocus={() => setState({ ...state, focused: true })}
+      onFocus={() => {
+        setState({ ...state, focused: true });
+        setActiveItemId(id);
+      }}
       onPointerMove={(e) => {
         if (state.enabled) {
           e.currentTarget.focus();

--- a/modules/oxide-components/src/main/ts/components/menu/internals/Context.ts
+++ b/modules/oxide-components/src/main/ts/components/menu/internals/Context.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+export interface MenuState {
+  readonly activeItemId: string | null;
+  readonly setActiveItemId: (id: string | null) => void;
+}
+
+const MenuContext = createContext<MenuState | null>(null);
+
+const useMenu = (): MenuState => {
+  const context = useContext(MenuContext);
+  if (context === null) {
+    throw new Error('Menu compound components must be rendered within the Menu component');
+  }
+  return context;
+};
+
+export { useMenu, MenuContext };

--- a/modules/oxide-components/src/test/ts/browser/components/SubmenuItem.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/SubmenuItem.spec.tsx
@@ -299,4 +299,40 @@ describe('browser.SubmenuItemTest', () => {
       expect(getByText('Nested Item').query()).toBeNull();
     }
   });
+
+  it('Should keep submenu open while item is active and close when moving to sibling', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.SubmenuItem
+              submenuContent={
+                <Menu.Root>
+                  <Menu.Item onAction={vi.fn()}>Nested Item</Menu.Item>
+                </Menu.Root>
+              }
+            >
+              Submenu
+            </Menu.SubmenuItem>
+            <Menu.Item onAction={vi.fn()}>Sibling Item</Menu.Item>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { getByText } = render(<TestComponent />, { wrapper });
+    await waitForElementText(getByText, 'Submenu');
+
+    await userEvent.hover(getByText('Submenu'));
+    await waitForElementText(getByText, 'Nested Item');
+    expect(getByText('Nested Item').element()).toBeVisible();
+
+    await userEvent.hover(document.body);
+
+    // Poll to ensure submenu remains visible after debounce timers
+    await expect.poll(() => getByText('Nested Item').element(), { timeout: 450 }).toBeVisible();
+
+    await userEvent.hover(getByText('Sibling Item'));
+    await expect.poll(() => getByText('Nested Item').query()).toBeNull();
+  });
 });

--- a/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
+++ b/modules/oxide-components/src/test/ts/browser/components/__snapshots__/Menu.spec.tsx.snap
@@ -366,98 +366,96 @@ exports[`browser.MenuTest > Should be able to open submenus > 2. After opening s
           popover="auto"
           style="inset-inline: 8px; position-area: span-block-end inline-end;"
         >
-          <div>
+          <div
+            class="tox-menu tox-collection tox-collection--list"
+            role="menu"
+          >
             <div
-              class="tox-menu tox-collection tox-collection--list"
-              role="menu"
+              class="tox-collection__group"
             >
               <div
-                class="tox-collection__group"
+                aria-disabled="false"
+                aria-haspopup="false"
+                class="tox-collection__item tox-collection__item--active"
+                id=":r3:"
+                role="menuitem"
+                tabindex="-1"
               >
                 <div
-                  aria-disabled="false"
-                  aria-haspopup="false"
-                  class="tox-collection__item tox-collection__item--active"
-                  id=":r3:"
-                  role="menuitem"
-                  tabindex="-1"
+                  class="tox-collection__item-label"
                 >
-                  <div
-                    class="tox-collection__item-label"
-                  >
-                    Nested menu item 1
-                  </div>
+                  Nested menu item 1
+                </div>
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-haspopup="false"
+                class="tox-collection__item tox-collection__item--state-disabled"
+                id=":r4:"
+                role="menuitemcheckbox"
+                tabindex="-1"
+              >
+                <div
+                  class="tox-collection__item-label"
+                >
+                  Nested menu item 2
                 </div>
                 <div
-                  aria-checked="false"
-                  aria-disabled="true"
-                  aria-haspopup="false"
-                  class="tox-collection__item tox-collection__item--state-disabled"
-                  id=":r4:"
-                  role="menuitemcheckbox"
-                  tabindex="-1"
+                  class="tox-collection__item-checkmark"
                 >
-                  <div
-                    class="tox-collection__item-label"
+                  <span
+                    class="tox-icon"
                   >
-                    Nested menu item 2
-                  </div>
-                  <div
-                    class="tox-collection__item-checkmark"
-                  >
-                    <span
-                      class="tox-icon"
-                    >
-                      <!--?xml version="1.0" encoding="UTF-8"?-->
-                      
+                    <!--?xml version="1.0" encoding="UTF-8"?-->
+                    
 
-                      <svg
-                        height="24px"
-                        version="1.1"
-                        viewBox="0 0 24 24"
-                        width="24px"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                    <svg
+                      height="24px"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      
+    
+                      <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+                      
+    
+                      <title>
+                        icon-checkmark
+                      </title>
+                      
+    
+                      <desc>
+                        Created with Sketch.
+                      </desc>
+                      
+    
+                      <defs />
+                      
+    
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                        stroke="none"
+                        stroke-width="1"
                       >
                         
-    
-                        <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-                        
-    
-                        <title>
-                          icon-checkmark
-                        </title>
-                        
-    
-                        <desc>
-                          Created with Sketch.
-                        </desc>
-                        
-    
-                        <defs />
-                        
-    
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                          stroke="none"
-                          stroke-width="1"
-                        >
-                          
         
-                          <path
-                            d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
-                            fill="#000000"
-                            fill-rule="nonzero"
-                          />
-                          
-    
-                        </g>
+                        <path
+                          d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
+                          fill="#000000"
+                          fill-rule="nonzero"
+                        />
                         
+    
+                      </g>
+                      
 
-                      </svg>
-                    </span>
-                  </div>
+                    </svg>
+                  </span>
                 </div>
               </div>
             </div>
@@ -821,98 +819,96 @@ exports[`browser.MenuTest > Should be able to render using MenuRenderer > 2. Aft
           popover="auto"
           style="inset-inline: 8px; position-area: span-block-end inline-end;"
         >
-          <div>
+          <div
+            class="tox-menu tox-collection tox-collection--list"
+            role="menu"
+          >
             <div
-              class="tox-menu tox-collection tox-collection--list"
-              role="menu"
+              class="tox-collection__group"
             >
               <div
-                class="tox-collection__group"
+                aria-disabled="false"
+                aria-haspopup="false"
+                class="tox-collection__item"
+                id=":r8:"
+                role="menuitem"
+                tabindex="-1"
               >
                 <div
-                  aria-disabled="false"
-                  aria-haspopup="false"
-                  class="tox-collection__item"
-                  id=":r8:"
-                  role="menuitem"
-                  tabindex="-1"
+                  class="tox-collection__item-label"
                 >
-                  <div
-                    class="tox-collection__item-label"
-                  >
-                    Nested menu item 1
-                  </div>
+                  Nested menu item 1
+                </div>
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="false"
+                aria-haspopup="false"
+                class="tox-collection__item"
+                id=":r9:"
+                role="menuitemcheckbox"
+                tabindex="-1"
+              >
+                <div
+                  class="tox-collection__item-label"
+                >
+                  Nested menu item 2
                 </div>
                 <div
-                  aria-checked="false"
-                  aria-disabled="false"
-                  aria-haspopup="false"
-                  class="tox-collection__item"
-                  id=":r9:"
-                  role="menuitemcheckbox"
-                  tabindex="-1"
+                  class="tox-collection__item-checkmark"
                 >
-                  <div
-                    class="tox-collection__item-label"
+                  <span
+                    class="tox-icon"
                   >
-                    Nested menu item 2
-                  </div>
-                  <div
-                    class="tox-collection__item-checkmark"
-                  >
-                    <span
-                      class="tox-icon"
-                    >
-                      <!--?xml version="1.0" encoding="UTF-8"?-->
-                      
+                    <!--?xml version="1.0" encoding="UTF-8"?-->
+                    
 
-                      <svg
-                        height="24px"
-                        version="1.1"
-                        viewBox="0 0 24 24"
-                        width="24px"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                    <svg
+                      height="24px"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                      
+    
+                      <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+                      
+    
+                      <title>
+                        icon-checkmark
+                      </title>
+                      
+    
+                      <desc>
+                        Created with Sketch.
+                      </desc>
+                      
+    
+                      <defs />
+                      
+    
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                        stroke="none"
+                        stroke-width="1"
                       >
                         
-    
-                        <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-                        
-    
-                        <title>
-                          icon-checkmark
-                        </title>
-                        
-    
-                        <desc>
-                          Created with Sketch.
-                        </desc>
-                        
-    
-                        <defs />
-                        
-    
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                          stroke="none"
-                          stroke-width="1"
-                        >
-                          
         
-                          <path
-                            d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
-                            fill="#000000"
-                            fill-rule="nonzero"
-                          />
-                          
-    
-                        </g>
+                        <path
+                          d="M18.1679497,5.4452998 C18.4743022,4.98577112 19.0951715,4.86159725 19.5547002,5.16794971 C20.0142289,5.47430216 20.1384028,6.09517151 19.8320503,6.5547002 L11.8320503,18.5547002 C11.4831227,19.0780915 10.7433669,19.1531818 10.2963845,18.7105809 L5.29919894,13.7623796 C4.90675595,13.3737835 4.90363744,12.7406262 5.29223356,12.3481832 C5.68082968,11.9557402 6.31398698,11.9526217 6.70642997,12.3412178 L10.8411868,16.4354442 L18.1679497,5.4452998 Z"
+                          fill="#000000"
+                          fill-rule="nonzero"
+                        />
                         
+    
+                      </g>
+                      
 
-                      </svg>
-                    </span>
-                  </div>
+                    </svg>
+                  </span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Added `keepOpen` prop to Dropdown component to suppress debounced hover close behavior
- Introduced MenuContext to track active menu item state across the menu hierarchy
- Modified SubmenuItem to use active item tracking instead of complex blur/focus logic for submenu visibility
- Updated all menu item components (Item, SubmenuItem, ToggleItem) to set active item ID on focus
- Simplified SubmenuItem state management by removing focus tracking and using context-based active state
- Added test coverage for submenu persistence behavior when item remains active

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Menu now centralizes active-item tracking for more consistent focus, highlighting, and submenu interactions; menu items register as active when focused to improve navigation.
- **Behavior Changes**
  - Dropdown hover simplified: show-on-hover still opens, but delayed/hysteresis-style hide on mouse leave has been removed.
- **Tests**
  - Added a browser test verifying submenu visibility and closure when moving between items.
- **Documentation**
  - Story updated to clarify hover opens on enter (no leave-based close) and arrow-key open behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->