### PR TITLE
TINY-13949: fix focus lost on tag delete

### DIFF
--- a/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
+++ b/modules/oxide-components/src/main/ts/bespoke/tinymceai/tag/Tag.tsx
@@ -48,7 +48,7 @@ export const Tag = forwardRef<HTMLDivElement | HTMLAnchorElement, TagProps>((pro
   const focusable = Type.isNullable(focusableProp) || closeable ? true : props.focusable;
   const sharedAttrs = {
     className: Bem.block('tox-tag'),
-    onKeyUp: (e: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>) => {
+    onKeyDown: (e: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>) => {
       if (closeable && [ 'Backspace', 'Delete' ].includes(e.key) && !disabled) {
         props.onClose();
       }

--- a/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
+++ b/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
@@ -1,6 +1,6 @@
 import { Fun } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
-import { useEffect, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
 
 import * as EscapingType from './keyboard/escaping/EscapingType';
 import * as ExecutingType from './keyboard/execution/ExecutionType';
@@ -28,17 +28,28 @@ const bindEvents = (container: HTMLElement, handlers: KeyingType.Handlers) => {
 
 export interface TabKeyingProps extends BaseProps, TabbingType.TabbingConfig { }
 
-export const useTabKeyNavigation = (props: TabKeyingProps): void => {
+export interface TabKeyNavigationApi {
+  readonly goBackwards: () => void;
+}
+
+export const useTabKeyNavigation = (props: TabKeyingProps): TabKeyNavigationApi => {
+  const goBackwardsRef = useRef<() => void>(Fun.noop);
+
   useEffect(() => {
     const { containerRef } = props;
 
     if (containerRef.current) {
       const handlers = TabbingType.create(SugarElement.fromDom(containerRef.current), props);
+      goBackwardsRef.current = handlers.goBackwards;
       return bindEvents(containerRef.current, handlers);
     } else {
+      goBackwardsRef.current = Fun.noop;
       return Fun.noop;
     }
   }, [ props ]);
+
+  const goBackwardsCallback = useCallback(() => goBackwardsRef.current(), []);
+  return { goBackwards: goBackwardsCallback };
 };
 
 export interface FlowKeyingProps extends BaseProps, FlowType.FlowConfig { }

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/Keys.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/Keys.ts
@@ -19,6 +19,8 @@ const RIGHT: ReadonlyArray<Key> = [{ code: 'ArrowRight', key: 'ArrowRight', whic
 const DOWN: ReadonlyArray<Key> = [{ code: 'ArrowDown', key: 'ArrowDown', which: 40 }];
 const SPACE: ReadonlyArray<Key> = [{ code: 'Space', key: ' ', which: 32 }];
 const ESCAPE: ReadonlyArray<Key> = [{ code: 'Escape', key: 'Escape', which: 27 }];
+const BACKSPACE: ReadonlyArray<Key> = [{ code: 'Backspace', key: 'Backspace', which: 8 }];
+const DELETE: ReadonlyArray<Key> = [{ code: 'Delete', key: 'Delete', which: 46 }];
 
 export {
   TAB,
@@ -30,5 +32,7 @@ export {
   RIGHT,
   DOWN,
   SPACE,
-  ESCAPE
+  ESCAPE,
+  BACKSPACE,
+  DELETE
 };

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/TabbingType.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/TabbingType.ts
@@ -3,7 +3,8 @@ import { Compare, Height, SelectorFilter, SelectorFind, type SugarElement, Trave
 
 import * as ArrNavigation from '../navigation/ArrNavigation';
 
-import type { GeneralKeyingConfig } from './KeyingModeTypes';
+import * as FocusManagers from './FocusManagers';
+import { FocusInsideModes, type GeneralKeyingConfig } from './KeyingModeTypes';
 import * as KeyingType from './KeyingType';
 import * as KeyMatch from './KeyMatch';
 import * as KeyRules from './KeyRules';
@@ -119,7 +120,11 @@ const getKeyupRules = Fun.constant([
   KeyRules.rule(KeyMatch.inSet(Keys.TAB), goFromPseudoTabstop),
 ]);
 
-const create = (source: SugarElement<HTMLElement>, config: TabbingConfig): KeyingType.Handlers => {
+export interface TabbingHandlers extends KeyingType.Handlers {
+  readonly goBackwards: () => void;
+}
+
+const create = (source: SugarElement<HTMLElement>, config: TabbingConfig): TabbingHandlers => {
   const partialConfig: Required<TabbingConfig> = {
     execute: Fun.constant(Optional.none()),
     escape: Fun.constant(Optional.none()),
@@ -131,12 +136,27 @@ const create = (source: SugarElement<HTMLElement>, config: TabbingConfig): Keyin
     ...config
   };
 
+  const fullConfig: FullTabbingConfig = {
+    ...partialConfig,
+    focusManager: FocusManagers.dom(),
+    focusInside: FocusInsideModes.OnFocusMode
+  };
+
   const keyingHandlers = KeyingType.typical<FullTabbingConfig>(partialConfig, getKeydownRules, getKeyupRules, () => Optionals.someIf(partialConfig.focusIn, focusIn));
 
   return {
     keydown: (event: KeyboardEvent) => keyingHandlers.handleKeydown(source, event),
     keyup: (event: KeyboardEvent) => keyingHandlers.handleKeyup(source, event),
-    focus: (event: FocusEvent) => keyingHandlers.handleFocus(source, event)
+    focus: (event: FocusEvent) => keyingHandlers.handleFocus(source, event),
+    goBackwards: () => {
+      const navigate = fullConfig.cyclic ? ArrNavigation.cyclePrev : ArrNavigation.tryPrev;
+      const tabstops = SelectorFilter.descendants<HTMLElement>(source, fullConfig.selector);
+      findCurrent(source, fullConfig).each((tabstop) => {
+        Arr.findIndex(tabstops, Fun.curry(Compare.eq, tabstop)).each((stopIndex) => {
+          goFromTabstop(source, tabstops, stopIndex, fullConfig, navigate);
+        });
+      });
+    }
   };
 };
 


### PR DESCRIPTION
Related Ticket: TINY-13949

Description of Changes:

- Changed Tag component keyboard handler from `onKeyUp` to `onKeyDown` for Backspace/Delete key handling
- Added `requestAnimationFrame` delay to tag removal to allow focus navigation to complete first
- Added BACKSPACE and DELETE key constants to the Keys module
- Enhanced TabbingType with `focusPreviousOnDelete` configuration option to enable automatic focus movement when delete keys are pressed on matching elements
- Modified keydown rules to conditionally include delete key handling based on the new configuration

Pre-checks:

- [x] ~~Changelog entry added~~ (in related PR)
- [x] Tests have been added (if applicable) (in related PR)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Closable tags can be dismissed with Backspace or Delete (now fires on key-down for more responsive keyboard interaction)
    - Added explicit Backspace/Delete keyboard recognition for navigation
    - Tab-key navigation API now exposes a stable "goBackwards" action to programmatically move focus backward for keyboard users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->