### PR TITLE
TINY-14157: reseve space for an icon button in chat history item

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -510,6 +510,7 @@
   .tox-ai-chat-history-list__item-actions {
     display: flex;
     align-items: center;
+    min-width: calc(24px + (var(--tox-private-pad-xs, @pad-xs) + 1px)* 2); // width of icon + padding and border width, to avoid layout shift when actions appear on hover
   }
 
   .tox-ai-chat-history-list__item-content-title {


### PR DESCRIPTION
Related Ticket: TINY-14157

Description of Changes:
* Added minimum width constraint to AI chat history item actions container to prevent layout shift when action buttons appear on hover

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI chat component layout stability by enforcing minimum horizontal space for action controls. This prevents visual jumps and inconsistent spacing when action buttons are conditionally shown (for example on hover), resulting in smoother interactions and a more consistent chat history appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->