### PR TITLE
TINY-14242: Fix `ContextToolbar` tab cycle and initial focus with disabled controls

### DIFF
--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.stories.tsx
@@ -469,3 +469,67 @@ export const ScrollAnchored: Story = {
     );
   },
 };
+
+export const DisabledControls: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates keyboard navigation with disabled controls. On open, focus moves to the first enabled control. Tab moves between groups using the first enabled control in each group and skips groups with no enabled controls. Arrow keys move within the current group.',
+      },
+    },
+  },
+  render: () => {
+    const anchorRef = useRef<HTMLDivElement>(null);
+    const [ showToolbar, setShowToolbar ] = useState(true);
+
+    return (
+      <div className='tox' style={{ position: 'relative' }}>
+        <div
+          ref={anchorRef}
+          style={{
+            backgroundColor: 'lightcoral',
+            padding: '10px',
+            cursor: 'pointer',
+            display: 'inline-block'
+          }}
+        >
+          Anchor element
+        </div>
+
+        <button onClick={() => setShowToolbar(!showToolbar)} style={{ marginLeft: '10px' }}>
+          {showToolbar ? 'Hide' : 'Show'} Toolbar
+        </button>
+
+        {showToolbar && (
+          <ContextToolbar.Root
+            anchorRef={anchorRef}
+            persistent={true}
+          >
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <Button>Accept A</Button>
+                <Button>Accept B</Button>
+                <Button disabled>Reject (Disabled)</Button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <Button disabled>Group 2 Action (Disabled)</Button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <Button disabled>Group 3 Action (Disabled)</Button>
+              </ContextToolbar.Group>
+
+              <ContextToolbar.Group>
+                <Button>Final Group A</Button>
+                <Button>Final Group B</Button>
+                <Button>Final Group C</Button>
+                <Button>Final Group D</Button>
+                <Button>Final Group E</Button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        )}
+      </div>
+    );
+  },
+};

--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
@@ -1,8 +1,21 @@
 import { Arr, Id, Optional, Type } from '@ephox/katamari';
-import { Class, Css, Focus, SelectorFilter, SelectorFind, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
+import {
+  Attribute,
+  Compare,
+  Css,
+  Focus,
+  PredicateFind,
+  SelectorFind,
+  Selectors,
+  SugarElement,
+  SugarNode,
+  Traverse
+} from '@ephox/sugar';
 import {
   createContext,
+  forwardRef,
   useContext,
+  useImperativeHandle,
   useRef,
   useState,
   useMemo,
@@ -14,7 +27,7 @@ import {
 
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
 
-import type { ContextToolbarContextValue, ContextToolbarProps, GroupProps, ToolbarProps, TriggerProps } from './ContextToolbarTypes';
+import type { ContextToolbarContextValue, ContextToolbarProps, GroupProps, ToolbarHandle, ToolbarProps, TriggerProps } from './ContextToolbarTypes';
 
 const ContextToolbarContext = createContext<ContextToolbarContextValue | null>(null);
 
@@ -27,6 +40,32 @@ const useContextToolbarContext = () => {
 };
 
 const defaultToolbarGap = '6px';
+const toolbarControlSelector = 'button, [role="button"], .tox-button';
+const enabledToolbarControlSelector = [
+  'button:not([disabled]):not([aria-disabled="true"])',
+  '[role="button"]:not([disabled]):not([aria-disabled="true"])',
+  '.tox-button:not([disabled]):not([aria-disabled="true"])'
+].join(', ');
+
+const isFocusableControl = (elem: SugarElement<Node>): elem is SugarElement<HTMLElement> => {
+  if (!SugarNode.isHTMLElement(elem)) {
+    return false;
+  }
+
+  if (!Selectors.is(elem, toolbarControlSelector)) {
+    return false;
+  }
+
+  return !Attribute.has(elem, 'disabled') && Attribute.get(elem, 'aria-disabled') !== 'true' && elem.dom.tabIndex >= 0;
+};
+
+const findFirstFocusable = (container: SugarElement<HTMLElement>): Optional<SugarElement<HTMLElement>> =>
+  PredicateFind.descendant(container, isFocusableControl);
+
+const focusFirstEnabledControl = (toolbar: HTMLElement) => {
+  const sugarToolbar = SugarElement.fromDom(toolbar);
+  findFirstFocusable(sugarToolbar).fold(() => Focus.focus(sugarToolbar), Focus.focus);
+};
 
 const Root: FC<ContextToolbarProps> = ({
   children,
@@ -136,11 +175,11 @@ const Trigger: FC<TriggerProps> = ({
   );
 };
 
-const Toolbar: FC<ToolbarProps> = ({
+const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(({
   children,
   onMouseDown,
   onEscape: passedOnEscape
-}) => {
+}, ref) => {
   const {
     isOpen,
     toolbarRef,
@@ -151,34 +190,31 @@ const Toolbar: FC<ToolbarProps> = ({
     usePopover
   } = useContextToolbarContext();
 
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      Optional.from(toolbarRef.current).each(focusFirstEnabledControl);
+    }
+  }), [ toolbarRef ]);
+
   useEffect(() => {
-    const element = toolbarRef.current;
-    if (Type.isNullable(element)) {
+    const toolbar = toolbarRef.current;
+    if (Type.isNullable(toolbar)) {
       return;
     }
     if (!isOpen) {
       if (usePopover) {
-        element.hidePopover();
+        toolbar.hidePopover();
       }
       return;
     }
 
     if (usePopover) {
-      element.showPopover();
+      toolbar.showPopover();
     }
     // Defer focus using queueMicrotask to ensure it runs after
     // the Popover API's internal focus management is complete
     window.queueMicrotask(() => {
-      const sugarElement = SugarElement.fromDom(element);
-      const firstGroup = SelectorFind.descendant(sugarElement, '.tox-toolbar__group');
-      const firstButton = firstGroup.bind((group) =>
-        SelectorFind.descendant(group, 'button, [role="button"]')
-      );
-
-      firstButton.fold(
-        () => element.focus(), // Falls back to container if no button found
-        (button) => Focus.focus(button as SugarElement<HTMLElement>) // Focus first button
-      );
+      focusFirstEnabledControl(toolbar);
     });
   }, [ usePopover, isOpen, toolbarRef ]);
 
@@ -203,15 +239,11 @@ const Toolbar: FC<ToolbarProps> = ({
 
   KeyboardNavigationHooks.useTabKeyNavigation({
     containerRef: toolbarRef,
-    selector: 'button, .tox-button',
+    selector: toolbarControlSelector,
     useTabstopAt: (elem) => {
-      // Only stop at the first button in each group
-      return Traverse.parent(elem)
-        .filter((parent) => Class.has(parent, 'tox-toolbar__group'))
-        .map((parent) => {
-          const buttons = SelectorFilter.descendants(parent, 'button, .tox-button');
-          return buttons.length > 0 && buttons[0].dom === elem.dom;
-        })
+      return SelectorFind.closest(elem, '.tox-toolbar__group')
+        .map((group) => PredicateFind.descendant(group, isFocusableControl)
+          .exists((firstInGroup) => Compare.eq(firstInGroup, elem)))
         .getOr(true);
     },
     cyclic: true
@@ -295,14 +327,14 @@ const Toolbar: FC<ToolbarProps> = ({
       </div>
     </div>
   );
-};
+});
 
 const Group: FC<GroupProps> = ({ children }) => {
   const groupRef = useRef<HTMLDivElement>(null);
 
   KeyboardNavigationHooks.useFlowKeyNavigation({
     containerRef: groupRef,
-    selector: 'button, .tox-button',
+    selector: enabledToolbarControlSelector,
     execute: (focused) => {
       focused.dom.click();
       return Optional.some(true);

--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
@@ -40,31 +40,35 @@ const useContextToolbarContext = () => {
 };
 
 const defaultToolbarGap = '6px';
-const toolbarControlSelector = 'button, [role="button"], .tox-button';
-const enabledToolbarControlSelector = [
-  'button:not([disabled]):not([aria-disabled="true"])',
-  '[role="button"]:not([disabled]):not([aria-disabled="true"])',
-  '.tox-button:not([disabled]):not([aria-disabled="true"])'
-].join(', ');
+const toolbarControlSelectors = [ 'button', '[role="button"]', '.tox-button' ];
+const toolbarControlSelector = toolbarControlSelectors.join(', ');
+const enabledToolbarControlSelector =
+  Arr.map(toolbarControlSelectors,
+    (selector) => `${selector}:not([disabled]):not([aria-disabled="true"])`).join(', ');
 
-const isFocusableControl = (elem: SugarElement<Node>): elem is SugarElement<HTMLElement> => {
-  if (!SugarNode.isHTMLElement(elem)) {
-    return false;
-  }
+const isEnabledAndTabbable = (elem: SugarElement<HTMLElement>): boolean =>
+  !Attribute.has(elem, 'disabled')
+  && Attribute.get(elem, 'aria-disabled') !== 'true'
+  && elem.dom.tabIndex >= 0;
 
-  if (!Selectors.is(elem, toolbarControlSelector)) {
-    return false;
-  }
+const focusablePredicate = (selector: string) => (elem: SugarElement<Node>): elem is SugarElement<HTMLElement> =>
+  SugarNode.isHTMLElement(elem)
+  && Selectors.is(elem, selector)
+  && isEnabledAndTabbable(elem);
 
-  return !Attribute.has(elem, 'disabled') && Attribute.get(elem, 'aria-disabled') !== 'true' && elem.dom.tabIndex >= 0;
-};
+const isFocusableControl = focusablePredicate(toolbarControlSelector);
 
-const findFirstFocusable = (container: SugarElement<HTMLElement>): Optional<SugarElement<HTMLElement>> =>
-  PredicateFind.descendant(container, isFocusableControl);
+const isFirstFocusableInClosestAncestor = (
+  elem: SugarElement<HTMLElement>,
+  ancestorSelector: string
+): boolean =>
+  SelectorFind.closest(elem, ancestorSelector).map((ancestor) =>
+    PredicateFind.descendant(ancestor, isFocusableControl).exists((firstMatch) => Compare.eq(firstMatch, elem))
+  ).getOr(true);
 
 const focusFirstEnabledControl = (toolbar: HTMLElement) => {
   const sugarToolbar = SugarElement.fromDom(toolbar);
-  findFirstFocusable(sugarToolbar).fold(() => Focus.focus(sugarToolbar), Focus.focus);
+  PredicateFind.descendant(sugarToolbar, isFocusableControl).fold(() => Focus.focus(sugarToolbar), Focus.focus);
 };
 
 const Root: FC<ContextToolbarProps> = ({
@@ -240,12 +244,7 @@ const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(({
   KeyboardNavigationHooks.useTabKeyNavigation({
     containerRef: toolbarRef,
     selector: toolbarControlSelector,
-    useTabstopAt: (elem) => {
-      return SelectorFind.closest(elem, '.tox-toolbar__group')
-        .map((group) => PredicateFind.descendant(group, isFocusableControl)
-          .exists((firstInGroup) => Compare.eq(firstInGroup, elem)))
-        .getOr(true);
-    },
+    useTabstopAt: (elem) => isFirstFocusableInClosestAncestor(elem, '.tox-toolbar__group'),
     cyclic: true
   });
 

--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbarTypes.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbarTypes.tsx
@@ -26,6 +26,10 @@ export interface ToolbarProps {
   readonly onEscape?: () => void;
 }
 
+export interface ToolbarHandle {
+  readonly focus: () => void;
+}
+
 export interface TriggerProps {
   readonly children: ReactNode;
   readonly onClick?: MouseEventHandler<HTMLDivElement>;

--- a/modules/oxide-components/src/test/ts/browser/components/ContextToolbar.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/ContextToolbar.spec.tsx
@@ -68,6 +68,7 @@ describe('browser.components.ContextToolbar', () => {
   it('TINY-13071: Should close toolbar on click outside when persistent={false}', async () => {
     const { getByTestId } = render(
       <Fragment>
+        <div data-testid="outside" style={{ height: 40, width: 40 }}>outside</div>
         <div className='tox' style={{ position: 'relative' }}>
           <ContextToolbar.Root persistent={false}>
             <ContextToolbar.Trigger>
@@ -92,8 +93,7 @@ describe('browser.components.ContextToolbar', () => {
     await expect.element(toolbar).toBeVisible();
 
     // Click outside
-    await page.elementLocator(document.body).click({ position: { x: 0, y: 0 }});
-
+    await getByTestId('outside').click();
     await expect.element(toolbar).not.toBeVisible();
   });
 
@@ -320,6 +320,12 @@ describe('browser.components.ContextToolbar', () => {
 
     await userEvent.keyboard('{Tab}');
     await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    await expect.element(button3).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    await expect.element(button1).toHaveFocus();
   });
 
   it('TINY-13066: Should navigate within group with arrow keys', async () => {
@@ -488,5 +494,199 @@ describe('browser.components.ContextToolbar', () => {
     // Verify clicking anchor doesn't close toolbar (visibility controlled externally via conditional rendering)
     await anchor.click();
     await expect.element(button).toBeVisible();
+  });
+
+  it('TINY-14242: Should focus the first non-disabled control when opening the toolbar', async () => {
+    const { getByTestId } = render(
+      <Fragment>
+        <div className='tox' style={{ position: 'relative' }}>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
+              <div data-testid={triggerTestId}>Click Me</div>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <button data-testid='button1' disabled>Button 1</button>
+                <button data-testid='button2'>Button 2</button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        </div>
+      </Fragment>,
+      { wrapper: Wrapper }
+    );
+
+    const trigger = getByTestId(triggerTestId);
+    await trigger.click();
+
+    const button1 = getByTestId('button2');
+    await expect.element(button1).toHaveFocus();
+  });
+
+  it('TINY-14242: Should focus the first non-disabled control across groups on open', async () => {
+    const { getByTestId } = render(
+      <Fragment>
+        <div className='tox' style={{ position: 'relative' }}>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
+              <div data-testid={triggerTestId}>Click Me</div>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <button data-testid='button1' disabled>Button 1</button>
+                <button data-testid='button2' disabled>Button 2</button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <button data-testid='button3'>Button 3</button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        </div>
+      </Fragment>,
+      { wrapper: Wrapper }
+    );
+
+    const trigger = getByTestId(triggerTestId);
+    await trigger.click();
+
+    const button1 = getByTestId('button3');
+    await expect.element(button1).toHaveFocus();
+  });
+
+  it('TINY-14242: Should tab to the first non-disabled control in each group', async () => {
+    const { getByTestId } = render(
+      <Fragment>
+        <div className='tox' style={{ position: 'relative' }}>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
+              <div data-testid={triggerTestId}>Click Me</div>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <button data-testid='button1' disabled>Button 1</button>
+                <button data-testid='button2'>Button 2</button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <button data-testid='button3' disabled>Button 3</button>
+                <button data-testid='button4'>Button 4</button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        </div>
+      </Fragment>,
+      { wrapper: Wrapper }
+    );
+
+    const trigger = getByTestId(triggerTestId);
+    await trigger.click();
+
+    const button1 = getByTestId('button2');
+    await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{Tab}');
+    const button3 = getByTestId('button4');
+    await expect.element(button3).toHaveFocus();
+
+    await userEvent.keyboard('{Tab}');
+    await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    await expect.element(button3).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    await expect.element(button1).toHaveFocus();
+  });
+
+  it('TINY-14242: Should cycle with arrow keys and skip disabled controls in a group', async () => {
+    const { getByTestId } = render(
+      <Fragment>
+        <div className='tox' style={{ position: 'relative' }}>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
+              <div data-testid={triggerTestId}>Click Me</div>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <button data-testid='button1'>Button 1</button>
+                <button data-testid='button2'>Button 2</button>
+                <button data-testid='button3' disabled>Button 3</button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        </div>
+      </Fragment>,
+      { wrapper: Wrapper }
+    );
+
+    const trigger = getByTestId(triggerTestId);
+    await trigger.click();
+
+    const button1 = getByTestId('button1');
+    const button2 = getByTestId('button2');
+
+    await userEvent.keyboard('{Tab}');
+    await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowRight}');
+    await expect.element(button2).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowRight}');
+    await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect.element(button2).toHaveFocus();
+  });
+
+  it('TINY-14242: Should skip groups with no enabled controls when tabbing', async () => {
+    const { getByTestId } = render(
+      <Fragment>
+        <div className='tox' style={{ position: 'relative' }}>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
+              <div data-testid={triggerTestId}>Click Me</div>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <button data-testid='button1'>Button 1</button>
+                <button data-testid='button2'>Button 2</button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <button data-testid='button3' disabled>Button 3</button>
+                <button data-testid='button4' disabled>Button 4</button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <button data-testid='button5' disabled>Button 5</button>
+                <button data-testid='button6' disabled>Button 6</button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <button data-testid='button7'>Button 7</button>
+                <button data-testid='button8'>Button 8</button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        </div>
+      </Fragment>,
+      { wrapper: Wrapper }
+    );
+
+    const trigger = getByTestId(triggerTestId);
+    await trigger.click();
+
+    const button1 = getByTestId('button1');
+    const button7 = getByTestId('button7');
+
+    await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{Tab}');
+    await expect.element(button7).toHaveFocus();
+
+    await userEvent.keyboard('{Tab}');
+    await expect.element(button1).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    await expect.element(button7).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    await expect.element(button1).toHaveFocus();
   });
 });

--- a/modules/oxide-components/src/test/ts/browser/components/ContextToolbar.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/ContextToolbar.spec.tsx
@@ -553,6 +553,37 @@ describe('browser.components.ContextToolbar', () => {
     await expect.element(button1).toHaveFocus();
   });
 
+  it('TINY-14242: Should focus toolbar container when no enabled controls exist', async () => {
+    const { getByTestId, container } = render(
+      <Fragment>
+        <div className='tox' style={{ position: 'relative' }}>
+          <ContextToolbar.Root>
+            <ContextToolbar.Trigger>
+              <div data-testid={triggerTestId}>Click Me</div>
+            </ContextToolbar.Trigger>
+            <ContextToolbar.Toolbar>
+              <ContextToolbar.Group>
+                <button data-testid='button1' disabled>Button 1</button>
+                <button data-testid='button2' disabled>Button 2</button>
+              </ContextToolbar.Group>
+              <ContextToolbar.Group>
+                <button data-testid='button3' disabled>Button 3</button>
+              </ContextToolbar.Group>
+            </ContextToolbar.Toolbar>
+          </ContextToolbar.Root>
+        </div>
+      </Fragment>,
+      { wrapper: Wrapper }
+    );
+
+    const trigger = getByTestId(triggerTestId);
+    await trigger.click();
+
+    const toolbar = container.querySelector('.tox-context-toolbar');
+    expect(toolbar).toBeTruthy();
+    expect(toolbar).toHaveFocus();
+  });
+
   it('TINY-14242: Should tab to the first non-disabled control in each group', async () => {
     const { getByTestId } = render(
       <Fragment>

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-contexttoolbar--disabled-controls-desktop-chrome-linux-desktop-chrome-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-contexttoolbar--disabled-controls-desktop-chrome-linux-desktop-chrome-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b85b6c087e486a4fe9c48542754f599503b0120fc1c46fb28101a6840060f40
+size 25071

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-contexttoolbar--disabled-controls-desktop-firefox-linux-desktop-firefox-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-contexttoolbar--disabled-controls-desktop-firefox-linux-desktop-firefox-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0914924b643017803449705959b565fbb2ba413c209eb9d75a6216a5a638e4f1
+size 51892

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-contexttoolbar--disabled-controls-desktop-safari-linux-desktop-safari-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-contexttoolbar--disabled-controls-desktop-safari-linux-desktop-safari-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edd85f047aa84e28d24539c23c4e91347aedd186098fbe5388abce1d0bccda69
+size 29900


### PR DESCRIPTION
Related Ticket:  TINY-14242

Description of Changes:
* Fix initial focus on open could target a disabled button
* Fix Tab/shift+tab cycling could get stuck when leading buttons were disabled.
* Expose an imperative Toolbar `focus()` API so consumers can request correct initial focus without relying on internal button refs.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a story demonstrating keyboard navigation with disabled controls.
  * Toolbar exposes a public focus() handle accessible via ref.

* **Bug Fixes**
  * On open, focus moves to the first enabled control (or toolbar container if none).
  * Tab/Shift+Tab skip disabled controls and groups with no enabled controls.
  * Arrow keys cycle within groups while skipping disabled controls.

* **Tests**
  * Added accessibility-focused tests covering the above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->