### PR TITLE
TINY-11214: New `content_language` option to set default language of the editor  

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11214-2026-04-07.yaml
+++ b/.changes/unreleased/tinymce-TINY-11214-2026-04-07.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: New `content_language` option to set the `lang` attribute on the iframe's `html` element or the inline editor's target element.
+time: 2026-04-07T15:32:30.329934+10:00
+custom:
+    Issue: TINY-11214

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -92,6 +92,7 @@ interface BaseEditorOptions {
   content_css_cors?: boolean;
   content_security_policy?: string;
   content_style?: string;
+  content_language?: string;
   content_langs?: ContentLanguage[];
   contextmenu?: string | string[] | false;
   contextmenu_never_use_native?: boolean;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -312,6 +312,10 @@ const register = (editor: Editor): void => {
     processor: 'string'
   });
 
+  registerOption('content_language', {
+    processor: 'string'
+  });
+
   registerOption('content_css_cors', {
     processor: 'boolean',
     default: false
@@ -1032,6 +1036,7 @@ const shouldIndentUseMargin = option('indent_use_margin');
 const getIndentation = option('indentation');
 const getContentCss = option('content_css');
 const getContentStyle = option('content_style');
+const getContentLanguage = option('content_language');
 const getFontCss = option('font_css');
 const getDirectionality = option('directionality');
 const getInlineBoundarySelector = option('inline_boundaries_selector');
@@ -1157,6 +1162,7 @@ export {
   getIndentation,
   getContentCss,
   getContentStyle,
+  getContentLanguage,
   getDirectionality,
   getInlineBoundarySelector,
   getObjectResizing,

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -420,6 +420,11 @@ const contentBodyLoaded = (editor: Editor): void => {
     editor.contentWindow = window;
     editor.bodyElement = targetElm;
     editor.contentAreaContainer = targetElm;
+
+    const contentLanguage = Options.getContentLanguage(editor);
+    if (contentLanguage) {
+      DOM.setAttrib(targetElm, 'lang', contentLanguage);
+    }
   }
 
   // It will not steal focus while setting contentEditable

--- a/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitContentBody.ts
@@ -420,11 +420,12 @@ const contentBodyLoaded = (editor: Editor): void => {
     editor.contentWindow = window;
     editor.bodyElement = targetElm;
     editor.contentAreaContainer = targetElm;
+  }
 
-    const contentLanguage = Options.getContentLanguage(editor);
-    if (contentLanguage) {
-      DOM.setAttrib(targetElm, 'lang', contentLanguage);
-    }
+  const contentLanguage = Options.getContentLanguage(editor);
+  if (contentLanguage) {
+    const langTarget = editor.inline ? targetElm : doc.documentElement;
+    DOM.setAttrib(langTarget, 'lang', contentLanguage);
   }
 
   // It will not steal focus while setting contentEditable

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -37,9 +37,7 @@ const createIframeElement = (id: string, title: TranslatedString, customAttrs: {
 };
 
 const getIframeHtml = (editor: Editor) => {
-  const contentLanguage = Options.getContentLanguage(editor);
-  const langAttr = contentLanguage ? `lang="${contentLanguage}"` : '';
-  let iframeHTML = Options.getDocType(editor) + `<html ${langAttr}><head>`;
+  let iframeHTML = Options.getDocType(editor) + '<html><head>';
 
   // We only need to override paths if we have to
   // IE has a bug where it remove site absolute urls to relative ones if this is specified

--- a/modules/tinymce/src/core/main/ts/init/InitIframe.ts
+++ b/modules/tinymce/src/core/main/ts/init/InitIframe.ts
@@ -37,7 +37,9 @@ const createIframeElement = (id: string, title: TranslatedString, customAttrs: {
 };
 
 const getIframeHtml = (editor: Editor) => {
-  let iframeHTML = Options.getDocType(editor) + '<html><head>';
+  const contentLanguage = Options.getContentLanguage(editor);
+  const langAttr = contentLanguage ? `lang="${contentLanguage}"` : '';
+  let iframeHTML = Options.getDocType(editor) + `<html ${langAttr}><head>`;
 
   // We only need to override paths if we have to
   // IE has a bug where it remove site absolute urls to relative ones if this is specified

--- a/modules/tinymce/src/core/test/ts/browser/init/InitEditorContentLanguageTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/init/InitEditorContentLanguageTest.ts
@@ -1,0 +1,28 @@
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Attribute } from '@ephox/sugar';
+import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.init.InitEditorContentLanguageTest', () => {
+  Arr.each([
+    { type: 'iframe', settings: {}, getLangElement: TinyDom.documentElement },
+    { type: 'inline', settings: { inline: true }, getLangElement: TinyDom.targetElement }
+  ], (tester) => {
+    context(`${tester.type} editor`, () => {
+      const hook = TinyHooks.bddSetupLight<Editor>({
+        content_language: 'fr',
+        base_url: '/project/tinymce/js/tinymce',
+        ...tester.settings
+      }, []);
+
+      it('should set the lang attribute from content_language', () => {
+        const editor = hook.editor();
+        const langElement = tester.getLangElement(editor);
+        assert.equal(Attribute.get(langElement, 'lang'), 'fr');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-11214

Description of Changes:
* Add `content_language` option to specify the default language of the editor content.
* When set, the editor applies the `lang` attribute to the `<html>` element of the editor's iframe or the target element in inline mode. In the iframe, this helps meet the accessibility requirement to set a `lang` attribute on the `<html>` element of the document.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `content_language` configuration option. Use this to specify the language of your editor content. The language attribute will be applied to the editor's content element, supporting both iframe and inline editor modes for improved accessibility and localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->