### PR TITLE
TINY-13958: change diff content styles

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13958-2026-04-13.yaml
+++ b/.changes/unreleased/tinymce-TINY-13958-2026-04-13.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Improved
+body: Improved visual styling of inline diff highlights in Suggested Edits and TinyMCE AI plugin.
+time: 2026-04-13T15:25:57.905329+02:00
+custom:
+    Issue: TINY-13958

--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -7,7 +7,7 @@
 @tinymceai-removed-background-color: @removed-background-color;
 
 @tinymceai-selected-outline-color: @selected-outline-color;
-@tinymceai-selected-box-shadow: 0 -2px 0 0 @tinymceai-selected-outline-color inset, 0 -2px 0 0 @tinymceai-selected-outline-color;
+@tinymceai-selected-box-shadow: 0 2px 0 0 @tinymceai-selected-outline-color, 0 -2px 0 0 @tinymceai-selected-outline-color;
 
 @tinymceai-dim-overlay-color: fade(@color-black, 20%);
 
@@ -36,7 +36,8 @@
   cursor: pointer;
 }
 
-div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"] {
+div[tinymceai-data-pending-diff="true"],
+span[tinymceai-data-pending-diff="true"] {
   position: relative;
   z-index: 1;
   background: @color-white;
@@ -50,40 +51,70 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
 .tox-tinymceai__preview-body--show-preview {
   .tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
   .tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
-    border-bottom: 3px solid @color-tint;
     cursor: pointer;
+    background-position: bottom;
+    background-image: linear-gradient(
+      transparent calc(100% - 3px),
+      @color-tint calc(100% - 3px)
+    );
   }
 
-  .tox-tinymceai__annotation--added__selected,
-  .tox-tinymceai__annotation--modified__selected {
-    background-color: fade(@color-tint, 20%);
-    border-top: 3px solid @color-tint;
-    border-bottom: 3px solid @color-tint;
-    box-shadow: none;
-    text-decoration: none;
+  .tox-tinymceai__annotation--added.tox-tinymceai__annotation--added__selected,
+  .tox-tinymceai__annotation--modified.tox-tinymceai__annotation--modified__selected {
+    background-position: center;
+    background-size: 100% calc(1lh + 3px);
+    background-image: linear-gradient(
+      @color-tint 3px,
+      fade(@color-tint, 20%) 3px,
+      fade(@color-tint, 20%) calc(100% - 3px),
+      @color-tint calc(100% - 3px)
+    );
   }
 
   // TEMP: Show deleted content when its review card is selected.
   // Makes deletions visible and scrollable in preview mode.
   // TODO: Replace with a proper visual marker that doesn't reveal full deleted content.
   .tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
-    display: inline;
-    background-color: fade(@color-error, 20%);
-    border-top: 3px solid @color-error;
-    border-bottom: 3px solid @color-error;
-    box-shadow: none;
+    display: revert;
     text-decoration: line-through;
+    background-position: center;
+    background-size: 100% calc(1lh + 3px);
+    background-image: linear-gradient(
+      @color-error 3px,
+      fade(@color-error, 20%) 3px,
+      fade(@color-error, 20%) calc(100% - 3px),
+      @color-error calc(100% - 3px)
+    );
+  }
+
+  // Block elements should not have background size of 1lh, so selection is based on box-shadow
+  div, p, ul, ol, li, table, section, header, footer, h1, h2, h3, h4, h5, h6, figure, hr {
+    &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--added__selected,
+    &.tox-tinymceai__annotation--modified.tox-tinymceai__annotation--modified__selected {
+      background-image: none;
+      background-color: fade(@color-tint, 20%);
+      box-shadow: @tinymceai-selected-box-shadow;
+    }
+
+    // TODO: Replace with a proper visual marker that doesn't reveal full deleted content.
+    &.tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
+      background-image: none;
+      background-color: fade(@color-error, 20%);
+      box-shadow: @tinymceai-selected-box-shadow;
+    }
   }
 
   img, video, iframe {
     &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
     &.tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
+      background-image: none;
       outline: 0.25em solid fade(@color-tint, 20%);
       padding: 0.25em;
     }
 
     &.tox-tinymceai__annotation--added__selected,
     &.tox-tinymceai__annotation--modified__selected {
+      background-image: none;
       border: 0.25em solid fade(@color-tint, 20%);
       outline: 0.125em solid @color-tint;
       padding: 0;
@@ -91,6 +122,7 @@ div[tinymceai-data-pending-diff="true"], span[tinymceai-data-pending-diff="true"
 
     &.tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
       display: inline;
+      background-image: none;
       border: 0.25em solid fade(@color-error, 20%);
       outline: 0.125em solid @color-error;
       padding: 0;

--- a/modules/oxide/src/less/theme/content/diff/diff.less
+++ b/modules/oxide/src/less/theme/content/diff/diff.less
@@ -3,9 +3,9 @@
 @removed-background-color: fade(@color-error, 20%);
 
 @selected-outline-color: @color-tint;
-@selected-box-shadow: 0 -2px 0 0 @selected-outline-color inset, 0 -2px 0 0 @selected-outline-color;
+@selected-box-shadow: 0 2px 0 0 @selected-outline-color, 0 -2px 0 0 @selected-outline-color;
 
-.diff-content(
+.diff-content( 
   @pluginName,
   @added-bg,
   @modified-bg,
@@ -17,41 +17,66 @@
   .tox-@{pluginName}__annotation--added,
   .tox-@{pluginName}__annotation--modified,
   .tox-@{pluginName}__annotation--removed {
+    padding-block: calc((1lh - 1.1em) / 2);
     text-decoration: none;
+    background-repeat: no-repeat;
+    text-decoration-thickness: max(1px, .07em); 
   }
 
   .tox-@{pluginName}__annotation--added__highlight {
-    background-color: @added-bg;
-    box-shadow: 0 -2px 0 0 @color-success inset;
+    background-position: bottom;
+    background-image: linear-gradient(@added-bg calc(100% - 2px), @color-success calc(100% - 2px));
   }
 
   .tox-@{pluginName}__annotation--added__selected {
-    background-color: @added-bg;
-    box-shadow: @selected-box-shadow;
-    text-decoration: none;
+    background-position: center;
+    background-size: 100% calc(1lh + 3px);
+    background-image: linear-gradient(@selected-outline-color 3px, @added-bg 3px, @added-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
   }
 
   .tox-@{pluginName}__annotation--modified__highlight {
-    background-color: @modified-bg;
-    text-decoration: underline;
+    background-position: bottom;
+    background-image: linear-gradient(@modified-bg calc(100% - 2px), @color-tint calc(100% - 2px));
   }
 
   .tox-@{pluginName}__annotation--modified__selected {
-    background-color: @modified-bg;
-    box-shadow: @selected-box-shadow;
-    text-decoration: none;
+    background-position: center;
+    background-size: 100% calc(1lh + 3px);
+    background-image: linear-gradient(@selected-outline-color 3px, @modified-bg 3px, @modified-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
   }
 
   .tox-@{pluginName}__annotation--removed__highlight {
-    background-color: @removed-bg;
     text-decoration: line-through;
-    box-shadow: 0 -2px 0 0 @color-error inset;
+    background-position: bottom;
+    background-image: linear-gradient(@removed-bg calc(100% - 2px), @color-error calc(100% - 2px));
   }
 
   .tox-@{pluginName}__annotation--removed__selected {
-    background-color: @removed-bg;
-    box-shadow: @selected-box-shadow;
     text-decoration: line-through;
+    background-position: center;
+    background-size: 100% calc(1lh + 3px);
+    background-image: linear-gradient(@selected-outline-color 3px, @removed-bg 3px, @removed-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
+  }
+
+  // Block elements should not have background size of 1lh, so selection is based on box-shadow
+  div, p, ul, ol, li, table, section, header, footer, h1, h2, h3, h4, h5, h6, figure, hr {
+    &.tox-@{pluginName}__annotation--added__selected {
+      background-image: none;
+      background-color: @added-bg;
+      box-shadow: @selected-box-shadow;
+    }
+
+    &.tox-@{pluginName}__annotation--modified__selected {
+      background-image: none;
+      background-color: @modified-bg;
+      box-shadow: @selected-box-shadow;
+    }
+
+    &.tox-@{pluginName}__annotation--removed__selected {
+      background-image: none;
+      background-color: @removed-bg;
+      box-shadow: @selected-box-shadow;
+    }
   }
 
   .tox-@{pluginName}__annotation--added.tox-@{pluginName}__annotation--added__hidden,
@@ -76,38 +101,45 @@
     &.tox-@{pluginName}__annotation--added__highlight {
       outline: 0.25em solid @added-bg;
       padding: 0.25em;
+      background-image: none;
     }
 
     &.tox-@{pluginName}__annotation--added__selected {
       border: 0.25em solid @added-bg;
       outline: 0.125em solid @selected-outline-color;
       padding: 0em;
+      background-image: none;
     }
 
     &.tox-@{pluginName}__annotation--modified__highlight {
       outline: 0.25em solid @modified-bg;
       padding: 0.25em;
+      background-image: none;
     }
 
     &.tox-@{pluginName}__annotation--modified__selected {
       border: 0.25em solid @modified-bg;
       outline: 0.125em solid @selected-outline-color;
       padding: 0em;
+      background-image: none;
     }
 
     &.tox-@{pluginName}__annotation--removed__highlight {
       outline: 0.25em solid @removed-bg;
       padding: 0.25em;
+      background-image: none;
     }
 
     &.tox-@{pluginName}__annotation--removed__selected {
       border: 0.25em solid @removed-bg;
       outline: 0.125em solid @selected-outline-color;
       padding: 0em;
+      background-image: none;
     }
   }
 
   div.tox-@{pluginName}__annotation:has(> hr) {
+    background-size: auto;
     padding: 0.25em;
   }
 
@@ -126,6 +158,7 @@
       // Taken from the content pagebreak styles
       border: 1px dashed #aaa;
       box-shadow: none;
+      background-image: none;
     }
 
     &.tox-@{pluginName}__annotation--added__highlight,

--- a/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/content/suggestededits/suggestededits.less
@@ -7,7 +7,7 @@
 @suggestededits-removed-background-color: @removed-background-color;
 
 @suggestededits-selected-outline-color: @selected-outline-color;
-@suggestededits-selected-box-shadow: 0 -2px 0 0 @suggestededits-selected-outline-color inset, 0 -2px 0 0 @suggestededits-selected-outline-color;
+@suggestededits-selected-box-shadow: 0 2px 0 0 @suggestededits-selected-outline-color, 0 -2px 0 0 @suggestededits-selected-outline-color;
 
 .diff-content(
   suggestededits,


### PR DESCRIPTION
Related Ticket: TINY-13958

Description of Changes:

- Replaced border-based highlighting with background gradient images for diff annotations to improve visual consistency
- Updated box-shadow positioning from inset to external shadows for selected block elements
- Added line-height-based padding and background sizing for inline text elements
- Implemented separate styling for block elements using box-shadow instead of background gradients
- Added explicit background-image resets for media elements (img, video, iframe) and special containers
- Enhanced text decoration thickness using modern CSS properties
- Improved selector specificity for added and modified selected states

Pre-checks:

- [x] Changelog entry added
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
    - Improved inline diff visuals with centered, full-width gradient bands for added, modified, and removed highlights; adjusted selection shadows for more consistent banding.
    - Block-level selections now use solid background tint plus shadow for full-band clarity.
- **Bug Fixes**
    - Disabled gradient overlays on media and special containers to prevent interference with outlines and borders.
- **Chores**
    - Added an unreleased changelog entry documenting these visual improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->