### PR TITLE
TINY-14064: add max height to dropdown content

### DIFF
--- a/modules/oxide/src/less/theme/components/dropdown/dropdown.less
+++ b/modules/oxide/src/less/theme/components/dropdown/dropdown.less
@@ -9,6 +9,7 @@
     width: fit-content;
     border-radius: var(--tox-private-panel-border-radius, @panel-border-radius);
     background-color: var(--tox-private-background-color, @background-color);
+    max-height: 50vh;
 
     // Make menu fill dropdown width; suppress duplicate shadow (dropdown-content provides its own)
     .tox-menu {


### PR DESCRIPTION
Related Ticket: TINY-14064

Description of Changes:

- Added `max-height: 50vh` constraint to dropdown components to prevent them from extending beyond the viewport height

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dropdowns now limit their visible height to half the viewport, preventing overly tall lists and keeping content scrollable. This improves usability and layout stability for long dropdowns across different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->