### PR TITLE
TINY-14085: Unify gap between review accordion elements to 12px

### DIFF
--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -19,7 +19,7 @@
       background-color: var(--tox-private-background-secondary, contrast(@background-color, darken(@background-color, 6%), lighten(@background-color, 7%)));
 
       .tox-accordion__content--expanded .tox-accordion__content-inner {
-        padding-top: var(--tox-private-pad-xs, @pad-xs);
+        padding-top: 0;
       }
     }
 

--- a/modules/oxide/src/less/theme/components/accordion/accordion.less
+++ b/modules/oxide/src/less/theme/components/accordion/accordion.less
@@ -114,10 +114,6 @@
     }
   }
 
-  .tox-accordion__content--expanded .tox-accordion__content-inner {
-    padding-top: calc(var(--tox-private-pad-sm, @pad-sm) + 1px);
-  }
-
   .tox-accordion__header-icon {
     align-items: center;
     color: var(--tox-private-text-color, @text-color);

--- a/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
+++ b/modules/oxide/src/less/theme/components/tinymceai/ai-review.less
@@ -28,7 +28,7 @@
       }
 
       .tox-ai__review-description {
-        padding-bottom: var(--tox-private-pad-sm, @pad-sm);
+        padding-bottom: calc(var(--tox-private-pad-sm, @pad-sm) + var(--tox-private-pad-xs, @pad-xs));
         font-size: var(--tox-private-font-size-sm, @font-size-sm);
       }
 


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-14085

Description of Changes:
* Set expanded accordion `content-inner` padding-top to 0 (the header's 12px padding-bottom provides the gap)
* Increased review description `padding-bottom` from 8px (`@pad-sm`) to 12px (`@pad-sm + @pad-xs`)
* Unifies all vertical spacing between elements inside review accordion items to 12px

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined accordion spacing: when expanded, the top inner padding is now removed to tighten layout and eliminate a previous alternate padding override.
  * Adjusted AI review spacing: increased bottom padding of the review description by combining two theme spacing values for slightly more vertical breathing room.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->