### PR TITLE
TINY-14156: fix `tox-tag` `max-width`

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -219,7 +219,7 @@
     .tox-tag {
       border: 1px solid var(--tox-private-separator-color, @tinymce-separator-color);
       background-color: transparent;
-      max-width: 132px;
+      max-width: 32%;
       max-height: 24px;
       cursor: pointer;
 


### PR DESCRIPTION
Related Ticket: TINY-14156

Description of Changes:
reduce the `max-width` to allow having 3 items when the scroll bar takes too much space

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved AI chat response source tag layout by changing tag sizing from a fixed width to a responsive percentage-based width, so source tags scale more consistently across different container and screen sizes for better visual balance and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->