### PR TITLE
TINY-14246: Remove box-shadow dimming CSS from a11ychecker Oxide skin

### DIFF
--- a/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
+++ b/modules/oxide/src/less/theme/content/accessibility-checker/accessibility-checker.less
@@ -4,10 +4,6 @@
 @accessibility-overlay-opacity-90: 90%;
 @accessibility-overlay-opacity-60: 60%;
 
-@accessibility-box-shadow-color: #222f3e80;
-@accessibility-box-shadow-width: 99999px;
-@accessibility-box-shadow-z-index: 1;
-
 @accessibility-issue-info-selection-color: if(@content-ui-darkmode = true, mix(@color-white, @color-tint, @accessibility-overlay-opacity-60), @color-tint);
 @accessibility-issue-info-selection-background-color: mix(@background-color, @color-tint, @accessibility-overlay-opacity-90);
 
@@ -25,8 +21,6 @@
 [data-ephox-foam-a11y-violation][data-ephox-foam-a11y-current-violation] {
   outline-width: 4px;
   transition: outline-width .1s ease-in-out, background-color .1s ease-in-out;
-  box-shadow: 0 0 0 @accessibility-box-shadow-width @accessibility-box-shadow-color;
-  z-index: @accessibility-box-shadow-z-index;
 }
 
 [data-ephox-foam-a11y-violation][data-ephox-foam-a11y-severity-info] {


### PR DESCRIPTION
Related Ticket: https://ephocks.atlassian.net/browse/TINY-14246

Description of Changes:
* Removed `box-shadow` and `z-index` from the `[data-ephox-foam-a11y-current-violation]` rule in the Oxide a11ychecker skin
* Removed the three `@accessibility-box-shadow-*` Less variables that only fed those properties
* Removed the old `box-shadow: 0 0 0 99999px` approach for dimming content

Pre-checks:
* [x] Changelog entry added (N/A - no user-facing change, the premium plugin handles dimming now)
* [x] Tests have been added (N/A - CSS removal, covered by premium plugin tests)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Streamlined visual styling for accessibility violation indicators by simplifying shadow effects while maintaining outline-based highlighting for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->