### PR TITLE
TINY-14287: fix `test-visual-local` task for Linux

### DIFF
--- a/modules/oxide-components/visual-regression-test.mjs
+++ b/modules/oxide-components/visual-regression-test.mjs
@@ -38,6 +38,7 @@ const dockerArgs = [
   '--rm',
   '--name=oxide-components-test-visual',
   '--userns=host',
+  '--add-host=host.docker.internal:host-gateway',
   '-e', "TEST_BASE_URL=http://host.docker.internal:6006",
   '-v', `${projectRoot}:/tinymce`,
   '-v', `${pwd}/src/test/ts/visual.spec.ts-snapshots:/tinymce/${relativeToRoot}/src/test/ts/visual.spec.ts-snapshots`,


### PR DESCRIPTION
Related Ticket: TINY-14287

Description of Changes:
`host.docker.internal` isn't working by default on Linux so we need to add: `'--add-host=host.docker.internal:host-gateway'`

P.S. do we need a changelog for this?

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] ~Milestone set~
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved visual regression test container configuration to explicitly map the development server host so tests can reliably resolve and access the running dev environment, reducing intermittent failures during visual snapshot runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->