### PR TITLE
TINY-14290: Post-merge bun migration fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "tinymce-monorepo",
+      "dependencies": {
+        "grunt-legacy-util": "2.0.2",
+      },
       "devDependencies": {
         "@ephox/bedrock-client": "^16.0.0",
         "@ephox/bedrock-server": "^16.2.0",
@@ -350,7 +353,7 @@
     },
     "modules/tinymce": {
       "name": "tinymce",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "dependencies": {
         "@ephox/acid": "^8.0.0",
         "@ephox/agar": "^10.0.0",
@@ -2015,6 +2018,8 @@
 
     "exit-hook": ["exit-hook@4.0.0", "", {}, "sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ=="],
 
+    "exit-x": ["exit-x@0.2.2", "", {}, "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ=="],
+
     "expand-tilde": ["expand-tilde@2.0.2", "", { "dependencies": { "homedir-polyfill": "^1.0.1" } }, "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw=="],
 
     "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
@@ -2227,7 +2232,7 @@
 
     "grunt-legacy-log-utils": ["grunt-legacy-log-utils@2.1.0", "", { "dependencies": { "chalk": "~4.1.0", "lodash": "~4.17.19" } }, "sha512-lwquaPXJtKQk0rUM1IQAop5noEpwFqOXasVoedLeNzaibf/OPWjKYvvdqnEHNmU+0T0CaReAXIbGo747ZD+Aaw=="],
 
-    "grunt-legacy-util": ["grunt-legacy-util@2.0.1", "", { "dependencies": { "async": "~3.2.0", "exit": "~0.1.2", "getobject": "~1.0.0", "hooker": "~0.2.3", "lodash": "~4.17.21", "underscore.string": "~3.3.5", "which": "~2.0.2" } }, "sha512-2bQiD4fzXqX8rhNdXkAywCadeqiPiay0oQny77wA2F3WF4grPJXCvAcyoWUJV+po/b15glGkxuSiQCK299UC2w=="],
+    "grunt-legacy-util": ["grunt-legacy-util@2.0.2", "", { "dependencies": { "async": "~3.2.0", "exit-x": "~0.2.2", "getobject": "~1.0.0", "hooker": "~0.2.3", "lodash": "^4.18.0", "underscore.string": "~3.3.5", "which": "~2.0.2" } }, "sha512-0xoDILyR4BVJel5uJwnhjdWN9evOQ8A0uXbQUIJ0hgVthIA6kloXHSoqATQPj6BRrHrHkcQtCeGVb0ixFoHyEQ=="],
 
     "grunt-nuget-pack": ["grunt-nuget-pack@1.0.1", "", { "dependencies": { "moxie-zip": "~0.0.3", "xml-writer": "~1.7.0" } }, "sha512-BC8d6kbJZv4r8WprBHYzn0ZOHCMDs4p5I2kavh1tta2L5FRgTos2T5IgVowBgfAob5MTSclqALQkudmiXEPnRw=="],
 
@@ -4003,6 +4008,8 @@
 
     "got/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
+    "grunt/grunt-legacy-util": ["grunt-legacy-util@2.0.1", "", { "dependencies": { "async": "~3.2.0", "exit": "~0.1.2", "getobject": "~1.0.0", "hooker": "~0.2.3", "lodash": "~4.17.21", "underscore.string": "~3.3.5", "which": "~2.0.2" } }, "sha512-2bQiD4fzXqX8rhNdXkAywCadeqiPiay0oQny77wA2F3WF4grPJXCvAcyoWUJV+po/b15glGkxuSiQCK299UC2w=="],
+
     "grunt/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
     "grunt-cli/interpret": ["interpret@1.1.0", "", {}, "sha512-CLM8SNMDu7C5psFCn6Wg/tgpj/bKAg7hc2gWqcuR9OD5Ft9PhBpIu8PLicPeis+xDd6YX2ncI8MCA64I9tftIA=="],
@@ -4018,6 +4025,8 @@
     "grunt-contrib-watch/async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
 
     "grunt-legacy-log-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "grunt-legacy-util/lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "grunt-shell/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "tinymce-monorepo",
-      "dependencies": {
-        "grunt-legacy-util": "2.0.2",
-      },
       "devDependencies": {
         "@ephox/bedrock-client": "^16.0.0",
         "@ephox/bedrock-server": "^16.2.0",
@@ -35,6 +32,7 @@
         "grunt-contrib-cssmin": "^5.0.0",
         "grunt-contrib-symlink": "^1.0.0",
         "grunt-contrib-watch": "^1.1.0",
+        "grunt-legacy-util": "2.0.2",
         "grunt-nuget-pack": "^1.0.1",
         "grunt-shell": "^4.0.0",
         "grunt-stylelint": "^0.20.1",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "typescript": "^5.9.3",
     "webpack": "^5.103.0",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.0"
+    "webpack-dev-server": "^5.2.0",
+    "grunt-legacy-util": "2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ci-all-seq": "npm-run-all -p eslint ci-seq -s tinymce-rollup",
     "local-ci": "run-s -s ci-all test",
     "test": "run-s headless-test browser-test",
-    "build": "npm-run-all -p oxide-icons-ci oxide-ci oxide-components-ci -s tinymce-grunt",
+    "build": "npm-run-all oxide-ci -p oxide-icons-ci oxide-components-ci -s tinymce-grunt",
     "prepublishOnly": "run-s oxide-icons-ci",
     "browser-test": "grunt browser-auto",
     "browser-test-manual": "grunt browser-manual",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
   ],
 
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       // duplicate paths, copied from each individual tsconfig.json
       // once there is a webpack path plugin that supports project references this can be deleted


### PR DESCRIPTION
Related Ticket: TINY-14290

## Description of Changes

Post-merge fixes for the bun migration (TINY-12819). Three issues discovered after switching from yarn to bun:

### 1. Oxide build race condition

The root `build` script ran `oxide-ci` and `oxide-components-ci` in parallel. The oxide-components `ci` script uses lerna with `--include-dependencies`, which builds oxide as a dependency. This caused two concurrent `grunt build` processes in `modules/oxide/`, where one's `clean` task wipes the other's `build/` output.

This was a latent race masked by yarn's slower startup. Bun's faster execution exposes it reliably.

**Fix:** Sequence `oxide-ci` first, then run `oxide-icons-ci` and `oxide-components-ci` in parallel.

```diff
- "build": "npm-run-all -p oxide-icons-ci oxide-ci oxide-components-ci -s tinymce-grunt"
+ "build": "npm-run-all oxide-ci -p oxide-icons-ci oxide-components-ci -s tinymce-grunt"
```

### 2. Bun path resolution warnings

Bun emits warnings when `baseUrl` is not explicitly set in the root `tsconfig.json`, even if inherited from a parent config.

**Fix:** Add `"baseUrl": "."` to root `tsconfig.json` compilerOptions.

### 3. grunt-legacy-util bun compatibility

Bun 1.3.12 removed `util.isError()` from its `node:util` polyfill (present in 1.3.11). `grunt-legacy-util@2.0.1` depends on `nodeUtil.isError()`, breaking the oxide cssmin build under bun.

**Fix:** Bump `grunt-legacy-util` from 2.0.1 to 2.0.2, which replaces `nodeUtil.isError(err)` with `err instanceof Error`.

## Pre-checks

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized build task ordering to improve CI reliability and reduce build flakiness.

* **Chores / Tooling**
  * Adjusted TypeScript module resolution base to simplify imports, improving developer tooling and build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->