### PR TITLE
TINY-14294: apply inline selection styles to ins/del elements

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -61,14 +61,9 @@ span[tinymceai-data-pending-diff="true"] {
 
   .tox-tinymceai__annotation--added.tox-tinymceai__annotation--added__selected,
   .tox-tinymceai__annotation--modified.tox-tinymceai__annotation--modified__selected {
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(
-      @color-tint 3px,
-      fade(@color-tint, 20%) 3px,
-      fade(@color-tint, 20%) calc(100% - 3px),
-      @color-tint calc(100% - 3px)
-    );
+    background-image: none;
+    background-color: fade(@color-tint, 20%);
+    box-shadow: @tinymceai-selected-box-shadow;
   }
 
   // TEMP: Show deleted content when its review card is selected.
@@ -77,30 +72,39 @@ span[tinymceai-data-pending-diff="true"] {
   .tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
     display: revert;
     text-decoration: line-through;
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(
-      @color-error 3px,
-      fade(@color-error, 20%) 3px,
-      fade(@color-error, 20%) calc(100% - 3px),
-      @color-error calc(100% - 3px)
-    );
+    background-image: none;
+    background-color: fade(@color-error, 20%);
+    box-shadow: @tinymceai-selected-box-shadow;
   }
 
-  // Block elements should not have background size of 1lh, so selection is based on box-shadow
-  div, p, ul, ol, li, table, section, header, footer, h1, h2, h3, h4, h5, h6, figure, hr {
+  // ins/del elements only contain text and inline formatting, so they can safely use
+  // the 1lh background-image approach for tighter inline selection styling
+  ins, del {
     &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--added__selected,
     &.tox-tinymceai__annotation--modified.tox-tinymceai__annotation--modified__selected {
-      background-image: none;
-      background-color: fade(@color-tint, 20%);
-      box-shadow: @tinymceai-selected-box-shadow;
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(
+        @color-tint 3px,
+        fade(@color-tint, 20%) 3px,
+        fade(@color-tint, 20%) calc(100% - 3px),
+        @color-tint calc(100% - 3px)
+      );
     }
 
-    // TODO: Replace with a proper visual marker that doesn't reveal full deleted content.
     &.tox-tinymceai__annotation--removed.tox-tinymceai__annotation--removed__selected {
-      background-image: none;
-      background-color: fade(@color-error, 20%);
-      box-shadow: @tinymceai-selected-box-shadow;
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(
+        @color-error 3px,
+        fade(@color-error, 20%) 3px,
+        fade(@color-error, 20%) calc(100% - 3px),
+        @color-error calc(100% - 3px)
+      );
     }
   }
 

--- a/modules/oxide/src/less/theme/content/diff/diff.less
+++ b/modules/oxide/src/less/theme/content/diff/diff.less
@@ -29,9 +29,9 @@
   }
 
   .tox-@{pluginName}__annotation--added__selected {
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(@selected-outline-color 3px, @added-bg 3px, @added-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
+    background-image: none;
+    background-color: @added-bg;
+    box-shadow: @selected-box-shadow;
   }
 
   .tox-@{pluginName}__annotation--modified__highlight {
@@ -40,9 +40,9 @@
   }
 
   .tox-@{pluginName}__annotation--modified__selected {
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(@selected-outline-color 3px, @modified-bg 3px, @modified-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
+    background-image: none;
+    background-color: @modified-bg;
+    box-shadow: @selected-box-shadow;
   }
 
   .tox-@{pluginName}__annotation--removed__highlight {
@@ -53,29 +53,36 @@
 
   .tox-@{pluginName}__annotation--removed__selected {
     text-decoration: line-through;
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(@selected-outline-color 3px, @removed-bg 3px, @removed-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
+    background-image: none;
+    background-color: @removed-bg;
+    box-shadow: @selected-box-shadow;
   }
 
-  // Block elements should not have background size of 1lh, so selection is based on box-shadow
-  div, p, ul, ol, li, table, section, header, footer, h1, h2, h3, h4, h5, h6, figure, hr {
+  // ins/del elements only contain text and inline formatting, so they can safely use
+  // the 1lh background-image approach for better inline selection styling
+  ins, del {
     &.tox-@{pluginName}__annotation--added__selected {
-      background-image: none;
-      background-color: @added-bg;
-      box-shadow: @selected-box-shadow;
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(@selected-outline-color 3px, @added-bg 3px, @added-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
     }
 
     &.tox-@{pluginName}__annotation--modified__selected {
-      background-image: none;
-      background-color: @modified-bg;
-      box-shadow: @selected-box-shadow;
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(@selected-outline-color 3px, @modified-bg 3px, @modified-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
     }
 
     &.tox-@{pluginName}__annotation--removed__selected {
-      background-image: none;
-      background-color: @removed-bg;
-      box-shadow: @selected-box-shadow;
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(@selected-outline-color 3px, @removed-bg 3px, @removed-bg calc(100% - 3px), @selected-outline-color calc(100% - 3px));
     }
   }
 


### PR DESCRIPTION
Related Ticket: TINY-14294

Description of Changes:
* Reversed the selection styling approach for diff annotations - block elements box-shadow based styling is now the "default" while inline `ins`/`del` elements use the line-height-based background-image approach. It's safer and doesn't require listing all possible block elements

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):