### PR TITLE
TINY-13690: change useEffect to useLayout effect in dropdown component

### DIFF
--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { Id, Type } from '@ephox/katamari';
-import { Children, cloneElement, forwardRef, isValidElement, useCallback, useEffect, useMemo, useRef, useState, type FC, type HTMLAttributes, type MouseEvent, type PropsWithChildren, type ReactElement, type KeyboardEvent } from 'react';
+import { Children, cloneElement, forwardRef, isValidElement, useCallback, useMemo, useRef, useState, type FC, type HTMLAttributes, type MouseEvent, type PropsWithChildren, type ReactElement, type KeyboardEvent, useLayoutEffect } from 'react';
 
 import { Bem } from '../../main';
 
@@ -17,7 +17,7 @@ const Content = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, on
     setIsOpen(event.newState === 'open');
   }, [ setIsOpen ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = contentRef.current;
     if (Type.isNullable(element)) {
       return;


### PR DESCRIPTION
Related Ticket: TINY-13690

Description of Changes:

- Replaced `useEffect` with `useLayoutEffect` in the `Dropdown` component's `Content` to ensure the popover toggle listener is registered synchronously after DOM updates, preventing potential timing issues with the dropdown open state

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] ~~Milestone set~~
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Optimized dropdown event listener initialization timing to ensure reliable toggle behavior and prevent potential timing-related interaction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->