### PR TITLE
TINY-11524: Retain user case for CSS property names and color values in Styles parser

### DIFF
--- a/.changes/unreleased/tinymce-TINY-11524-2026-04-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11524-2026-04-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: CSS property names and color values in the style attribute were being lowercased when parsed.
+time: 2026-04-20T18:48:03.608483+10:00
+custom:
+    Issue: TINY-11524

--- a/.changes/unreleased/tinymce-TINY-11524-2026-04-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-11524-2026-04-20.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: CSS property names and color values in the style attribute were being lowercased when parsed.
+body: CSS custom property names and color values in the style attribute were being lowercased when parsed.
 time: 2026-04-20T18:48:03.608483+10:00
 custom:
     Issue: TINY-11524

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -246,8 +246,10 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             // Decode escaped sequences like \65 -> e
             name = decodeHexSequences(name);
             value = decodeHexSequences(value);
-            // Lowercase form for internal comparisons and storage; custom properties keep user case
-            const lowerName = name.toLowerCase();
+            // Custom properties (--*) keep user case; standard names normalize to lowercase
+            if (!name.startsWith('--')) {
+              name = name.toLowerCase();
+            }
 
             // Skip properties with double quotes and sequences like \" \' in their names
             // See 'mXSS Attacks: Attacking well-secured Web-Applications by using innerHTML Mutations'
@@ -257,12 +259,12 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             }
 
             // Don't allow behavior name or expression/comments within the values
-            if (!settings.allow_script_urls && (lowerName === 'behavior' || /expression\s*\(|\/\*|\*\//.test(value))) {
+            if (!settings.allow_script_urls && (name === 'behavior' || /expression\s*\(|\/\*|\*\//.test(value))) {
               continue;
             }
 
             // Opera will produce 700 instead of bold in their style values
-            if (lowerName === 'font-weight' && value === '700') {
+            if (name === 'font-weight' && value === '700') {
               value = 'bold';
             }
 
@@ -275,7 +277,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
 
             // Convert URLs and force them into url('value') format
             value = value.replace(urlOrStrRegExp, processUrl);
-            styles[name.startsWith('--') ? name : lowerName] = isEncoded ? decode(value, true) : value;
+            styles[name] = isEncoded ? decode(value, true) : value;
           }
         }
         // Compress the styles to reduce it's size for example IE will expand styles

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -239,13 +239,15 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
         let matches: RegExpExecArray | null;
         while ((matches = styleRegExp.exec(css))) {
           styleRegExp.lastIndex = matches.index + matches[0].length;
-          let name = matches[1].replace(trimRightRegExp, '').toLowerCase();
+          let name = matches[1].replace(trimRightRegExp, '');
           let value = matches[2].replace(trimRightRegExp, '');
 
           if (name && value) {
             // Decode escaped sequences like \65 -> e
             name = decodeHexSequences(name);
             value = decodeHexSequences(value);
+            // Canonical lowercase form for internal comparisons only; storage keeps user case
+            const lowerName = name.toLowerCase();
 
             // Skip properties with double quotes and sequences like \" \' in their names
             // See 'mXSS Attacks: Attacking well-secured Web-Applications by using innerHTML Mutations'
@@ -255,15 +257,13 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             }
 
             // Don't allow behavior name or expression/comments within the values
-            if (!settings.allow_script_urls && (name === 'behavior' || /expression\s*\(|\/\*|\*\//.test(value))) {
+            if (!settings.allow_script_urls && (lowerName === 'behavior' || /expression\s*\(|\/\*|\*\//.test(value))) {
               continue;
             }
 
             // Opera will produce 700 instead of bold in their style values
-            if (name === 'font-weight' && value === '700') {
+            if (lowerName === 'font-weight' && value === '700') {
               value = 'bold';
-            } else if (name === 'color' || name === 'background-color') { // Lowercase colors like RED
-              value = value.toLowerCase();
             }
 
             // Convert RGB colors to HEX

--- a/modules/tinymce/src/core/main/ts/api/html/Styles.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Styles.ts
@@ -246,7 +246,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
             // Decode escaped sequences like \65 -> e
             name = decodeHexSequences(name);
             value = decodeHexSequences(value);
-            // Canonical lowercase form for internal comparisons only; storage keeps user case
+            // Lowercase form for internal comparisons and storage; custom properties keep user case
             const lowerName = name.toLowerCase();
 
             // Skip properties with double quotes and sequences like \" \' in their names
@@ -275,7 +275,7 @@ const Styles = (settings: StylesSettings = {}, schema?: Schema): Styles => {
 
             // Convert URLs and force them into url('value') format
             value = value.replace(urlOrStrRegExp, processUrl);
-            styles[name] = isEncoded ? decode(value, true) : value;
+            styles[name.startsWith('--') ? name : lowerName] = isEncoded ? decode(value, true) : value;
           }
         }
         // Compress the styles to reduce it's size for example IE will expand styles

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -21,10 +21,9 @@ describe('browser.tinymce.core.html.StylesTest', () => {
   it('Basic parsing/serializing', () => {
     const styles = Styles();
 
-    assertStyles(styles, 'FONT-SIZE:10px', 'FONT-SIZE: 10px;');
-    assertStyles(styles, 'FONT-SIZE:10px;COLOR:red', 'FONT-SIZE: 10px; COLOR: red;');
-    assertStyles(styles, 'FONT-SIZE  :  10px  ;   COLOR  :  red   ', 'FONT-SIZE: 10px; COLOR: red;');
-    assertStyles(styles, 'font-size:10px', 'font-size: 10px;');
+    assertStyles(styles, 'FONT-SIZE:10px', 'font-size: 10px;');
+    assertStyles(styles, 'FONT-SIZE:10px;COLOR:red', 'font-size: 10px; color: red;');
+    assertStyles(styles, 'FONT-SIZE  :  10px  ;   COLOR  :  red   ', 'font-size: 10px; color: red;');
     assertStyles(styles, 'key:"value"', `key: 'value';`);
     assertStyles(styles, `key:"value1" 'value2'`, `key: 'value1' 'value2';`);
     assertStyles(styles, `key:"val\\"ue1" 'val\\'ue2'`, `key: 'val"ue1' 'val\\'ue2';`);
@@ -48,11 +47,11 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, '  color:   RGB  (  1  ,  2  ,  3  )  ', 'color: #010203;');
     assertStyles(styles,
       '   FONT-SIZE  :  10px  ;   COLOR  :  RGB  (  1  ,  2  ,  3  )   ',
-      'FONT-SIZE: 10px; COLOR: #010203;'
+      'font-size: 10px; color: #010203;'
     );
     assertStyles(styles,
       '   FONT-SIZE  :  10px  ;   COLOR  :  RED   ',
-      'FONT-SIZE: 10px; COLOR: RED;'
+      'font-size: 10px; color: RED;'
     );
     assertStyles(
       styles,
@@ -76,21 +75,21 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'background-color: Blue;', 'background-color: Blue;');
   });
 
-  it('TINY-11524: CSS property names retain user case', () => {
+  it('TINY-11524: custom property (--*) names retain user case; standard names are lowercased', () => {
     const styles = Styles();
 
-    assertStyles(styles, 'Margin-Top: 20px;', 'Margin-Top: 20px;');
-    assertStyles(styles, 'Padding-Top: 20px;', 'Padding-Top: 20px;');
-    assertStyles(styles, 'Border-Top: 1px solid red;', 'Border-Top: 1px solid red;');
-    assertStyles(styles, 'FONT-FAMILY: Arial;', 'FONT-FAMILY: Arial;');
-    assertStyles(styles, 'Background-Image: url(a.png);', `Background-Image: url('a.png');`);
+    assertStyles(styles, '--MyVar: 10px;', '--MyVar: 10px;');
+    assertStyles(styles, '--my-color: red;', '--my-color: red;');
+    assertStyles(styles, '--FooBar: 1; --baz: 2;', '--FooBar: 1; --baz: 2;');
+    assertStyles(styles, 'Margin-Top: 20px;', 'margin-top: 20px;');
+    assertStyles(styles, 'FONT-FAMILY: Arial;', 'font-family: Arial;');
   });
 
   it('TINY-11524: font-weight 700 substitution fires on mixed-case name', () => {
     const styles = Styles();
 
-    assertStyles(styles, 'Font-Weight: 700', 'Font-Weight: bold;');
-    assertStyles(styles, 'FONT-WEIGHT: 700', 'FONT-WEIGHT: bold;');
+    assertStyles(styles, 'Font-Weight: 700', 'font-weight: bold;');
+    assertStyles(styles, 'FONT-WEIGHT: 700', 'font-weight: bold;');
     assertStyles(styles, 'font-weight: 700', 'font-weight: bold;');
   });
 
@@ -102,7 +101,7 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     assertStyles(styles, 'bEhAvIoR: url(test.htc)', '');
   });
 
-  it('TINY-11524: compression still fires when all longhands are lowercase', () => {
+  it('TINY-11524: compression fires regardless of input case', () => {
     const styles = Styles();
 
     assertStyles(
@@ -112,23 +111,8 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     );
     assertStyles(
       styles,
-      'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px',
-      'margin: 1px 2px 3px 4px;'
-    );
-  });
-
-  it('TINY-11524: compression skips when any longhand is mixed-case', () => {
-    const styles = Styles();
-
-    assertStyles(
-      styles,
-      'Padding-Top: 1px; padding-right: 1px; padding-bottom: 1px; padding-left: 1px',
-      'Padding-Top: 1px; padding-right: 1px; padding-bottom: 1px; padding-left: 1px;'
-    );
-    assertStyles(
-      styles,
       'Margin-Top: 1px; Margin-Right: 2px; Margin-Bottom: 3px; Margin-Left: 4px',
-      'Margin-Top: 1px; Margin-Right: 2px; Margin-Bottom: 3px; Margin-Left: 4px;'
+      'margin: 1px 2px 3px 4px;'
     );
   });
 

--- a/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/StylesTest.ts
@@ -21,9 +21,10 @@ describe('browser.tinymce.core.html.StylesTest', () => {
   it('Basic parsing/serializing', () => {
     const styles = Styles();
 
-    assertStyles(styles, 'FONT-SIZE:10px', 'font-size: 10px;');
-    assertStyles(styles, 'FONT-SIZE:10px;COLOR:red', 'font-size: 10px; color: red;');
-    assertStyles(styles, 'FONT-SIZE  :  10px  ;   COLOR  :  red   ', 'font-size: 10px; color: red;');
+    assertStyles(styles, 'FONT-SIZE:10px', 'FONT-SIZE: 10px;');
+    assertStyles(styles, 'FONT-SIZE:10px;COLOR:red', 'FONT-SIZE: 10px; COLOR: red;');
+    assertStyles(styles, 'FONT-SIZE  :  10px  ;   COLOR  :  red   ', 'FONT-SIZE: 10px; COLOR: red;');
+    assertStyles(styles, 'font-size:10px', 'font-size: 10px;');
     assertStyles(styles, 'key:"value"', `key: 'value';`);
     assertStyles(styles, `key:"value1" 'value2'`, `key: 'value1' 'value2';`);
     assertStyles(styles, `key:"val\\"ue1" 'val\\'ue2'`, `key: 'val"ue1' 'val\\'ue2';`);
@@ -38,20 +39,20 @@ describe('browser.tinymce.core.html.StylesTest', () => {
     );
   });
 
-  it('Colors force hex and lowercase', () => {
+  it('RGB colors convert to lowercase hex; other color values retain case', () => {
     const styles = Styles();
 
     assertStyles(styles, 'color: rgb(1,2,3)', 'color: #010203;');
     assertStyles(styles, 'color: RGB(1,2,3)', 'color: #010203;');
-    assertStyles(styles, 'color: #FF0000', 'color: #ff0000;');
+    assertStyles(styles, 'color: #FF0000', 'color: #FF0000;');
     assertStyles(styles, '  color:   RGB  (  1  ,  2  ,  3  )  ', 'color: #010203;');
     assertStyles(styles,
       '   FONT-SIZE  :  10px  ;   COLOR  :  RGB  (  1  ,  2  ,  3  )   ',
-      'font-size: 10px; color: #010203;'
+      'FONT-SIZE: 10px; COLOR: #010203;'
     );
     assertStyles(styles,
       '   FONT-SIZE  :  10px  ;   COLOR  :  RED   ',
-      'font-size: 10px; color: red;'
+      'FONT-SIZE: 10px; COLOR: RED;'
     );
     assertStyles(
       styles,
@@ -59,6 +60,75 @@ describe('browser.tinymce.core.html.StylesTest', () => {
       'border: 1px solid rgb(255, 0, 0);'
       // TODO: color in border style should be in HEX format once https://ephocks.atlassian.net/browse/TINY-8917 is fixed.
       // 'border: 1px solid #ff0000;' // Should expect this
+    );
+  });
+
+  it('TINY-11524: color and background-color values retain user case', () => {
+    const styles = Styles();
+
+    assertStyles(styles, 'color: {{FooBar}};', 'color: {{FooBar}};');
+    assertStyles(styles, 'background-color: ${bgColor};', 'background-color: ${bgColor};');
+    assertStyles(styles, 'color: var(--MyColor);', 'color: var(--MyColor);');
+    assertStyles(styles, 'background-color: var(--BgColor);', 'background-color: var(--BgColor);');
+    assertStyles(styles, 'color: #AABBCC;', 'color: #AABBCC;');
+    assertStyles(styles, 'background-color: #AaBbCc;', 'background-color: #AaBbCc;');
+    assertStyles(styles, 'color: RED;', 'color: RED;');
+    assertStyles(styles, 'background-color: Blue;', 'background-color: Blue;');
+  });
+
+  it('TINY-11524: CSS property names retain user case', () => {
+    const styles = Styles();
+
+    assertStyles(styles, 'Margin-Top: 20px;', 'Margin-Top: 20px;');
+    assertStyles(styles, 'Padding-Top: 20px;', 'Padding-Top: 20px;');
+    assertStyles(styles, 'Border-Top: 1px solid red;', 'Border-Top: 1px solid red;');
+    assertStyles(styles, 'FONT-FAMILY: Arial;', 'FONT-FAMILY: Arial;');
+    assertStyles(styles, 'Background-Image: url(a.png);', `Background-Image: url('a.png');`);
+  });
+
+  it('TINY-11524: font-weight 700 substitution fires on mixed-case name', () => {
+    const styles = Styles();
+
+    assertStyles(styles, 'Font-Weight: 700', 'Font-Weight: bold;');
+    assertStyles(styles, 'FONT-WEIGHT: 700', 'FONT-WEIGHT: bold;');
+    assertStyles(styles, 'font-weight: 700', 'font-weight: bold;');
+  });
+
+  it('TINY-11524: behavior XSS guard blocks mixed-case name', () => {
+    const styles = Styles();
+
+    assertStyles(styles, 'Behavior: url(test.htc)', '');
+    assertStyles(styles, 'BEHAVIOR: url(test.htc)', '');
+    assertStyles(styles, 'bEhAvIoR: url(test.htc)', '');
+  });
+
+  it('TINY-11524: compression still fires when all longhands are lowercase', () => {
+    const styles = Styles();
+
+    assertStyles(
+      styles,
+      'padding-top: 1px; padding-right: 1px; padding-bottom: 1px; padding-left: 1px',
+      'padding: 1px;'
+    );
+    assertStyles(
+      styles,
+      'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px',
+      'margin: 1px 2px 3px 4px;'
+    );
+  });
+
+  it('TINY-11524: compression skips when any longhand is mixed-case', () => {
+    const styles = Styles();
+
+    assertStyles(
+      styles,
+      'Padding-Top: 1px; padding-right: 1px; padding-bottom: 1px; padding-left: 1px',
+      'Padding-Top: 1px; padding-right: 1px; padding-bottom: 1px; padding-left: 1px;'
+    );
+    assertStyles(
+      styles,
+      'Margin-Top: 1px; Margin-Right: 2px; Margin-Bottom: 3px; Margin-Left: 4px',
+      'Margin-Top: 1px; Margin-Right: 2px; Margin-Bottom: 3px; Margin-Left: 4px;'
     );
   });
 


### PR DESCRIPTION
Related Ticket: TINY-11524

Description of Changes:
* Stop lowercasing CSS property names and color values in `Styles.parse`. `color: RED`, `color: var(--MyVar)`, `color: {{MyVar}}`, `Margin-Top: 20px` now round-trip unchanged.
* Internal `behavior:` XSS guard and legacy `font-weight: 700 → bold` substitution route through a local lowercase so mixed-case names still trigger them.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues:
* https://github.com/tinymce/tinymce/issues/7832
* https://github.com/tinymce/tinymce/issues/4204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Styles parsing now preserves user-provided casing for custom CSS properties and for many color values in style attributes; standard property names remain normalized and font-weight shorthand still normalizes.
* **Tests**
  * Added/updated tests covering casing preservation, shorthand compression, font-weight normalization, and XSS/behavior guarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->