### PR TITLE
TINY-14188: fix code overflowing the container in the ai html content

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat-html-content.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat-html-content.less
@@ -111,6 +111,7 @@
       border-radius: 4px;
       white-space: pre-wrap;
       margin: 1em 0;
+      overflow-wrap: break-word;
     }
 
     /* Horizontal rule */


### PR DESCRIPTION
Related Ticket: TINY-14188

Description of Changes:

- Added `overflow-wrap: break-word` to the AI chat HTML content code block styles to prevent long unbreakable strings from overflowing their container.

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - Improved code block display in AI chat by enabling word wrapping for long strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->