### PR TITLE
TINY-14264: fix selected link color in dark mode

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14264-2026-04-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-14264-2026-04-20.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Fixed focused links in dark mode having the same color as the background
+time: 2026-04-20T15:32:58.739366+02:00
+custom:
+    Issue: TINY-14264

--- a/.changes/unreleased/tinymce-TINY-14264-2026-04-20.yaml
+++ b/.changes/unreleased/tinymce-TINY-14264-2026-04-20.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Fixed focused links in dark mode having the same color as the background
+body: Focused links in dark mode was having the same text color as the background.
 time: 2026-04-20T15:32:58.739366+02:00
 custom:
     Issue: TINY-14264

--- a/modules/oxide/src/less/skins/content/dark/content.less
+++ b/modules/oxide/src/less/skins/content/dark/content.less
@@ -14,6 +14,10 @@ a {
   color: #4099ff;
 }
 
+a[data-mce-selected="inline-boundary"] {
+  color: #fff;
+}
+
 table {
   border-collapse: collapse;
 }


### PR DESCRIPTION
Related Ticket:

Description of Changes:
* In the dark skin content styles, selected inline boundary anchor elements (`a[data-mce-selected="inline-boundary"]`) now have their text color set to `#fff` (white) to ensure proper visibility (before the background and color where the same for selected links)

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focused links in dark mode now use a high-contrast color to ensure they are visible against the background.
  * Improves readability for selected/keyboard-focused links in the dark theme.
  * Enhances accessibility and usability when navigating content in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->