### PR TITLE
TINY-12791: add editor announce api

### DIFF
--- a/.changes/unreleased/tinymce-TINY-12791-2026-05-04.yaml
+++ b/.changes/unreleased/tinymce-TINY-12791-2026-05-04.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Added
+body: Added `editor.announce()` for posting messages to screen readers via an aria-live region.
+time: 2026-05-04T16:15:48.230039+02:00
+custom:
+    Issue: TINY-12791

--- a/modules/tinymce/src/core/main/ts/EditorRemove.ts
+++ b/modules/tinymce/src/core/main/ts/EditorRemove.ts
@@ -66,6 +66,7 @@ const remove = (editor: Editor): void => {
     }
 
     Events.fireDetach(editor);
+
     DOM.remove(editor.getContainer());
 
     safeDestroy(_selectionOverrides);

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -20,6 +20,7 @@ import * as VisualAids from '../view/VisualAids';
 import AddOnManager from './AddOnManager';
 import type Annotator from './Annotator';
 import * as Commands from './commands/Commands';
+import AriaAnnouncer from './dom/AriaAnnouncer';
 import DOMUtils from './dom/DOMUtils';
 import type { EventUtilsCallback } from './dom/EventUtils';
 import ScriptLoader from './dom/ScriptLoader';
@@ -1134,6 +1135,22 @@ class Editor implements EditorObservable {
    */
   public hasEditableRoot(): boolean {
     return EditableRoot.hasEditableRoot(this);
+  }
+
+  /**
+   * Announces a message to screen readers via the page-wide aria-live region, without shifting focus.
+   * Delegates to {@link tinymce.dom.AriaAnnouncer#announce}.
+   *
+   * @method announce
+   * @param {String} message The message to announce to screen readers.
+   * @param {Object} options Optional settings.
+   * @param {Boolean} options.assertive If true, uses aria-live="assertive" (role="alert") instead of polite.
+   * @example
+   * tinymce.activeEditor.announce('Bold on');
+   * tinymce.activeEditor.announce('Error occurred', { assertive: true });
+   */
+  public announce(message: string, options?: { assertive?: boolean }): void {
+    AriaAnnouncer.announce(message, options);
   }
 
   /**

--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -3,6 +3,7 @@ import type { UndoManager as UndoManagerType } from '../undo/UndoManagerTypes';
 
 import AddOnManager from './AddOnManager';
 import Annotator from './Annotator';
+import AriaAnnouncer, { type AriaAnnouncerApi } from './dom/AriaAnnouncer';
 import BookmarkManager from './dom/BookmarkManager';
 import ControlSelection from './dom/ControlSelection';
 import DOMUtils, { type DOMUtilsSettings } from './dom/DOMUtils';
@@ -112,6 +113,7 @@ interface TinyMCE extends EditorManager {
     BookmarkManager: BookmarkManagerNamespace;
     Selection: (dom: DOMUtils, win: Window, serializer: DomSerializer, editor: Editor) => EditorSelection;
     StyleSheetLoader: (documentOrShadowRoot: Document | ShadowRoot, settings: StyleSheetLoaderSettings) => StyleSheetLoader;
+    AriaAnnouncer: AriaAnnouncerApi;
     Event: EventUtils;
   };
 
@@ -207,6 +209,7 @@ const publicApi = {
     ControlSelection,
     BookmarkManager,
     Selection: EditorSelection,
+    AriaAnnouncer,
     Event: EventUtils.Event
   },
 

--- a/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
@@ -1,0 +1,89 @@
+import { Id } from '@ephox/katamari';
+import { Attribute, Css, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+
+/**
+ * Page-wide aria-live announcer used to send messages to screen readers without
+ * shifting focus. The aria-live container is created lazily on the first
+ * announcement and removed once no tokens remain in flight.
+ *
+ * @class tinymce.dom.AriaAnnouncer
+ */
+
+export interface AriaAnnouncerApi {
+  readonly announce: (message: string, options?: { assertive?: boolean }) => void;
+}
+
+const announcerContainerId = Id.generate('tiny-aria-announcer');
+let activeTokens = 0;
+
+const offscreenStyles = {
+  position: 'absolute',
+  left: '-9999px',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden'
+};
+
+const getOrCreateContainer = (): SugarElement<HTMLElement> => {
+  return SelectorFind.descendant<HTMLElement>(SugarBody.body(), `#${announcerContainerId}`).getOrThunk(() => {
+    const container = SugarElement.fromTag('div');
+    Attribute.set(container, 'id', announcerContainerId);
+    Css.setAll(container, offscreenStyles);
+    Insert.append(SugarBody.body(), container);
+    return container;
+  });
+};
+
+const createToken = (message: string, assertive: boolean): SugarElement<HTMLSpanElement> => {
+  const span = SugarElement.fromTag('span');
+
+  if (assertive) {
+    Attribute.setAll(span, {
+      'aria-live': 'assertive',
+      'aria-atomic': 'true',
+      'role': 'alert'
+    });
+  } else {
+    Attribute.setAll(span, {
+      'role': 'presentation',
+      'aria-live': 'polite',
+      'aria-atomic': 'true',
+      'aria-label': message
+    });
+  }
+
+  Insert.append(span, SugarElement.fromText(message));
+  return span;
+};
+
+/**
+ * Announces a message to screen readers via an aria-live region, without shifting focus.
+ *
+ * @method announce
+ * @param {String} message The message to announce to screen readers.
+ * @param {Object} options Optional settings.
+ * @param {Boolean} options.assertive If true, uses aria-live="assertive" (role="alert") instead of polite.
+ * @example
+ * tinymce.dom.AriaAnnouncer.announce('Bold on');
+ * tinymce.dom.AriaAnnouncer.announce('Error occurred', { assertive: true });
+ */
+const announce = (message: string, options?: { assertive?: boolean }): void => {
+  const container = getOrCreateContainer();
+  const token = createToken(message, options?.assertive === true);
+  Insert.append(container, token);
+  activeTokens++;
+
+  setTimeout(() => {
+    Attribute.remove(token, 'aria-live');
+    Remove.remove(token);
+    activeTokens--;
+    if (activeTokens === 0) {
+      Remove.remove(container);
+    }
+  }, 1000);
+};
+
+const AriaAnnouncer: AriaAnnouncerApi = { announce };
+
+export { announcerContainerId };
+export default AriaAnnouncer;

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -1,0 +1,117 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { SugarBody, type SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import AriaAnnouncer, { announcerContainerId } from 'tinymce/core/api/dom/AriaAnnouncer';
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.AriaAnnouncerTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  const containerSelector = `#${announcerContainerId}`;
+
+  const pGetContainer = (): Promise<SugarElement<HTMLElement>> =>
+    UiFinder.pWaitFor<HTMLElement>('aria announcer container should exist on the body', SugarBody.body(), containerSelector);
+
+  afterEach(async () => {
+    await Waiter.pTryUntil(
+      'Announcer container should be cleaned up between tests',
+      () => UiFinder.notExists(SugarBody.body(), containerSelector),
+      100,
+      3000
+    );
+  });
+
+  it('Container is created lazily on first announce with offscreen styles', async () => {
+    const editor = hook.editor();
+
+    editor.announce('Setup');
+    const container = (await pGetContainer()).dom;
+
+    assert.equal(container.style.position, 'absolute');
+    assert.equal(container.style.left, '-9999px');
+    assert.equal(container.style.overflow, 'hidden');
+  });
+
+  it('Announce creates a polite token with correct attributes', async () => {
+    const editor = hook.editor();
+
+    editor.announce('Bold on');
+    const container = await pGetContainer();
+
+    const token = (await UiFinder.pWaitFor<HTMLElement>('polite token should exist', container, 'span[aria-live="polite"][aria-label="Bold on"]')).dom;
+    assert.equal(token.getAttribute('aria-atomic'), 'true');
+    assert.equal(token.getAttribute('role'), 'presentation');
+    assert.equal(token.textContent, 'Bold on');
+  });
+
+  it('Assertive announce creates an assertive token with correct attributes', async () => {
+    const editor = hook.editor();
+
+    editor.announce('Error occurred', { assertive: true });
+    const container = await pGetContainer();
+
+    const token = (await UiFinder.pWaitFor<HTMLElement>('assertive token should exist', container, 'span[aria-live="assertive"]')).dom;
+    assert.equal(token.getAttribute('aria-atomic'), 'true');
+    assert.equal(token.getAttribute('role'), 'alert');
+    assert.equal(token.textContent, 'Error occurred');
+  });
+
+  it('Token is removed after timeout', async () => {
+    const editor = hook.editor();
+
+    editor.announce('Italic on');
+    const container = await pGetContainer();
+    const tokenSelector = 'span[aria-label="Italic on"]';
+
+    await UiFinder.pWaitFor('token "Italic on" should exist immediately', container, tokenSelector);
+
+    await Waiter.pTryUntil(
+      'Token should be removed after timeout',
+      () => UiFinder.notExists(container, tokenSelector),
+      100,
+      2000
+    );
+  });
+
+  it('Container is removed once all tokens have been cleaned up', async () => {
+    const editor = hook.editor();
+
+    editor.announce('Cleanup');
+    await pGetContainer();
+
+    await Waiter.pTryUntil(
+      'Container should be removed once all tokens have been cleaned up',
+      () => UiFinder.notExists(SugarBody.body(), containerSelector),
+      100,
+      3000
+    );
+  });
+
+  it('Rapid calls create separate tokens for each message', async () => {
+    const editor = hook.editor();
+
+    editor.announce('First');
+    editor.announce('Second');
+    editor.announce('Third');
+    const container = await pGetContainer();
+
+    await UiFinder.pWaitFor('all three tokens should be present', container, 'span[aria-label="Third"]');
+    const tokens = UiFinder.findAllIn<HTMLElement>(container, 'span[aria-live="polite"]');
+    const labels = tokens.map((t) => t.dom.getAttribute('aria-label'));
+    assert.include(labels, 'First');
+    assert.include(labels, 'Second');
+    assert.include(labels, 'Third');
+  });
+
+  it('Announcer is accessible via the tinymce.dom.AriaAnnouncer', async () => {
+    AriaAnnouncer.announce('Global announce');
+    const container = await pGetContainer();
+
+    await UiFinder.pWaitFor('token should be created via the global singleton', container, 'span[aria-label="Global announce"]');
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-12791

Description of Changes:

- Added a new `AriaAnnouncer` module that creates a shared off-screen `aria-live` container on the document body, used to deliver screen reader announcements without shifting focus
- Introduced a public `announce(message, options?)` method on the `Editor` class, supporting both `polite` (default) and `assertive` announcement modes
- The announcer is initialised during editor setup and properly cleaned up (including removing the shared container when no editors remain) when an editor is removed
- Each announcement is injected as a `<span>` token with appropriate `aria-live`, `aria-atomic`, and `role` attributes, then removed from the DOM after 1 second
- The module is based on Alloy `AriaVoice` and tinymcecomments `AriaAnnouncer`

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Add screen reader announcements via editor.announce(message, { assertive?: boolean }) and a public dom AriaAnnouncer API for polite or assertive aria-live messages without shifting focus.
- **Tests**
    - Add browser tests covering on-demand announcer creation, polite/assertive token attributes, lifecycle/timing and cleanup, and multiple rapid announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->