### PR TITLE
TINY-14189: fix content being visible through AI suggestions for transparent background

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
@@ -19,7 +19,8 @@
       min-height: 0;
 
       .tox-ai__iframe {
-        background-color: @edit-area-iframe-background-color;
+        // if the background color of the iframe is transparent, we need to set it to white to prevent the editor content visually showing through the preview
+        background-color: if((alpha(@edit-area-iframe-background-color) > 0), @edit-area-iframe-background-color, @color-white);
         border: @edit-area-border;
         width: 100%;
         height: 100%;


### PR DESCRIPTION
Related Ticket: TINY-14189

Description of Changes:
* Fixed an issue where the AI preview iframe background color would be transparent, causing the editor content to visually show through the preview. The background color now falls back to white when the configured `edit-area-iframe-background-color` has an alpha value of 0 (fully transparent).

Pre-checks:
* [x] Changelog entry added
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI preview display to prevent underlying editor content from appearing through the preview when using transparent background settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->