### PR TITLE
TINY-14272: Remove roving-tabindex pattern from segmented control

### DIFF
--- a/modules/oxide-components/src/main/ts/components/segmentedcontrol/SegmentedControl.tsx
+++ b/modules/oxide-components/src/main/ts/components/segmentedcontrol/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { Arr, Optional, Type } from '@ephox/katamari';
+import { Optional, Type } from '@ephox/katamari';
 import { Attribute, type SugarElement } from '@ephox/sugar';
 import {
   createContext,
@@ -6,11 +6,7 @@ import {
   type PropsWithChildren,
   useContext,
   useEffect,
-  useMemo,
-  useRef,
-  Children,
-  isValidElement,
-  type ReactElement
+  useRef
 } from 'react';
 
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
@@ -20,7 +16,6 @@ interface SegmentedControlContextValue {
   readonly value: string;
   readonly onChange: (value: string) => void;
   readonly disabled?: boolean;
-  readonly firstOptionValue: string | null;
 }
 
 interface SegmentedControlRootProps extends PropsWithChildren<Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>> {
@@ -64,17 +59,6 @@ const Root = forwardRef<HTMLDivElement, SegmentedControlRootProps>(
       }
     }, [ ref ]);
 
-    const firstOptionValue = useMemo(() => {
-      const childArray = Children.toArray(children);
-
-      const validOptions = Arr.filter(childArray, (child): child is ReactElement<SegmentedControlOptionProps> =>
-        isValidElement(child) && typeof child.type !== 'string'
-      );
-
-      const firstNonDisabledOption = Arr.find(validOptions, (option) => !disabled && !option.props.disabled);
-      return firstNonDisabledOption.map((option) => option.props.value).getOrNull();
-    }, [ children, disabled ]);
-
     KeyboardNavigationHooks.useFlowKeyNavigation({
       containerRef,
       selector: '[role="radio"]',
@@ -95,8 +79,7 @@ const Root = forwardRef<HTMLDivElement, SegmentedControlRootProps>(
     const contextValue: SegmentedControlContextValue = {
       value,
       onChange,
-      disabled,
-      firstOptionValue
+      disabled
     };
 
     return (
@@ -126,19 +109,17 @@ const Option = forwardRef<HTMLSpanElement, SegmentedControlOptionProps>((
   const {
     value: selectedValue,
     onChange,
-    disabled: groupDisabled,
-    firstOptionValue
+    disabled: groupDisabled
   } = useSegmentedControlContext();
 
   const isActive = selectedValue === optionValue;
   const isDisabled = groupDisabled || optionDisabled;
-  const isFirstOption = firstOptionValue === optionValue;
 
   const getTabIndex = (): number => {
     if (isDisabled) {
       return -1;
     }
-    return isFirstOption ? 0 : -1;
+    return isActive ? 0 : -1;
   };
 
   const handleClick = () => {

--- a/modules/oxide-components/src/main/ts/components/segmentedcontrol/SegmentedControl.tsx
+++ b/modules/oxide-components/src/main/ts/components/segmentedcontrol/SegmentedControl.tsx
@@ -115,13 +115,6 @@ const Option = forwardRef<HTMLSpanElement, SegmentedControlOptionProps>((
   const isActive = selectedValue === optionValue;
   const isDisabled = groupDisabled || optionDisabled;
 
-  const getTabIndex = (): number => {
-    if (isDisabled) {
-      return -1;
-    }
-    return isActive ? 0 : -1;
-  };
-
   const handleClick = () => {
     if (!isDisabled && !isActive) {
       onChange(optionValue);
@@ -135,7 +128,7 @@ const Option = forwardRef<HTMLSpanElement, SegmentedControlOptionProps>((
       role="radio"
       aria-checked={isActive}
       aria-disabled={isDisabled ? 'true' : 'false'}
-      tabIndex={getTabIndex()}
+      tabIndex={-1}
       data-value={optionValue}
       onClick={handleClick}
     >

--- a/modules/oxide-components/src/test/ts/browser/components/SegmentedControl.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/SegmentedControl.spec.tsx
@@ -92,8 +92,8 @@ describe('browser.components.SegmentedControl', () => {
 
     await expect.poll(() => previewOption.getAttribute('aria-checked')).toBe('true');
     await expect.poll(() => diffOption.getAttribute('aria-checked')).toBe('false');
-    await expect.poll(() => diffOption.getAttribute('tabindex')).toBe('0');
-    await expect.poll(() => previewOption.getAttribute('tabindex')).toBe('-1');
+    await expect.poll(() => diffOption.getAttribute('tabindex')).toBe('-1');
+    await expect.poll(() => previewOption.getAttribute('tabindex')).toBe('0');
   });
 
   it('TINY-13937: Should keep first option in tab order when non-first option is selected', async () => {
@@ -110,8 +110,8 @@ describe('browser.components.SegmentedControl', () => {
 
     expect(diffOption.getAttribute('aria-checked')).toBe('false');
     expect(previewOption.getAttribute('aria-checked')).toBe('true');
-    expect(diffOption.getAttribute('tabindex')).toBe('0');
-    expect(previewOption.getAttribute('tabindex')).toBe('-1');
+    expect(diffOption.getAttribute('tabindex')).toBe('-1');
+    expect(previewOption.getAttribute('tabindex')).toBe('0');
   });
 
   it('TINY-13470: Should work with three or more options', async () => {

--- a/modules/oxide-components/src/test/ts/browser/components/SegmentedControl.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/SegmentedControl.spec.tsx
@@ -5,7 +5,7 @@ import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 
 describe('browser.components.SegmentedControl', () => {
-  it('TINY-13937: Should render with correct initial value and first option in tab order', async () => {
+  it('TINY-13937: Should render with correct initial value', async () => {
     const { container } = render(
       <SegmentedControl.Root value="diff" onChange={vi.fn()}>
         <SegmentedControl.Option value="diff">Diff mode</SegmentedControl.Option>
@@ -23,9 +23,7 @@ describe('browser.components.SegmentedControl', () => {
     const previewOption = options[1] as HTMLElement;
 
     expect(diffOption.getAttribute('aria-checked')).toBe('true');
-    expect(diffOption.getAttribute('tabindex')).toBe('0');
     expect(previewOption.getAttribute('aria-checked')).toBe('false');
-    expect(previewOption.getAttribute('tabindex')).toBe('-1');
   });
 
   it('TINY-13470: Should call onChange when clicking inactive option', async () => {
@@ -65,7 +63,7 @@ describe('browser.components.SegmentedControl', () => {
     expect(onChangeSpy).not.toHaveBeenCalled();
   });
 
-  it('TINY-13937: Should update aria-checked when value changes but keep tabindex on first option', async () => {
+  it('TINY-13937: Should update aria-checked when value changes', async () => {
     const TestComponent = () => {
       const [ value, setValue ] = React.useState('diff');
 
@@ -85,33 +83,11 @@ describe('browser.components.SegmentedControl', () => {
 
     expect(diffOption.getAttribute('aria-checked')).toBe('true');
     expect(previewOption.getAttribute('aria-checked')).toBe('false');
-    expect(diffOption.getAttribute('tabindex')).toBe('0');
-    expect(previewOption.getAttribute('tabindex')).toBe('-1');
 
     await userEvent.click(previewOption);
 
     await expect.poll(() => previewOption.getAttribute('aria-checked')).toBe('true');
     await expect.poll(() => diffOption.getAttribute('aria-checked')).toBe('false');
-    await expect.poll(() => diffOption.getAttribute('tabindex')).toBe('-1');
-    await expect.poll(() => previewOption.getAttribute('tabindex')).toBe('0');
-  });
-
-  it('TINY-13937: Should keep first option in tab order when non-first option is selected', async () => {
-    const { container } = render(
-      <SegmentedControl.Root value="preview" onChange={vi.fn()}>
-        <SegmentedControl.Option value="diff">Diff mode</SegmentedControl.Option>
-        <SegmentedControl.Option value="preview">Preview</SegmentedControl.Option>
-      </SegmentedControl.Root>
-    );
-
-    const options = container.querySelectorAll('[role="radio"]');
-    const diffOption = options[0] as HTMLElement;
-    const previewOption = options[1] as HTMLElement;
-
-    expect(diffOption.getAttribute('aria-checked')).toBe('false');
-    expect(previewOption.getAttribute('aria-checked')).toBe('true');
-    expect(diffOption.getAttribute('tabindex')).toBe('-1');
-    expect(previewOption.getAttribute('tabindex')).toBe('0');
   });
 
   it('TINY-13470: Should work with three or more options', async () => {
@@ -189,25 +165,6 @@ describe('browser.components.SegmentedControl', () => {
     previewOption.click();
 
     expect(onChangeSpy).not.toHaveBeenCalled();
-  });
-
-  it('TINY-13937: Should put first non-disabled option in tab order when first option is disabled', () => {
-    const { container } = render(
-      <SegmentedControl.Root value="preview" onChange={vi.fn()}>
-        <SegmentedControl.Option value="diff" disabled>Diff mode</SegmentedControl.Option>
-        <SegmentedControl.Option value="preview">Preview</SegmentedControl.Option>
-        <SegmentedControl.Option value="edit">Edit</SegmentedControl.Option>
-      </SegmentedControl.Root>
-    );
-
-    const options = container.querySelectorAll('[role="radio"]');
-    const diffOption = options[0] as HTMLElement;
-    const previewOption = options[1] as HTMLElement;
-    const editOption = options[2] as HTMLElement;
-
-    expect(diffOption.getAttribute('tabindex')).toBe('-1');
-    expect(previewOption.getAttribute('tabindex')).toBe('0');
-    expect(editOption.getAttribute('tabindex')).toBe('-1');
   });
 
   it('TINY-13470: Should apply custom className and aria-label', () => {


### PR DESCRIPTION
Related Ticket: TINY-14272

Description of Changes:
Remove roving tab-index pattern from segmented control.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
~~* [] Docs ticket created (if applicable)~~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified segmented control focus/tab behavior: segments no longer use a custom tab-order heuristic; keyboard focus now follows standard/native tabbing and respects disabled state.
* **Tests**
  * Updated segmented control tests to validate selection state (aria-checked) and removed assertions about custom tabindex behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11091)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->