### PR TITLE
TINY-12791: announce toggled format

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/commands/FormatCommands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/FormatCommands.ts
@@ -6,10 +6,18 @@ import type { FormatVars } from '../../fmt/FormatTypes';
 import type Editor from '../Editor';
 import type { ContentLanguage } from '../OptionTypes';
 
+const announceFormatToggle = (editor: Editor, name: string, value?: FormatVars): void => {
+  const state = editor.formatter.match(name, value);
+  const displayName = name.charAt(0).toUpperCase() + name.slice(1);
+  const msg = state ? editor.translate([ '{0} on', editor.translate(displayName) ]) : editor.translate([ '{0} off', editor.translate(displayName) ]);
+  editor.announce(msg);
+};
+
 const registerExecCommands = (editor: Editor): void => {
   const toggleFormat = (name: string, value?: FormatVars) => {
     editor.formatter.toggle(name, value);
     editor.nodeChanged();
+    announceFormatToggle(editor, name, value);
   };
 
   editor.editorCommands.addCommands({

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnounceFormatToggleTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnounceFormatToggleTest.ts
@@ -1,0 +1,114 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
+import { SugarBody } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import { announcerContainerId } from 'tinymce/core/api/dom/AriaAnnouncer';
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.core.AriaAnnounceFormatToggleTest', () => {
+  const hook = TinyHooks.bddSetup<Editor>({
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  const platform = PlatformDetection.detect();
+
+  const containerSelector = `#${announcerContainerId}`;
+
+  const tokenSelector = (label: string): string =>
+    `${containerSelector} span[aria-label="${label}"]`;
+
+  afterEach(async () => {
+    await Waiter.pTryUntil(
+      'Announcer container should be cleaned up between tests',
+      () => UiFinder.notExists(SugarBody.body(), containerSelector),
+      100,
+      3000
+    );
+  });
+
+  const pAssertAnnouncement = (expected: string): Promise<void> =>
+    UiFinder.pWaitFor(
+      `Announcement token for "${expected}" should exist`,
+      SugarBody.body(),
+      tokenSelector(expected)
+    ).then(() => undefined);
+
+  const pWaitForTokenRemoval = (message: string): Promise<void> =>
+    Waiter.pTryUntil(
+      `Announcement token for "${message}" should be removed`,
+      () => UiFinder.notExists(SugarBody.body(), tokenSelector(message)),
+      100,
+      2000
+    );
+
+  const keystroke = (editor: Editor, key: string) => {
+    TinyContentActions.keystroke(editor, key.charCodeAt(0), platform.os.isMacOS() ? { meta: true } : { ctrl: true });
+  };
+
+  const setupEditor = (editor: Editor) => {
+    editor.setContent('<p>abc</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+  };
+
+  it('TINY-12791: Ctrl+B announces "Bold on" then "Bold off"', async () => {
+    const editor = hook.editor();
+    setupEditor(editor);
+
+    keystroke(editor, 'B');
+    await pAssertAnnouncement('Bold on');
+    await pWaitForTokenRemoval('Bold on');
+
+    keystroke(editor, 'B');
+    await pAssertAnnouncement('Bold off');
+  });
+
+  it('TINY-12791: Ctrl+I announces "Italic on" then "Italic off"', async () => {
+    const editor = hook.editor();
+    setupEditor(editor);
+
+    keystroke(editor, 'I');
+    await pAssertAnnouncement('Italic on');
+    await pWaitForTokenRemoval('Italic on');
+
+    keystroke(editor, 'I');
+    await pAssertAnnouncement('Italic off');
+  });
+
+  it('TINY-12791: execCommand Bold announces "Bold on" then "Bold off"', async () => {
+    const editor = hook.editor();
+    setupEditor(editor);
+
+    editor.execCommand('Bold');
+    await pAssertAnnouncement('Bold on');
+    await pWaitForTokenRemoval('Bold on');
+
+    editor.execCommand('Bold');
+    await pAssertAnnouncement('Bold off');
+  });
+
+  it('TINY-12791: execCommand Strikethrough announces correctly', async () => {
+    const editor = hook.editor();
+    setupEditor(editor);
+
+    editor.execCommand('Strikethrough');
+    await pAssertAnnouncement('Strikethrough on');
+    await pWaitForTokenRemoval('Strikethrough on');
+
+    editor.execCommand('Strikethrough');
+    await pAssertAnnouncement('Strikethrough off');
+  });
+
+  it('TINY-12791: mceToggleFormat for Bold announces correctly', async () => {
+    const editor = hook.editor();
+    setupEditor(editor);
+
+    editor.execCommand('mceToggleFormat', false, 'bold');
+    await pAssertAnnouncement('Bold on');
+    await pWaitForTokenRemoval('Bold on');
+
+    editor.execCommand('mceToggleFormat', false, 'bold');
+    await pAssertAnnouncement('Bold off');
+  });
+});


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Format toggle commands (Bold, Italic, Strikethrough, etc.) now automatically announce their new state (e.g. "Bold on" / "Bold off") to screen readers whenever a format is toggled via keyboard shortcut or `execCommand`

Pre-checks:

- [ ] Changelog entry added
- [ ] Tests have been added (if applicable)
- [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [ ] Milestone set
- [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):