### PR TITLE
TINY-13585: Add pointerevents support to Agar

### DIFF
--- a/.changes/unreleased/agar-TINY-13585-2026-04-28.yaml
+++ b/.changes/unreleased/agar-TINY-13585-2026-04-28.yaml
@@ -1,0 +1,6 @@
+project: agar
+kind: Added
+body: Added `mouseEnter` and `mouseLeave` to the `Mouse` API.
+time: 2026-04-28T08:43:24.354477+02:00
+custom:
+    Issue: TINY-13585

--- a/.changes/unreleased/agar-TINY-13585-2026-04-29.yaml
+++ b/.changes/unreleased/agar-TINY-13585-2026-04-29.yaml
@@ -1,0 +1,6 @@
+project: agar
+kind: Added
+body: Added new `Pointer` API.
+time: 2026-04-29T08:49:38.406668+02:00
+custom:
+    Issue: TINY-13585

--- a/modules/agar/src/main/ts/ephox/agar/api/Main.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Main.ts
@@ -26,6 +26,7 @@ import { Monitor } from './Monitor';
 import * as Mouse from './Mouse';
 import { NamedChain } from './NamedChain';
 import { Pipeline } from './Pipeline';
+import * as Pointer from './Pointer';
 import * as PropertySteps from './PropertySteps';
 import * as RealClipboard from './RealClipboard';
 import { type KeyPressAdt, RealKeys } from './RealKeys';
@@ -70,6 +71,7 @@ export {
   Logger,
   Monitor,
   Mouse,
+  Pointer,
   NamedChain,
   Pipeline,
   PropertySteps,

--- a/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Mouse.ts
@@ -14,6 +14,8 @@ const mouseDown = (element: SugarElement<Node>, settings: Clicks.Settings = { })
 const mouseUp = (element: SugarElement<Node>, settings: Clicks.Settings = { }): void => Clicks.mouseUp(settings)(element);
 const mouseMove = (element: SugarElement<Node>, settings: Clicks.Settings = { }): void => Clicks.mouseMove(settings)(element);
 const mouseOut = (element: SugarElement<Node>, settings: Clicks.Settings = { }): void => Clicks.mouseOut(settings)(element);
+const mouseEnter = (element: SugarElement<Node>, settings: Clicks.Settings = { }): void => Clicks.mouseEnter(settings)(element);
+const mouseLeave = (element: SugarElement<Node>, settings: Clicks.Settings = { }): void => Clicks.mouseLeave(settings)(element);
 const mouseMoveTo = (element: SugarElement<Node>, dx: number, dy: number, settings: Omit<Clicks.Settings, 'dx' | 'dy'> = { }): void =>
   Clicks.mouseMove({ ...settings, dx, dy })(element);
 const mouseUpTo = (element: SugarElement<Node>, dx: number, dy: number, settings: Omit<Clicks.Settings, 'dx' | 'dy'> = { }): void =>
@@ -183,6 +185,8 @@ export {
   mouseMove,
   mouseMoveTo,
   mouseOut,
+  mouseEnter,
+  mouseLeave,
 
   clickOn,
   clickByLabel,

--- a/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import type { SugarElement } from '@ephox/sugar';
 
 import * as Pointers from '../pointer/Pointers';
@@ -8,6 +9,32 @@ const pointerMove = (element: SugarElement<Node>, settings: Pointers.Settings = 
 const pointerMoveTo = (element: SugarElement<Node>, dx: number, dy: number, settings: Omit<Pointers.Settings, 'dx' | 'dy'> = { }): void =>
   Pointers.pointerMove({ ...settings, dx, dy })(element);
 
+interface MockPointerCaptureOptions {
+  setPointerCapture?: (pointerId: number) => void;
+  releasePointerCapture?: (pointerId: number) => void;
+}
+
+const pWithMockPointerCapture = async <T>(
+  element: SugarElement<Element>,
+  options: MockPointerCaptureOptions,
+  callback: () => Promise<T>
+): Promise<T> => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalSetPointerCapture = element.dom.setPointerCapture;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalReleasePointerCapture = element.dom.releasePointerCapture;
+
+  element.dom.setPointerCapture = options.setPointerCapture ?? Fun.noop;
+  element.dom.releasePointerCapture = options.releasePointerCapture ?? Fun.noop;
+
+  try {
+    return await callback();
+  } finally {
+    element.dom.setPointerCapture = originalSetPointerCapture;
+    element.dom.releasePointerCapture = originalReleasePointerCapture;
+  }
+};
+
 const event = Pointers.event;
 
 export {
@@ -15,5 +42,6 @@ export {
   pointerUp,
   pointerMove,
   pointerMoveTo,
+  pWithMockPointerCapture,
   event
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
@@ -10,8 +10,8 @@ const pointerMoveBy = (element: SugarElement<Node>, dx: number, dy: number, sett
   Pointers.pointerMove({ ...settings, dx, dy })(element);
 
 interface MockPointerCaptureOptions {
-  setPointerCapture?: (pointerId: number) => void;
-  releasePointerCapture?: (pointerId: number) => void;
+  readonly setPointerCapture?: (pointerId: number) => void;
+  readonly releasePointerCapture?: (pointerId: number) => void;
 }
 
 const pWithMockPointerCapture = async <T>(

--- a/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
@@ -17,7 +17,7 @@ interface MockPointerCaptureOptions {
 const pWithMockPointerCapture = async <T>(
   element: SugarElement<Element>,
   options: MockPointerCaptureOptions,
-  callback: () => Promise<T>
+  callback: () => T
 ): Promise<T> => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalSetPointerCapture = element.dom.setPointerCapture;

--- a/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
@@ -17,7 +17,7 @@ interface MockPointerCaptureOptions {
 const pWithMockPointerCapture = async <T>(
   element: SugarElement<Element>,
   options: MockPointerCaptureOptions,
-  callback: () => T
+  callback: () => T | Promise<T>
 ): Promise<T> => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalSetPointerCapture = element.dom.setPointerCapture;

--- a/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
@@ -6,7 +6,7 @@ import * as Pointers from '../pointer/Pointers';
 const pointerDown = (element: SugarElement<Node>, settings: Pointers.Settings = { }): void => Pointers.pointerDown(settings)(element);
 const pointerUp = (element: SugarElement<Node>, settings: Pointers.Settings = { }): void => Pointers.pointerUp(settings)(element);
 const pointerMove = (element: SugarElement<Node>, settings: Pointers.Settings = { }): void => Pointers.pointerMove(settings)(element);
-const pointerMoveTo = (element: SugarElement<Node>, dx: number, dy: number, settings: Omit<Pointers.Settings, 'dx' | 'dy'> = { }): void =>
+const pointerMoveBy = (element: SugarElement<Node>, dx: number, dy: number, settings: Omit<Pointers.Settings, 'dx' | 'dy'> = { }): void =>
   Pointers.pointerMove({ ...settings, dx, dy })(element);
 
 interface MockPointerCaptureOptions {
@@ -41,7 +41,7 @@ export {
   pointerDown,
   pointerUp,
   pointerMove,
-  pointerMoveTo,
+  pointerMoveBy,
   pWithMockPointerCapture,
   event
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Pointer.ts
@@ -1,0 +1,19 @@
+import type { SugarElement } from '@ephox/sugar';
+
+import * as Pointers from '../pointer/Pointers';
+
+const pointerDown = (element: SugarElement<Node>, settings: Pointers.Settings = { }): void => Pointers.pointerDown(settings)(element);
+const pointerUp = (element: SugarElement<Node>, settings: Pointers.Settings = { }): void => Pointers.pointerUp(settings)(element);
+const pointerMove = (element: SugarElement<Node>, settings: Pointers.Settings = { }): void => Pointers.pointerMove(settings)(element);
+const pointerMoveTo = (element: SugarElement<Node>, dx: number, dy: number, settings: Omit<Pointers.Settings, 'dx' | 'dy'> = { }): void =>
+  Pointers.pointerMove({ ...settings, dx, dy })(element);
+
+const event = Pointers.event;
+
+export {
+  pointerDown,
+  pointerUp,
+  pointerMove,
+  pointerMoveTo,
+  event
+};

--- a/modules/agar/src/main/ts/ephox/agar/mouse/Clicks.ts
+++ b/modules/agar/src/main/ts/ephox/agar/mouse/Clicks.ts
@@ -30,7 +30,7 @@ interface Settings {
 }
 
 // Types of events
-type EventType = 'click' | 'mousedown' | 'mouseup' | 'mousemove' | 'mouseover' | 'mouseout' | 'contextmenu' | 'dblclick';
+type EventType = 'click' | 'mousedown' | 'mouseup' | 'mousemove' | 'mouseover' | 'mouseout' | 'mouseenter' | 'mouseleave' | 'contextmenu' | 'dblclick';
 
 // Fire an event
 const event = (type: EventType, { dx, dy, ...settings }: Settings) => (element: SugarElement<Node>): void => {
@@ -58,6 +58,10 @@ const mouseOver = Fun.curry(event, 'mouseover');
 const mouseOut = Fun.curry(event, 'mouseout');
 const contextMenu = (settings: Settings): (element: SugarElement<Node>) => void =>
   event('contextmenu', { button: rightClickButton, ...settings });
+const mouseEnter = (settings: Settings): (element: SugarElement<Node>) => void =>
+  event('mouseenter', { bubbles: false, ...settings });
+const mouseLeave = (settings: Settings): (element: SugarElement<Node>) => void =>
+  event('mouseleave', { bubbles: false, ...settings });
 const dblclick = Fun.curry(event, 'dblclick');
 
 // Note: This can be used for phantomjs.
@@ -100,6 +104,8 @@ export {
   mouseMove,
   mouseOver,
   mouseOut,
+  mouseEnter,
+  mouseLeave,
   contextMenu,
   point,
   trigger,

--- a/modules/agar/src/main/ts/ephox/agar/pointer/Pointers.ts
+++ b/modules/agar/src/main/ts/ephox/agar/pointer/Pointers.ts
@@ -1,9 +1,6 @@
 import { Fun } from '@ephox/katamari';
 import { type SugarElement, SugarLocation, SugarNode, SugarPosition } from '@ephox/sugar';
 
-// TODO: The most important part in simulating these is what fields to setup and how.
-// This has ben ai generated, so it has to be verified manually before mering the pr
-
 // Settings for pointer events
 interface Settings {
   // used to tweak the location before firing the event
@@ -26,7 +23,6 @@ interface Settings {
   pressure?: number;
   tiltX?: number;
   tiltY?: number;
-  pointerType?: string;
   isPrimary?: boolean;
 }
 

--- a/modules/agar/src/main/ts/ephox/agar/pointer/Pointers.ts
+++ b/modules/agar/src/main/ts/ephox/agar/pointer/Pointers.ts
@@ -1,7 +1,6 @@
 import { Fun } from '@ephox/katamari';
 import { type SugarElement, SugarLocation, SugarNode, SugarPosition } from '@ephox/sugar';
 
-// Settings for pointer events
 interface Settings {
   // used to tweak the location before firing the event
   dx?: number;
@@ -31,7 +30,8 @@ type EventType = 'pointerdown' | 'pointerup' | 'pointermove';
 
 // Fire an event
 const event = (type: EventType, { dx, dy, ...settings }: Settings) => (element: SugarElement<Node>): void => {
-  const location = (SugarNode.isElement(element) ? SugarLocation.absolute(element) : SugarPosition(0, 0)).translate(dx || 0, dy || 0);
+  const basePosition = SugarNode.isElement(element) ? SugarLocation.absolute(element) : SugarPosition(0, 0);
+  const location = basePosition.translate(dx ?? 0, dy ?? 0);
   const event = new window.PointerEvent(type, {
     screenX: location.left,
     screenY: location.top,

--- a/modules/agar/src/main/ts/ephox/agar/pointer/Pointers.ts
+++ b/modules/agar/src/main/ts/ephox/agar/pointer/Pointers.ts
@@ -1,0 +1,61 @@
+import { Fun } from '@ephox/katamari';
+import { type SugarElement, SugarLocation, SugarNode, SugarPosition } from '@ephox/sugar';
+
+// TODO: The most important part in simulating these is what fields to setup and how.
+// This has ben ai generated, so it has to be verified manually before mering the pr
+
+// Settings for pointer events
+interface Settings {
+  // used to tweak the location before firing the event
+  dx?: number;
+  dy?: number;
+  // settings for the event itself
+  button?: number;
+  buttons?: number;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+  bubbles?: boolean;
+  cancelable?: boolean;
+  detail?: number;
+  // pointer-specific settings
+  pointerId?: number;
+  width?: number;
+  height?: number;
+  pressure?: number;
+  tiltX?: number;
+  tiltY?: number;
+  pointerType?: string;
+  isPrimary?: boolean;
+}
+
+// Types of events
+type EventType = 'pointerdown' | 'pointerup' | 'pointermove';
+
+// Fire an event
+const event = (type: EventType, { dx, dy, ...settings }: Settings) => (element: SugarElement<Node>): void => {
+  const location = (SugarNode.isElement(element) ? SugarLocation.absolute(element) : SugarPosition(0, 0)).translate(dx || 0, dy || 0);
+  const event = new window.PointerEvent(type, {
+    screenX: location.left,
+    screenY: location.top,
+    clientX: location.left,
+    clientY: location.top,
+    bubbles: true,
+    cancelable: true,
+    ...settings
+  });
+  element.dom.dispatchEvent(event);
+};
+
+const pointerDown = Fun.curry(event, 'pointerdown');
+const pointerUp = Fun.curry(event, 'pointerup');
+const pointerMove = Fun.curry(event, 'pointermove');
+
+export type { Settings, EventType };
+export {
+  event,
+  pointerDown,
+  pointerUp,
+  pointerMove
+};

--- a/modules/agar/src/test/ts/browser/MouseTest.ts
+++ b/modules/agar/src/test/ts/browser/MouseTest.ts
@@ -24,7 +24,7 @@ UnitTest.asynctest('MouseTest', (success, failure) => {
   let repository = [];
 
   // TODO: Free handlers.
-  const handlers = Arr.bind([ 'mousedown', 'mouseup', 'mouseover', 'click', 'focus', 'contextmenu' ], (evt) =>
+  const handlers = Arr.bind([ 'mousedown', 'mouseup', 'mouseover', 'click', 'focus', 'contextmenu', 'mouseenter', 'mouseleave' ], (evt) =>
     [
       DomEvent.bind(container, evt, () => {
         repository.push('container.' + evt);
@@ -104,6 +104,18 @@ UnitTest.asynctest('MouseTest', (success, failure) => {
       'sHoverOn (container > input)',
       [ 'input.mouseover', 'container.mouseover' ],
       Mouse.sHoverOn(container, 'input')
+    ),
+
+    runStep(
+      'mouseEnter (container > input)',
+      [ 'input.mouseenter' ],
+      Step.sync(() => Mouse.mouseEnter(input))
+    ),
+
+    runStep(
+      'mouseLeave (container > input)',
+      [ 'input.mouseleave' ],
+      Step.sync(() => Mouse.mouseLeave(input))
     ),
 
     runStep(

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -1,11 +1,12 @@
-import { afterEach, Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
+import { afterEach, Assert, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun } from '@ephox/katamari';
-import { DomEvent, Insert, Remove, SugarElement } from '@ephox/sugar';
+import { DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { assert } from 'chai';
 
 import * as Pointer from 'ephox/agar/api/Pointer';
 
 describe('browser.agar.PointerTest', () => {
-  const body = SugarElement.fromDom(document.body);
+  const body = SugarBody.body();
   let container: SugarElement<HTMLElement>;
   let input: SugarElement<HTMLInputElement>;
   let repository: string[];
@@ -118,67 +119,65 @@ describe('browser.agar.PointerTest', () => {
     Assert.eq('button should be 1', 1, receivedEvent?.button);
   });
 
-  it('pWithMockPointerCapture substitutes setPointerCapture and releasePointerCapture', async () => {
-    const setCalls: number[] = [];
-    const releaseCalls: number[] = [];
+  context('pWithMockPointerCapture', () => {
+    it('pWithMockPointerCapture substitutes setPointerCapture and releasePointerCapture', async () => {
+      const events: string[] = [];
 
-    await Pointer.pWithMockPointerCapture(input, {
-      setPointerCapture: (id) => setCalls.push(id),
-      releasePointerCapture: (id) => releaseCalls.push(id)
-    }, async () => {
-      input.dom.setPointerCapture(1);
-      input.dom.releasePointerCapture(1);
-    });
-
-    Assert.eq('setPointerCapture called with pointerId 1', [ 1 ], setCalls);
-    Assert.eq('releasePointerCapture called with pointerId 1', [ 1 ], releaseCalls);
-  });
-
-  it('pWithMockPointerCapture restores originals after callback', async () => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalSet = input.dom.setPointerCapture;
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalRelease = input.dom.releasePointerCapture;
-
-    await Pointer.pWithMockPointerCapture(input, {
-      setPointerCapture: Fun.noop,
-      releasePointerCapture: Fun.noop
-    }, async () => {
-      Assert.eq('setPointerCapture should be replaced', true, input.dom.setPointerCapture !== originalSet);
-      Assert.eq('releasePointerCapture should be replaced', true, input.dom.releasePointerCapture !== originalRelease);
-    });
-
-    Assert.eq('setPointerCapture should be restored', originalSet, input.dom.setPointerCapture);
-    Assert.eq('releasePointerCapture should be restored', originalRelease, input.dom.releasePointerCapture);
-  });
-
-  it('pWithMockPointerCapture restores originals even if callback throws', async () => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalSet = input.dom.setPointerCapture;
-
-    try {
       await Pointer.pWithMockPointerCapture(input, {
-        setPointerCapture: Fun.noop
+        setPointerCapture: (id) => events.push(`setPointerCapture(${id})`),
+        releasePointerCapture: (id) => events.push(`releasePointerCapture(${id})`)
       }, async () => {
-        throw new Error('test error');
+        input.dom.setPointerCapture(1);
+        input.dom.releasePointerCapture(1);
       });
-    } catch {
-      // expected
-    }
 
-    Assert.eq('setPointerCapture should be restored after error', originalSet, input.dom.setPointerCapture);
-  });
-
-  it('pWithMockPointerCapture defaults to noop when stubs not provided', async () => {
-    await Pointer.pWithMockPointerCapture(input, {}, async () => {
-      // Should not throw even though no stubs were provided
-      input.dom.setPointerCapture(1);
-      input.dom.releasePointerCapture(1);
+      Assert.eq('setPointerCapture and releasePointerCapture should be replaced', [ 'setPointerCapture(1)', 'releasePointerCapture(1)' ], events);
     });
-  });
 
-  it('pWithMockPointerCapture returns the callback result', async () => {
-    const result = await Pointer.pWithMockPointerCapture(input, {}, async () => 42);
-    Assert.eq('should return callback result', 42, result);
+    it('pWithMockPointerCapture restores originals after callback', async () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalSet = input.dom.setPointerCapture;
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalRelease = input.dom.releasePointerCapture;
+
+      await Pointer.pWithMockPointerCapture(input, {}, async () => {
+        Assert.eq('setPointerCapture should be replaced', true, input.dom.setPointerCapture !== originalSet);
+        Assert.eq('releasePointerCapture should be replaced', true, input.dom.releasePointerCapture !== originalRelease);
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      Assert.eq('setPointerCapture should be restored', originalSet, input.dom.setPointerCapture);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      Assert.eq('releasePointerCapture should be restored', originalRelease, input.dom.releasePointerCapture);
+    });
+
+    it('pWithMockPointerCapture restores originals even if callback throws', async () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalSet = input.dom.setPointerCapture;
+
+      try {
+        await Pointer.pWithMockPointerCapture(input, {}, async () => {
+          throw new Error('test error');
+        });
+      } catch {
+        // expected
+      }
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      Assert.eq('setPointerCapture should be restored after error', originalSet, input.dom.setPointerCapture);
+    });
+
+    it('pWithMockPointerCapture defaults to noop when stubs not provided', async () => {
+      await Pointer.pWithMockPointerCapture(input, {}, async () => {
+        input.dom.setPointerCapture(1);
+        input.dom.releasePointerCapture(1);
+      });
+    });
+
+    // TODO: add support for non promise returning functions
+    it('pWithMockPointerCapture returns the callback result', async () => {
+      const result = await Pointer.pWithMockPointerCapture(input, {}, async () => 40 + 2);
+      Assert.eq('should return callback result', 42, result);
+    });
   });
 });

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -1,7 +1,6 @@
 import { afterEach, Assert, beforeEach, context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Fun } from '@ephox/katamari';
-import { DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
-import { assert } from 'chai';
+import { Arr, Singleton } from '@ephox/katamari';
+import { Css, DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import * as Pointer from 'ephox/agar/api/Pointer';
 
@@ -9,12 +8,18 @@ describe('browser.agar.PointerTest', () => {
   const body = SugarBody.body();
   let container: SugarElement<HTMLElement>;
   let input: SugarElement<HTMLInputElement>;
+  const inputLatestEvent = Singleton.value<PointerEvent>();
   let repository: string[];
   let handlers: { unbind: () => void }[];
 
   beforeEach(() => {
     container = SugarElement.fromTag('div');
     input = SugarElement.fromTag('input');
+    Css.setAll(input, {
+      position: 'fixed',
+      top: '0',
+      left: '0'
+    });
     Insert.append(container, input);
     Insert.append(body, container);
 
@@ -23,14 +28,16 @@ describe('browser.agar.PointerTest', () => {
       DomEvent.bind(container, evt, () => {
         repository.push('container.' + evt);
       }),
-      DomEvent.bind(input, evt, () => {
+      DomEvent.bind(input, evt, (event) => {
         repository.push('input.' + evt);
+        inputLatestEvent.set(event.raw as PointerEvent);
       })
     ]);
   });
 
   afterEach(() => {
     Arr.each(handlers, (h) => h.unbind());
+    inputLatestEvent.clear();
     Remove.remove(container);
   });
 
@@ -49,74 +56,65 @@ describe('browser.agar.PointerTest', () => {
     Assert.eq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ], repository);
   });
 
-  it('pointerDown on container fires only on container', () => {
-    Pointer.pointerDown(container);
-    Assert.eq('pointerdown on container', [ 'container.pointerdown' ], repository);
-  });
-
   it('pointerDown passes settings to the event', () => {
-    let receivedEvent: PointerEvent | undefined;
-    const handler = DomEvent.bind(input, 'pointerdown', (evt) => {
-      receivedEvent = evt.raw as PointerEvent;
-    });
-
     Pointer.pointerDown(input, { button: 2, shiftKey: true });
-    handler.unbind();
 
-    Assert.eq('button should be 2', 2, receivedEvent?.button);
-    Assert.eq('shiftKey should be true', true, receivedEvent?.shiftKey);
+    Assert.eq('event should be captured', true, inputLatestEvent.isSet());
+    const event = inputLatestEvent.get().getOrDie();
+
+    Assert.eq('pointer down should be latest event', 'pointerdown', event.type);
+    Assert.eq('button should be 2', 2, event.button);
+    Assert.eq('shiftKey should be true', true, event.shiftKey);
   });
 
   it('pointerUp passes settings to the event', () => {
-    let receivedEvent: PointerEvent | undefined;
-    const handler = DomEvent.bind(input, 'pointerup', (evt) => {
-      receivedEvent = evt.raw as PointerEvent;
-    });
+    Pointer.pointerUp(input, { button: 2, shiftKey: true });
 
-    Pointer.pointerUp(input, { ctrlKey: true });
-    handler.unbind();
+    Assert.eq('event should be captured', true, inputLatestEvent.isSet());
+    const event = inputLatestEvent.get().getOrDie();
 
-    Assert.eq('ctrlKey should be true', true, receivedEvent?.ctrlKey);
+    Assert.eq('pointer up should be latest event', 'pointerup', event.type);
+    Assert.eq('button should be 2', 2, event.button);
+    Assert.eq('shiftKey should be true', true, event.shiftKey);
+  });
+
+  it('pointerMove passes settings to the event', () => {
+    Pointer.pointerMove(input, { button: 2, shiftKey: true });
+
+    Assert.eq('event should be captured', true, inputLatestEvent.isSet());
+    const event = inputLatestEvent.get().getOrDie();
+
+    Assert.eq('pointer move should be latest event', 'pointermove', event.type);
+    Assert.eq('button should be 2', 2, event.button);
+    Assert.eq('shiftKey should be true', true, event.shiftKey);
   });
 
   it('pointerMove passes dx/dy offsets to coordinates', () => {
-    let receivedEvent: PointerEvent | undefined;
-    const handler = DomEvent.bind(input, 'pointermove', (evt) => {
-      receivedEvent = evt.raw as PointerEvent;
-    });
-
     Pointer.pointerMove(input, { dx: 10, dy: 20 });
-    handler.unbind();
 
-    // The coordinates should include the element's absolute position plus the offsets
-    Assert.eq('clientX should include dx offset', true, receivedEvent !== undefined);
-    Assert.eq('clientY should include dy offset', true, receivedEvent !== undefined);
+    Assert.eq('event should be captured', true, inputLatestEvent.isSet());
+    const event = inputLatestEvent.get().getOrDie();
+
+    Assert.eq('pointer move should be latest event', 'pointermove', event.type);
+
+    Assert.eq('clientX should be set', 10, event.clientX);
+    Assert.eq('clientY should be set', 20, event.clientY);
+    Assert.eq('screenX should be set', 10, event.clientX);
+    Assert.eq('screenY should be set', 20, event.clientY);
   });
 
   it('pointerMoveBy fires pointermove with dx/dy offsets', () => {
-    let receivedEvent: PointerEvent | undefined;
-    const handler = DomEvent.bind(input, 'pointermove', (evt) => {
-      receivedEvent = evt.raw as PointerEvent;
-    });
+    Pointer.pointerMoveBy(input, 10, 20);
 
-    Pointer.pointerMoveBy(input, 15, 25);
-    handler.unbind();
+    Assert.eq('event should be captured', true, inputLatestEvent.isSet());
+    const event = inputLatestEvent.get().getOrDie();
 
-    Assert.eq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ], repository);
-    Assert.eq('event should have been received', true, receivedEvent !== undefined);
-  });
+    Assert.eq('pointer move should be latest event', 'pointermove', event.type);
 
-  it('pointerMoveBy passes additional settings to the event', () => {
-    let receivedEvent: PointerEvent | undefined;
-    const handler = DomEvent.bind(input, 'pointermove', (evt) => {
-      receivedEvent = evt.raw as PointerEvent;
-    });
-
-    Pointer.pointerMoveBy(input, 10, 20, { shiftKey: true, button: 1 });
-    handler.unbind();
-
-    Assert.eq('shiftKey should be true', true, receivedEvent?.shiftKey);
-    Assert.eq('button should be 1', 1, receivedEvent?.button);
+    Assert.eq('clientX should be set', 10, event.clientX);
+    Assert.eq('clientY should be set', 20, event.clientY);
+    Assert.eq('screenX should be set', 10, event.clientX);
+    Assert.eq('screenY should be set', 20, event.clientY);
   });
 
   context('pWithMockPointerCapture', () => {

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -1,0 +1,120 @@
+import { afterEach, Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { DomEvent, Insert, Remove, SugarElement } from '@ephox/sugar';
+
+import * as Pointer from 'ephox/agar/api/Pointer';
+
+describe('browser.agar.PointerTest', () => {
+  const body = SugarElement.fromDom(document.body);
+  let container: SugarElement<HTMLElement>;
+  let input: SugarElement<HTMLInputElement>;
+  let repository: string[];
+  let handlers: { unbind: () => void }[];
+
+  beforeEach(() => {
+    container = SugarElement.fromTag('div');
+    input = SugarElement.fromTag('input');
+    Insert.append(container, input);
+    Insert.append(body, container);
+
+    repository = [];
+    handlers = Arr.bind([ 'pointerdown', 'pointerup', 'pointermove' ], (evt) => [
+      DomEvent.bind(container, evt, () => {
+        repository.push('container.' + evt);
+      }),
+      DomEvent.bind(input, evt, () => {
+        repository.push('input.' + evt);
+      })
+    ]);
+  });
+
+  afterEach(() => {
+    Arr.each(handlers, (h) => h.unbind());
+    Remove.remove(container);
+  });
+
+  it('pointerDown fires pointerdown on element', () => {
+    Pointer.pointerDown(input);
+    Assert.eq('pointerdown should bubble', [ 'input.pointerdown', 'container.pointerdown' ], repository);
+  });
+
+  it('pointerUp fires pointerup on element', () => {
+    Pointer.pointerUp(input);
+    Assert.eq('pointerup should bubble', [ 'input.pointerup', 'container.pointerup' ], repository);
+  });
+
+  it('pointerMove fires pointermove on element', () => {
+    Pointer.pointerMove(input);
+    Assert.eq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ], repository);
+  });
+
+  it('pointerDown on container fires only on container', () => {
+    Pointer.pointerDown(container);
+    Assert.eq('pointerdown on container', [ 'container.pointerdown' ], repository);
+  });
+
+  it('pointerDown passes settings to the event', () => {
+    let receivedEvent: PointerEvent | undefined;
+    const handler = DomEvent.bind(input, 'pointerdown', (evt) => {
+      receivedEvent = evt.raw as PointerEvent;
+    });
+
+    Pointer.pointerDown(input, { button: 2, shiftKey: true });
+    handler.unbind();
+
+    Assert.eq('button should be 2', 2, receivedEvent?.button);
+    Assert.eq('shiftKey should be true', true, receivedEvent?.shiftKey);
+  });
+
+  it('pointerUp passes settings to the event', () => {
+    let receivedEvent: PointerEvent | undefined;
+    const handler = DomEvent.bind(input, 'pointerup', (evt) => {
+      receivedEvent = evt.raw as PointerEvent;
+    });
+
+    Pointer.pointerUp(input, { ctrlKey: true });
+    handler.unbind();
+
+    Assert.eq('ctrlKey should be true', true, receivedEvent?.ctrlKey);
+  });
+
+  it('pointerMove passes dx/dy offsets to coordinates', () => {
+    let receivedEvent: PointerEvent | undefined;
+    const handler = DomEvent.bind(input, 'pointermove', (evt) => {
+      receivedEvent = evt.raw as PointerEvent;
+    });
+
+    Pointer.pointerMove(input, { dx: 10, dy: 20 });
+    handler.unbind();
+
+    // The coordinates should include the element's absolute position plus the offsets
+    Assert.eq('clientX should include dx offset', true, receivedEvent !== undefined);
+    Assert.eq('clientY should include dy offset', true, receivedEvent !== undefined);
+  });
+
+  it('pointerMoveTo fires pointermove with dx/dy offsets', () => {
+    let receivedEvent: PointerEvent | undefined;
+    const handler = DomEvent.bind(input, 'pointermove', (evt) => {
+      receivedEvent = evt.raw as PointerEvent;
+    });
+
+    Pointer.pointerMoveTo(input, 15, 25);
+    handler.unbind();
+
+    Assert.eq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ], repository);
+    Assert.eq('event should have been received', true, receivedEvent !== undefined);
+  });
+
+  it('pointerMoveTo passes additional settings to the event', () => {
+    let receivedEvent: PointerEvent | undefined;
+    const handler = DomEvent.bind(input, 'pointermove', (evt) => {
+      receivedEvent = evt.raw as PointerEvent;
+    });
+
+    Pointer.pointerMoveTo(input, 10, 20, { shiftKey: true, button: 1 });
+    handler.unbind();
+
+    Assert.eq('shiftKey should be true', true, receivedEvent?.shiftKey);
+    Assert.eq('button should be 1', 1, receivedEvent?.button);
+  });
+});

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -99,8 +99,8 @@ describe('browser.agar.PointerTest', () => {
 
     Assert.eq('clientX should be set', 10, event.clientX);
     Assert.eq('clientY should be set', 20, event.clientY);
-    Assert.eq('screenX should be set', 10, event.clientX);
-    Assert.eq('screenY should be set', 20, event.clientY);
+    Assert.eq('screenX should be set', 10, event.screenX);
+    Assert.eq('screenY should be set', 20, event.screenY);
   });
 
   it('pointerMoveBy fires pointermove with dx/dy offsets', () => {
@@ -113,8 +113,8 @@ describe('browser.agar.PointerTest', () => {
 
     Assert.eq('clientX should be set', 10, event.clientX);
     Assert.eq('clientY should be set', 20, event.clientY);
-    Assert.eq('screenX should be set', 10, event.clientX);
-    Assert.eq('screenY should be set', 20, event.clientY);
+    Assert.eq('screenX should be set', 10, event.screenX);
+    Assert.eq('screenY should be set', 20, event.screenY);
   });
 
   context('pWithMockPointerCapture', () => {

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -1,5 +1,5 @@
 import { afterEach, Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Fun } from '@ephox/katamari';
 import { DomEvent, Insert, Remove, SugarElement } from '@ephox/sugar';
 
 import * as Pointer from 'ephox/agar/api/Pointer';
@@ -116,5 +116,69 @@ describe('browser.agar.PointerTest', () => {
 
     Assert.eq('shiftKey should be true', true, receivedEvent?.shiftKey);
     Assert.eq('button should be 1', 1, receivedEvent?.button);
+  });
+
+  it('pWithMockPointerCapture substitutes setPointerCapture and releasePointerCapture', async () => {
+    const setCalls: number[] = [];
+    const releaseCalls: number[] = [];
+
+    await Pointer.pWithMockPointerCapture(input, {
+      setPointerCapture: (id) => setCalls.push(id),
+      releasePointerCapture: (id) => releaseCalls.push(id)
+    }, async () => {
+      input.dom.setPointerCapture(1);
+      input.dom.releasePointerCapture(1);
+    });
+
+    Assert.eq('setPointerCapture called with pointerId 1', [ 1 ], setCalls);
+    Assert.eq('releasePointerCapture called with pointerId 1', [ 1 ], releaseCalls);
+  });
+
+  it('pWithMockPointerCapture restores originals after callback', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalSet = input.dom.setPointerCapture;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalRelease = input.dom.releasePointerCapture;
+
+    await Pointer.pWithMockPointerCapture(input, {
+      setPointerCapture: Fun.noop,
+      releasePointerCapture: Fun.noop
+    }, async () => {
+      Assert.eq('setPointerCapture should be replaced', true, input.dom.setPointerCapture !== originalSet);
+      Assert.eq('releasePointerCapture should be replaced', true, input.dom.releasePointerCapture !== originalRelease);
+    });
+
+    Assert.eq('setPointerCapture should be restored', originalSet, input.dom.setPointerCapture);
+    Assert.eq('releasePointerCapture should be restored', originalRelease, input.dom.releasePointerCapture);
+  });
+
+  it('pWithMockPointerCapture restores originals even if callback throws', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalSet = input.dom.setPointerCapture;
+
+    try {
+      await Pointer.pWithMockPointerCapture(input, {
+        setPointerCapture: Fun.noop
+      }, async () => {
+        throw new Error('test error');
+      });
+    } catch {
+      // expected
+    }
+
+    Assert.eq('setPointerCapture should be restored after error', originalSet, input.dom.setPointerCapture);
+  });
+
+  it('pWithMockPointerCapture defaults to noop when stubs not provided', async () => {
+    await Pointer.pWithMockPointerCapture(input, {}, async () => {
+      // Should not throw even though no stubs were provided
+      input.dom.setPointerCapture(1);
+      input.dom.releasePointerCapture(1);
+    });
+  });
+
+  it('pWithMockPointerCapture returns the callback result', async () => {
+    const result = await Pointer.pWithMockPointerCapture(input, {}, async () => 42);
+    Assert.eq('should return callback result', 42, result);
   });
 });

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -92,26 +92,26 @@ describe('browser.agar.PointerTest', () => {
     Assert.eq('clientY should include dy offset', true, receivedEvent !== undefined);
   });
 
-  it('pointerMoveTo fires pointermove with dx/dy offsets', () => {
+  it('pointerMoveBy fires pointermove with dx/dy offsets', () => {
     let receivedEvent: PointerEvent | undefined;
     const handler = DomEvent.bind(input, 'pointermove', (evt) => {
       receivedEvent = evt.raw as PointerEvent;
     });
 
-    Pointer.pointerMoveTo(input, 15, 25);
+    Pointer.pointerMoveBy(input, 15, 25);
     handler.unbind();
 
     Assert.eq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ], repository);
     Assert.eq('event should have been received', true, receivedEvent !== undefined);
   });
 
-  it('pointerMoveTo passes additional settings to the event', () => {
+  it('pointerMoveBy passes additional settings to the event', () => {
     let receivedEvent: PointerEvent | undefined;
     const handler = DomEvent.bind(input, 'pointermove', (evt) => {
       receivedEvent = evt.raw as PointerEvent;
     });
 
-    Pointer.pointerMoveTo(input, 10, 20, { shiftKey: true, button: 1 });
+    Pointer.pointerMoveBy(input, 10, 20, { shiftKey: true, button: 1 });
     handler.unbind();
 
     Assert.eq('shiftKey should be true', true, receivedEvent?.shiftKey);

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -152,15 +152,17 @@ describe('browser.agar.PointerTest', () => {
     it('pWithMockPointerCapture restores originals even if callback throws', async () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const originalSet = input.dom.setPointerCapture;
+      let threwException = false;
 
       try {
         await Pointer.pWithMockPointerCapture(input, {}, () => {
           throw new Error('test error');
         });
       } catch {
-        // expected
+        threwException = true;
       }
 
+      Assert.eq('callback should have thrown', true, threwException);
       // eslint-disable-next-line @typescript-eslint/unbound-method
       Assert.eq('setPointerCapture should be restored after error', originalSet, input.dom.setPointerCapture);
     });

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -3,13 +3,14 @@ import { Arr, Singleton } from '@ephox/katamari';
 import { Css, DomEvent, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 import * as Pointer from 'ephox/agar/api/Pointer';
+import { TestStore } from 'ephox/agar/api/TestStore';
 
 describe('browser.agar.PointerTest', () => {
   const body = SugarBody.body();
   let container: SugarElement<HTMLElement>;
   let input: SugarElement<HTMLInputElement>;
   const inputLatestEvent = Singleton.value<PointerEvent>();
-  let repository: string[];
+  const store = TestStore<string>();
   let handlers: { unbind: () => void }[];
 
   beforeEach(() => {
@@ -23,13 +24,13 @@ describe('browser.agar.PointerTest', () => {
     Insert.append(container, input);
     Insert.append(body, container);
 
-    repository = [];
+    store.clear();
     handlers = Arr.bind([ 'pointerdown', 'pointerup', 'pointermove' ], (evt) => [
       DomEvent.bind(container, evt, () => {
-        repository.push('container.' + evt);
+        store.add('container.' + evt);
       }),
       DomEvent.bind(input, evt, (event) => {
-        repository.push('input.' + evt);
+        store.add('input.' + evt);
         inputLatestEvent.set(event.raw as PointerEvent);
       })
     ]);
@@ -43,17 +44,17 @@ describe('browser.agar.PointerTest', () => {
 
   it('pointerDown fires pointerdown on element', () => {
     Pointer.pointerDown(input);
-    Assert.eq('pointerdown should bubble', [ 'input.pointerdown', 'container.pointerdown' ], repository);
+    store.assertEq('pointerdown should bubble', [ 'input.pointerdown', 'container.pointerdown' ]);
   });
 
   it('pointerUp fires pointerup on element', () => {
     Pointer.pointerUp(input);
-    Assert.eq('pointerup should bubble', [ 'input.pointerup', 'container.pointerup' ], repository);
+    store.assertEq('pointerup should bubble', [ 'input.pointerup', 'container.pointerup' ]);
   });
 
   it('pointerMove fires pointermove on element', () => {
     Pointer.pointerMove(input);
-    Assert.eq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ], repository);
+    store.assertEq('pointermove should bubble', [ 'input.pointermove', 'container.pointermove' ]);
   });
 
   it('pointerDown passes settings to the event', () => {

--- a/modules/agar/src/test/ts/browser/PointerTest.ts
+++ b/modules/agar/src/test/ts/browser/PointerTest.ts
@@ -138,7 +138,7 @@ describe('browser.agar.PointerTest', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const originalRelease = input.dom.releasePointerCapture;
 
-      await Pointer.pWithMockPointerCapture(input, {}, async () => {
+      await Pointer.pWithMockPointerCapture(input, {}, () => {
         Assert.eq('setPointerCapture should be replaced', true, input.dom.setPointerCapture !== originalSet);
         Assert.eq('releasePointerCapture should be replaced', true, input.dom.releasePointerCapture !== originalRelease);
       });
@@ -154,7 +154,7 @@ describe('browser.agar.PointerTest', () => {
       const originalSet = input.dom.setPointerCapture;
 
       try {
-        await Pointer.pWithMockPointerCapture(input, {}, async () => {
+        await Pointer.pWithMockPointerCapture(input, {}, () => {
           throw new Error('test error');
         });
       } catch {
@@ -166,15 +166,14 @@ describe('browser.agar.PointerTest', () => {
     });
 
     it('pWithMockPointerCapture defaults to noop when stubs not provided', async () => {
-      await Pointer.pWithMockPointerCapture(input, {}, async () => {
+      await Pointer.pWithMockPointerCapture(input, {}, () => {
         input.dom.setPointerCapture(1);
         input.dom.releasePointerCapture(1);
       });
     });
 
-    // TODO: add support for non promise returning functions
     it('pWithMockPointerCapture returns the callback result', async () => {
-      const result = await Pointer.pWithMockPointerCapture(input, {}, async () => 40 + 2);
+      const result = await Pointer.pWithMockPointerCapture(input, {}, () => 40 + 2);
       Assert.eq('should return callback result', 42, result);
     });
   });


### PR DESCRIPTION
Related Ticket: TINY-13585

Description of Changes:

- Added `mouseEnter` and `mouseLeave` helpers to the `Mouse` API, firing non-bubbling `mouseenter` and `mouseleave` events respectively
- Introduced a new `Pointer` API module exposing `pointerDown`, `pointerUp`, `pointerMove`, and `pointerMoveBy` helpers for dispatching `PointerEvent`s with configurable settings including `dx`/`dy` offsets and pointer-specific properties
- Added `pWithMockPointerCapture` to temporarily replace `setPointerCapture` and `releasePointerCapture` on an element during a callback, restoring the originals afterwards even if the callback throws
- Extended `MouseTest` to cover `mouseEnter` and `mouseLeave` behavior
- Added `PointerTest` covering all new pointer event helpers and `pWithMockPointerCapture` behavior

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high-level pointer helpers for simulating pointer down/up/move (including move-by) with configurable coordinates/options.
  * Added mouse helpers to trigger mouse enter and leave events.
  * Added a utility to mock pointer capture behavior during tests.

* **Tests**
  * Added/extended browser tests covering pointer and mouse behavior, coordinate handling, event bubbling, and pointer-capture mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->