### PR TITLE
TINY-14318: AutoResizingTextarea no longer over-grows when first rendered inside a collapsed accordion

### DIFF
--- a/modules/oxide-components/src/main/ts/components/autoresizingtextarea/AutoResizingTextarea.tsx
+++ b/modules/oxide-components/src/main/ts/components/autoresizingtextarea/AutoResizingTextarea.tsx
@@ -1,4 +1,5 @@
-import { Type } from '@ephox/katamari';
+import { Cell, Singleton, Type } from '@ephox/katamari';
+import { SugarElement, Visibility } from '@ephox/sugar';
 import { forwardRef, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 
 import * as Bem from '../../utils/Bem';
@@ -36,15 +37,42 @@ export const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, AutoResizing
 }, ref) => {
   const textareaRef: MutableRefObject<HTMLTextAreaElement | null> = useRef(null);
 
-  // Here we use the useState hook instead of useMemo, because computing the singleRowHeight
-  // requires the textareaRef.current to be available, but useMemo is computed before the render,
-  //  so we set it to 1 initially and update it in the useLayoutEffect
+  // Initial value of 1 is a placeholder; the real value is measured once the textarea
+  // actually has layout (it may mount inside a `display: none` ancestor — e.g. a collapsed
+  // accordion — where `scrollHeight` reads 0). A ResizeObserver re-measures when layout returns.
   const [ singleRowHeight, setSingleRowHeight ] = useState(1);
 
   useLayoutEffect(() => {
-    if (textareaRef.current) {
-      setSingleRowHeight(computeSingleRowHeight(textareaRef.current));
+    const textarea = textareaRef.current;
+    if (Type.isNullable(textarea)) {
+      return;
     }
+
+    const measured = Cell(false);
+    const observer = Singleton.value<InstanceType<typeof window.ResizeObserver>>();
+
+    const tryCompute = () => {
+      if (measured.get() || !Visibility.isVisible(SugarElement.fromDom(textarea))) {
+        return;
+      }
+      const value = computeSingleRowHeight(textarea);
+      if (value > 1) {
+        measured.set(true);
+        setSingleRowHeight(value);
+        // Once measured, we're done — stop observing so subsequent `rows`
+        // mutations from `resizeTextarea` don't re-fire this callback (which
+        // would surface as a `ResizeObserver loop` warning).
+        observer.on((obs) => obs.disconnect());
+        observer.clear();
+      }
+    };
+
+    tryCompute();
+    if (!measured.get()) {
+      observer.set(new window.ResizeObserver(tryCompute));
+      observer.on((obs) => obs.observe(textarea));
+    }
+    return () => observer.on((obs) => obs.disconnect());
   }, []);
 
   // The minRows and maxRows only need to be computed once per component instance, so they are in the useMemo hook

--- a/modules/oxide-components/src/main/ts/components/autoresizingtextarea/AutoResizingTextareaUtils.ts
+++ b/modules/oxide-components/src/main/ts/components/autoresizingtextarea/AutoResizingTextareaUtils.ts
@@ -1,8 +1,22 @@
+import { SugarElement, Visibility } from '@ephox/sugar';
+
 import type { Height } from './AutoResizingTextareaTypes';
 
 interface ComputeMaxRowsProps {
   readonly maxHeight: Height;
   readonly singleRowHeight: number;
+}
+
+interface ComputeMinRowsProps {
+  readonly minHeight: Height;
+  readonly singleRowHeight: number;
+}
+
+interface ComputeNewRowsProps {
+  readonly minRows: number;
+  readonly maxRows: number;
+  readonly singleRowHeight: number;
+  readonly textarea: HTMLTextAreaElement;
 }
 
 const computeSingleRowHeight = (textarea: HTMLTextAreaElement): number => {
@@ -13,7 +27,7 @@ const computeSingleRowHeight = (textarea: HTMLTextAreaElement): number => {
   const res = textarea.scrollHeight;
   textarea.rows = originalRows;
   textarea.value = originalValue;
-  return res;
+  return Math.max(res, 1);
 };
 
 const computeMaxRows = ({ maxHeight, singleRowHeight }: ComputeMaxRowsProps): number => {
@@ -25,10 +39,6 @@ const computeMaxRows = ({ maxHeight, singleRowHeight }: ComputeMaxRowsProps): nu
   return Math.max(maxRows, 1);
 };
 
-interface ComputeMinRowsProps {
-  readonly minHeight: Height;
-  readonly singleRowHeight: number;
-}
 const computeMinRows = ({ minHeight, singleRowHeight }: ComputeMinRowsProps): number => {
   if (minHeight.unit === 'rows') {
     return Math.max(minHeight.value, 1);
@@ -38,14 +48,10 @@ const computeMinRows = ({ minHeight, singleRowHeight }: ComputeMinRowsProps): nu
   return Math.max(minRows, 1);
 };
 
-interface ComputeNewRowsProps {
-  readonly minRows: number;
-  readonly maxRows: number;
-  readonly singleRowHeight: number;
-  readonly textarea: HTMLTextAreaElement;
-}
-
 const resizeTextarea = ({ minRows, maxRows, singleRowHeight, textarea }: ComputeNewRowsProps): void => {
+  if (!Visibility.isVisible(SugarElement.fromDom(textarea))) {
+    return;
+  }
   textarea.rows = minRows;
 
   const { scrollHeight } = textarea;

--- a/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
+++ b/modules/oxide-components/src/main/ts/components/dropdown/Dropdown.tsx
@@ -1,5 +1,21 @@
 import { Id, Type } from '@ephox/katamari';
-import { Children, cloneElement, forwardRef, isValidElement, useCallback, useMemo, useRef, useState, type FC, type HTMLAttributes, type MouseEvent, type PropsWithChildren, type ReactElement, type KeyboardEvent, useLayoutEffect } from 'react';
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PropsWithChildren,
+  type ReactElement
+} from 'react';
 
 import { Bem } from '../../main';
 
@@ -174,7 +190,6 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
     ...triggerEvents.includes('click') && onClickTriggerProps,
     ...triggerEvents.includes('hover') && onHoverTriggerProps,
     ...triggerEvents.includes('arrows') && onArrowTriggerProps,
-
   });
 });
 
@@ -207,7 +222,7 @@ const Root: FC<DropdownProps> = ({ children, side = 'bottom', align = 'start', g
 };
 
 export {
-  Root,
   Content,
+  Root,
   Trigger
 };

--- a/modules/oxide-components/src/test/ts/browser/components/AutoResizingTextarea.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/AutoResizingTextarea.spec.tsx
@@ -1,6 +1,6 @@
 import { AutoResizingTextarea } from 'oxide-components/components/autoresizingtextarea/AutoResizingTextarea';
 import type { Height } from 'oxide-components/components/autoresizingtextarea/AutoResizingTextareaTypes';
-import { classes } from 'oxide-components/utils/Styles';
+import { Bem } from 'oxide-components/main';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
@@ -15,7 +15,7 @@ describe('browser.components.AutoResizingTextareaTest', () => {
 
         wrapper: ({ children }) => {
           return (
-            <div className={classes([ 'tox' ])}>
+            <div className={Bem.block('tox')}>
               <div style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -68,7 +68,7 @@ describe('browser.components.AutoResizingTextareaTest', () => {
 
         wrapper: ({ children }) => {
           return (
-            <div className={classes([ 'tox' ])}>
+            <div className={Bem.block('tox')}>
               <div style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -136,7 +136,7 @@ describe('browser.components.AutoResizingTextareaTest', () => {
       {
         wrapper: ({ children }) => {
           return (
-            <div className={classes([ 'tox' ])}>
+            <div className={Bem.block('tox')}>
               <div style={{
                 display: 'flex',
                 flexDirection: 'column',
@@ -208,7 +208,7 @@ describe('browser.components.AutoResizingTextareaTest', () => {
       {
         wrapper: ({ children }) => {
           return (
-            <div className={classes([ 'tox' ])}>
+            <div className={Bem.block('tox')}>
               <div style={{
                 display: 'flex',
                 flexDirection: 'column',
@@ -235,5 +235,58 @@ describe('browser.components.AutoResizingTextareaTest', () => {
     await expect.element(textareaLocator, {
       message: 'Textarea rows should be initially resolved to 1'
     }).toHaveAttribute('rows', `${1}`);
+  });
+
+  it('TINY-14318: Should size to 1 row when typed in a textarea that was initially mounted hidden', async () => {
+
+    const lineOfText = 'Hello';
+
+    const TestComponent = () => {
+      const [ hidden, setHidden ] = useState(true);
+      const [ value, setValue ] = useState('');
+      return (
+        <>
+          <button data-testid="toggle" onClick={() => setHidden(false)}>show</button>
+          <div style={{ display: hidden ? 'none' : 'block' }}>
+            <AutoResizingTextarea value={value} onChange={setValue} data-testid="textarea" />
+          </div>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(
+      <TestComponent />,
+      {
+        wrapper: ({ children }) => {
+          return (
+            <div className={Bem.block('tox')}>
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '10px'
+              }}>
+                <div style={{
+                  width: '120px'
+                }}>
+                  {children}
+                </div>
+              </div>
+            </div>
+          );
+        },
+      });
+
+    await userEvent.click(getByTestId('toggle'));
+
+    const textareaLocator = getByTestId('textarea');
+    await expect.element(textareaLocator, {
+      message: 'Textarea rows should be 1 once revealed'
+    }).toHaveAttribute('rows', '1');
+
+    await userEvent.type(textareaLocator, lineOfText);
+    await expect.element(textareaLocator, {
+      message: 'Textarea rows should stay at 1 after typing one short line'
+    }).toHaveAttribute('rows', '1');
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-14318

Description of Changes:

- Fixed `AutoResizingTextarea` incorrectly measuring `singleRowHeight` as `0` when the component is initially mounted inside a hidden ancestor (e.g. a `display: none` container such as a collapsed accordion)
- Added an `isVisible` utility that checks whether a textarea has layout by inspecting `offsetParent` and `getClientRects`, and used it to guard both the height measurement and the resize logic
- Introduced a `ResizeObserver` in the `useLayoutEffect` to defer the `singleRowHeight` measurement until the textarea becomes visible, disconnecting once a valid measurement is obtained to avoid spurious `ResizeObserver loop` warnings
- Ensured `computeSingleRowHeight` returns a minimum of `1` rather than a potentially invalid `0` when `scrollHeight` is unavailable
- Added a browser test covering the case where a textarea is mounted hidden and then revealed, verifying it correctly sizes to 1 row and remains at 1 row after typing a short line of text

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-resizing textarea now defers measuring until visible and guarantees a minimum single-row height, preventing incorrect sizing and spurious resize updates when mounted hidden.

* **Tests**
  * Added a browser test that verifies the textarea resolves to one row when revealed and stays stable after typing, improving regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->