### PR TITLE
TINY-13171: Use crossorigin option in Preview plugin

### DIFF
--- a/modules/tinymce/src/plugins/preview/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/api/Options.ts
@@ -9,12 +9,14 @@ const option: {
 
 const getContentStyle = option('content_style');
 const shouldUseContentCssCors = option('content_css_cors');
+const getCrossOrigin = option('crossorigin');
 const getBodyClass = option('body_class');
 const getBodyId = option('body_id');
 
 export {
   getContentStyle,
   shouldUseContentCssCors,
+  getCrossOrigin,
   getBodyClass,
   getBodyId
 };

--- a/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
@@ -18,7 +18,7 @@ const getComponentScriptsHtml = (editor: Editor) => {
   }).join('');
 };
 
-const getEffectiveCrossOrigin = (editor: Editor): CrossOriginResolver => {
+const getStyleSheetCrossOrigin = (editor: Editor): CrossOriginResolver => {
   if (Options.shouldUseContentCssCors(editor)) {
     return Fun.constant('anonymous');
   }
@@ -33,13 +33,13 @@ const getPreviewHtml = (editor: Editor, contentCssResources: ContentCssResource[
 
   headHtml += `<base href="${encode(editor.documentBaseURI.getURI())}">`;
 
-  const crossOrigin = getEffectiveCrossOrigin(editor);
+  const styleSheetCrossOrigin = getStyleSheetCrossOrigin(editor);
 
   Tools.each(contentCssResources, (resource) => {
     if (resource.type === 'bundled') {
       headHtml += '<style type="text/css">' + resource.content + '</style>';
     } else {
-      const corsValue = crossOrigin(resource.url);
+      const corsValue = styleSheetCrossOrigin(resource.url);
       const cors = corsValue ? ' crossorigin="' + encode(corsValue) + '"' : '';
       headHtml += '<link type="text/css" rel="stylesheet" href="' + encode(resource.url) + '"' + cors + '>';
     }

--- a/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
@@ -1,14 +1,13 @@
-import { Arr, Obj } from '@ephox/katamari';
+import { Arr, Fun, Obj } from '@ephox/katamari';
 import { Link } from '@ephox/sugar';
 
 import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import type Editor from 'tinymce/core/api/Editor';
-import type { EditorOptions } from 'tinymce/core/api/OptionTypes';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
 
-import type { ContentCssResource } from './Types';
+import type { ContentCssResource, CrossOriginResolver } from './Types';
 
 const getComponentScriptsHtml = (editor: Editor) => {
   const urls = Arr.unique(Obj.values(editor.schema.getComponentUrls()));
@@ -19,13 +18,12 @@ const getComponentScriptsHtml = (editor: Editor) => {
   }).join('');
 };
 
-const getEffectiveCrossOrigin = (editor: Editor): EditorOptions['crossorigin'] => {
-  const crossOrigin = Options.getCrossOrigin(editor);
-  if (!Options.shouldUseContentCssCors(editor)) {
-    return crossOrigin;
+const getEffectiveCrossOrigin = (editor: Editor): CrossOriginResolver => {
+  if (Options.shouldUseContentCssCors(editor)) {
+    return Fun.constant('anonymous');
   }
-  return (url, resourceType) =>
-    resourceType === 'stylesheet' ? 'anonymous' : crossOrigin(url, resourceType);
+  const crossOrigin = Options.getCrossOrigin(editor);
+  return (url) => crossOrigin(url, 'stylesheet');
 };
 
 const getPreviewHtml = (editor: Editor, contentCssResources: ContentCssResource[]): string => {
@@ -41,7 +39,7 @@ const getPreviewHtml = (editor: Editor, contentCssResources: ContentCssResource[
     if (resource.type === 'bundled') {
       headHtml += '<style type="text/css">' + resource.content + '</style>';
     } else {
-      const corsValue = crossOrigin(resource.url, 'stylesheet');
+      const corsValue = crossOrigin(resource.url);
       const cors = corsValue ? ' crossorigin="' + encode(corsValue) + '"' : '';
       headHtml += '<link type="text/css" rel="stylesheet" href="' + encode(resource.url) + '"' + cors + '>';
     }

--- a/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
@@ -3,11 +3,12 @@ import { Link } from '@ephox/sugar';
 
 import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import type Editor from 'tinymce/core/api/Editor';
+import type { CrossOrigin } from 'tinymce/core/api/OptionTypes';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
 
-import type { ContentCssResource, CrossOriginResolver } from './Types';
+import type { ContentCssResource } from './Types';
 
 const getComponentScriptsHtml = (editor: Editor) => {
   const urls = Arr.unique(Obj.values(editor.schema.getComponentUrls()));
@@ -18,7 +19,7 @@ const getComponentScriptsHtml = (editor: Editor) => {
   }).join('');
 };
 
-const getStyleSheetCrossOrigin = (editor: Editor): CrossOriginResolver => {
+const getStyleSheetCrossOrigin = (editor: Editor): (url: string) => ReturnType<CrossOrigin> => {
   if (Options.shouldUseContentCssCors(editor)) {
     return Fun.constant('anonymous');
   }

--- a/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/IframeContent.ts
@@ -3,6 +3,7 @@ import { Link } from '@ephox/sugar';
 
 import ScriptLoader from 'tinymce/core/api/dom/ScriptLoader';
 import type Editor from 'tinymce/core/api/Editor';
+import type { EditorOptions } from 'tinymce/core/api/OptionTypes';
 import Tools from 'tinymce/core/api/util/Tools';
 
 import * as Options from '../api/Options';
@@ -18,6 +19,15 @@ const getComponentScriptsHtml = (editor: Editor) => {
   }).join('');
 };
 
+const getEffectiveCrossOrigin = (editor: Editor): EditorOptions['crossorigin'] => {
+  const crossOrigin = Options.getCrossOrigin(editor);
+  if (!Options.shouldUseContentCssCors(editor)) {
+    return crossOrigin;
+  }
+  return (url, resourceType) =>
+    resourceType === 'stylesheet' ? 'anonymous' : crossOrigin(url, resourceType);
+};
+
 const getPreviewHtml = (editor: Editor, contentCssResources: ContentCssResource[]): string => {
   let headHtml = '';
   const encode = editor.dom.encode;
@@ -25,12 +35,14 @@ const getPreviewHtml = (editor: Editor, contentCssResources: ContentCssResource[
 
   headHtml += `<base href="${encode(editor.documentBaseURI.getURI())}">`;
 
-  const cors = Options.shouldUseContentCssCors(editor) ? ' crossorigin="anonymous"' : '';
+  const crossOrigin = getEffectiveCrossOrigin(editor);
 
   Tools.each(contentCssResources, (resource) => {
     if (resource.type === 'bundled') {
       headHtml += '<style type="text/css">' + resource.content + '</style>';
     } else {
+      const corsValue = crossOrigin(resource.url, 'stylesheet');
+      const cors = corsValue ? ' crossorigin="' + encode(corsValue) + '"' : '';
       headHtml += '<link type="text/css" rel="stylesheet" href="' + encode(resource.url) + '"' + cors + '>';
     }
   });

--- a/modules/tinymce/src/plugins/preview/main/ts/core/Types.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/Types.ts
@@ -9,3 +9,5 @@ export interface BundledContentCss {
 }
 
 export type ContentCssResource = LinkContentCss | BundledContentCss;
+
+export type CrossOriginResolver = (url: string) => 'anonymous' | 'use-credentials' | undefined;

--- a/modules/tinymce/src/plugins/preview/main/ts/core/Types.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/Types.ts
@@ -1,3 +1,5 @@
+import type { CrossOrigin } from 'tinymce/core/api/OptionTypes';
+
 export interface LinkContentCss {
   readonly type: 'link';
   readonly url: string;
@@ -10,4 +12,4 @@ export interface BundledContentCss {
 
 export type ContentCssResource = LinkContentCss | BundledContentCss;
 
-export type CrossOriginResolver = (url: string) => 'anonymous' | 'use-credentials' | undefined;
+export type CrossOriginResolver = (url: string) => ReturnType<CrossOrigin>;

--- a/modules/tinymce/src/plugins/preview/main/ts/core/Types.ts
+++ b/modules/tinymce/src/plugins/preview/main/ts/core/Types.ts
@@ -1,5 +1,3 @@
-import type { CrossOrigin } from 'tinymce/core/api/OptionTypes';
-
 export interface LinkContentCss {
   readonly type: 'link';
   readonly url: string;
@@ -11,5 +9,3 @@ export interface BundledContentCss {
 }
 
 export type ContentCssResource = LinkContentCss | BundledContentCss;
-
-export type CrossOriginResolver = (url: string) => ReturnType<CrossOrigin>;

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
@@ -1,4 +1,5 @@
-import { describe, it } from '@ephox/bedrock-client';
+import { afterEach, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
 import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -19,6 +20,12 @@ describe('browser.tinymce.plugins.preview.PreviewContentCssTest', () => {
     assert.match(actual, regexp, 'Should be the same html');
   };
 
+  afterEach(() => {
+    const editor = hook.editor();
+    editor.options.set('content_css_cors', false);
+    editor.options.set('crossorigin', Fun.constant(undefined));
+  });
+
   it('TBA: Set content, set content_css_cors and assert link elements. Delete setting and assert crossOrigin attr is removed', () => {
     const editor = hook.editor();
     const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
@@ -38,5 +45,32 @@ describe('browser.tinymce.plugins.preview.PreviewContentCssTest', () => {
 
     editor.setContent('<p>hello world</p>');
     assertIframeHtmlContains(editor, contentCssResources, `<style type="text/css">${css}</style>`);
+  });
+
+  Arr.each([
+    { value: 'anonymous' as const, expectedAttr: ' crossorigin="anonymous"' },
+    { value: 'use-credentials' as const, expectedAttr: ' crossorigin="use-credentials"' },
+    { value: undefined, expectedAttr: '' }
+  ], ({ value, expectedAttr }) => {
+    it(`TINY-13171: crossorigin function returning ${value ?? 'undefined'} produces "${expectedAttr}"`, () => {
+      const editor = hook.editor();
+      const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
+      const contentCssResources: ContentCssResource[] = [{ type: 'link', url: contentCssUrl }];
+
+      editor.setContent('<p>hello world</p>');
+      editor.options.set('crossorigin', Fun.constant(value));
+      assertIframeHtmlContains(editor, contentCssResources, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}"${expectedAttr}>`);
+    });
+  });
+
+  it('TINY-13171: content_css_cors takes precedence over crossorigin', () => {
+    const editor = hook.editor();
+    const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');
+    const contentCssResources: ContentCssResource[] = [{ type: 'link', url: contentCssUrl }];
+
+    editor.setContent('<p>hello world</p>');
+    editor.options.set('content_css_cors', true);
+    editor.options.set('crossorigin', Fun.constant('use-credentials'));
+    assertIframeHtmlContains(editor, contentCssResources, `<link type="text/css" rel="stylesheet" href="${contentCssUrl}" crossorigin="anonymous">`);
   });
 });

--- a/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
+++ b/modules/tinymce/src/plugins/preview/test/ts/browser/PreviewContentCssTest.ts
@@ -4,6 +4,7 @@ import { TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import type Editor from 'tinymce/core/api/Editor';
+import type { CrossOrigin } from 'tinymce/core/api/OptionTypes';
 import * as IframeContent from 'tinymce/plugins/preview/core/IframeContent';
 import type { ContentCssResource } from 'tinymce/plugins/preview/core/Types';
 import Plugin from 'tinymce/plugins/preview/Plugin';
@@ -47,11 +48,13 @@ describe('browser.tinymce.plugins.preview.PreviewContentCssTest', () => {
     assertIframeHtmlContains(editor, contentCssResources, `<style type="text/css">${css}</style>`);
   });
 
-  Arr.each([
-    { value: 'anonymous' as const, expectedAttr: ' crossorigin="anonymous"' },
-    { value: 'use-credentials' as const, expectedAttr: ' crossorigin="use-credentials"' },
+  const crossOriginCases: Array<{ value: ReturnType<CrossOrigin>; expectedAttr: string }> = [
+    { value: 'anonymous', expectedAttr: ' crossorigin="anonymous"' },
+    { value: 'use-credentials', expectedAttr: ' crossorigin="use-credentials"' },
     { value: undefined, expectedAttr: '' }
-  ], ({ value, expectedAttr }) => {
+  ];
+
+  Arr.each(crossOriginCases, ({ value, expectedAttr }) => {
     it(`TINY-13171: crossorigin function returning ${value ?? 'undefined'} produces "${expectedAttr}"`, () => {
       const editor = hook.editor();
       const contentCssUrl = editor.documentBaseURI.toAbsolute('/project/tinymce/js/tinymce/skins/content/default/content.css');


### PR DESCRIPTION
Related Ticket: TINY-13171

Description of Changes:
* Use `crossorigin` option to apply the `crossorigin` attribute to content CSS `link` tags in the Iframe. `content_css_cors` (deprecated) will still take precedence if set. 
* Add tests to verify the value of `crossorigin` attribute is correctly set on the `link` tags. 

Pre-checks:
* ~~[ ] Changelog entry added~~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced preview plugin with improved `crossorigin` attribute handling for stylesheets, allowing per-resource configuration instead of applying a single value to all stylesheets.

* **Tests**
  * Added test coverage for `crossorigin` option behavior and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->