### PR TITLE
TINY-13317: change LESS math mode from always to parens-division

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13317-2026-04-30.yaml
+++ b/.changes/unreleased/tinymce-TINY-13317-2026-04-30.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Changed
+body: Changed LESS math mode from always to parens-division.
+time: 2026-04-30T12:29:05.185705+02:00
+custom:
+    Issue: TINY-13317

--- a/modules/oxide/src/less/theme/components/comments/comment.less
+++ b/modules/oxide/src/less/theme/components/comments/comment.less
@@ -91,7 +91,7 @@
   .tox-comment__date {
     color: @user-name-text-color;
     font-size: @font-size-xs;
-    line-height: @user-avatar-height / 2;
+    line-height: (@user-avatar-height / 2);
   }
 
   .tox-comment__body {

--- a/modules/oxide/src/less/theme/components/comments/user.less
+++ b/modules/oxide/src/less/theme/components/comments/user.less
@@ -34,7 +34,7 @@
     font-size: @user-name-font-size;
     font-style: @user-name-font-style;
     font-weight: @user-name-font-weight;
-    line-height: @user-avatar-height / 2;
+    line-height: (@user-avatar-height / 2);
     text-transform: @user-name-text-transform;
   }
 }

--- a/modules/oxide/src/less/theme/components/form/textfield.less
+++ b/modules/oxide/src/less/theme/components/form/textfield.less
@@ -14,7 +14,7 @@
 @textfield-line-height: 24px;
 @textfield-outline: none;
 @textfield-pad-x: @pad-xs + (@control-border-radius / 4); // Add a border radius modifier for pill shaped controls
-@textfield-pad-y: (@textfield-height - @textfield-line-height - (@textfield-border-width * 2)) / 2;
+@textfield-pad-y: ((@textfield-height - @textfield-line-height - (@textfield-border-width * 2)) / 2);
 @textfield-text-color: @text-color;
 
 @textfield-disabled-background-color: darken(@textfield-background-color, 5%);

--- a/modules/oxide/src/less/theme/components/pop/pop.less
+++ b/modules/oxide/src/less/theme/components/pop/pop.less
@@ -31,7 +31,7 @@
     // Make the arrow transition in as the bubble arrow appears
     &::before,
     &::after {
-      transition: all @pop-transition-time, visibility 0s, opacity @pop-transition-time / 2 ease @pop-transition-time / 2;
+      transition: all @pop-transition-time, visibility 0s, opacity (@pop-transition-time / 2) ease (@pop-transition-time / 2);
     }
   }
 
@@ -80,7 +80,7 @@
   .tox-pop.tox-pop--inset::before,
   .tox-pop.tox-pop--inset::after {
     opacity: 0;
-    transition: all 0s @pop-transition-time, visibility 0s, opacity @pop-transition-time / 2 ease;
+    transition: all 0s @pop-transition-time, visibility 0s, opacity (@pop-transition-time / 2) ease;
   }
 
   // Default (bottom) pointing arrow

--- a/modules/oxide/src/less/theme/components/spinner/spinner.less
+++ b/modules/oxide/src/less/theme/components/spinner/spinner.less
@@ -3,7 +3,7 @@
 //
 
 @spinner-color: @text-color-muted;
-@spinner-size: @base-value / 2;
+@spinner-size: (@base-value / 2);
 
 .tox {
   .tox-spinner {
@@ -36,13 +36,13 @@
 
 .tox:not([dir=rtl]) {
   .tox-spinner > div:not(:first-child) {
-    margin-left: @spinner-size / 2;
+    margin-left: (@spinner-size / 2);
   }
 }
 
 // RTL
 .tox[dir=rtl] {
   .tox-spinner > div:not(:first-child) {
-    margin-right: @spinner-size / 2;
+    margin-right: (@spinner-size / 2);
   }
 }

--- a/modules/oxide/src/less/theme/components/tooltip/tooltip.less
+++ b/modules/oxide/src/less/theme/components/tooltip/tooltip.less
@@ -2,7 +2,7 @@
 // Tooltip
 //
 
-@tooltip-arrow-size: @base-value / 2;
+@tooltip-arrow-size: (@base-value / 2);
 @tooltip-background-color: @color-black;
 @tooltip-border-radius: @panel-border-radius;
 @tooltip-box-shadow: none;

--- a/modules/oxide/src/less/theme/content/resize-handles/resize-handle.less
+++ b/modules/oxide/src/less/theme/content/resize-handles/resize-handle.less
@@ -8,7 +8,7 @@
 
 .mce-content-body {
   div.mce-resizehandle {
-    @offset: -@resize-handle-size / 3;
+    @offset: (-@resize-handle-size / 3);
 
     background-color: @resize-handle-color;
     border-color: @resize-handle-color;

--- a/modules/oxide/src/less/theme/globals/global-variables.less
+++ b/modules/oxide/src/less/theme/globals/global-variables.less
@@ -53,8 +53,8 @@
 @font-size-lg: @font-size-base * 1.25;
 
 // Spacings
-@pad-xs: @base-value / 4;
-@pad-sm: @base-value / 2;
+@pad-xs: (@base-value / 4);
+@pad-sm: (@base-value / 2);
 @pad-md: @base-value;
 @pad-lg: @base-value * 1.5;
 @pad-xl: @base-value * 2;

--- a/modules/oxide/tasks/less-task.js
+++ b/modules/oxide/tasks/less-task.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
     const done = this.async();
     const opts = {
       relativeUrls: true,
-      math: 'always',
+      math: 'parens-division',
       plugins: [ presetEnv ],
       paths: ['./src/less/skins'] // Define the path(s) where LESS should look for files
     };


### PR DESCRIPTION
Related Ticket: TINY-13317

Description of Changes:

- Changed LESS math mode from `always` to `parens-division`, which requires division operations to be wrapped in parentheses to be evaluated as math
- Wrapped all division expressions in LESS files with parentheses to comply with the new `parens-division` math mode

Pre-checks:

- [x] Changelog entry added
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mathematical expression handling in stylesheets to ensure consistent calculation of spacing, sizing, and positioning values across theme components and layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->