### PR TITLE
TINY-14279: fix paddings in card component

### DIFF
--- a/modules/oxide/src/less/theme/components/card/card.less
+++ b/modules/oxide/src/less/theme/components/card/card.less
@@ -26,6 +26,7 @@
     display: flex;
     flex-direction: column;
     gap: @card-section-gap;
+    padding: @card-section-padding;
     cursor: pointer;
     transition: box-shadow 0.15s ease-in-out, border 0.15s ease-in-out;
     border: @card-selected-border-width solid transparent;
@@ -79,7 +80,6 @@
     }
 
     &__header {
-      padding: @card-section-padding;
       padding-bottom: 0;
       color: @card-text-color;
       font-size: @font-size-md;
@@ -100,7 +100,6 @@
     }
 
     &__body {
-      padding: @card-section-padding @card-section-padding 0 @card-section-padding;
       color: @card-text-color;
       font-size: @font-size-md;
 
@@ -109,10 +108,6 @@
         padding: 0;
         gap: @card-section-gap;
       }
-    }
-
-    &--has-decision &__body {
-      padding: 0 @card-section-padding 0 @card-section-padding;
     }
 
     &__highlight {
@@ -135,7 +130,6 @@
     &__actions {
       display: flex;
       gap: @card-button-gap;
-      padding: 0 @card-section-padding @card-section-padding;
 
       &--space-between {
         justify-content: space-between;


### PR DESCRIPTION
Related Ticket: TINY-14279

Description of Changes:

- Moved padding from individual card sections (`__header`, `__body`, `__actions`) to the card container level, applying `@card-section-padding` uniformly to the card itself
- Removed the `--has-decision` modifier's override for `__body` padding, as it is no longer needed with the consolidated padding approach

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - Optimized card component styling by consolidating padding rules for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->