### PR TITLE
TINY-14386: Use bunInstall waluigi step instead of inline sh call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ timestamps { notifyStatusChange(
           timeout(time: 5, unit: 'MINUTES') {
             // cancel build if primary branch doesn't merge cleanly
             gitMerge(primaryBranch)
-            sh 'bun install'
+            bunInstall()
           }
         }
 


### PR DESCRIPTION
Related Ticket: [TINY-14386](https://ephocks.atlassian.net/browse/TINY-14386)

Description of Changes:
* Replaces the inline `sh 'bun install'` in the `Deps` stage with `bunInstall()`, the new waluigi step, which runs `bun install --frozen-lockfile`. This is a behavioural tightening: the previous unfrozen install would silently update the lockfile on drift; CI now fails fast instead.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

[TINY-14386]: https://ephocks.atlassian.net/browse/TINY-14386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->