### PR TITLE
TINY-14275: Add allowVertical prop to ContextToolbar.Group

### DIFF
--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbar.tsx
@@ -328,12 +328,13 @@ const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(({
   );
 });
 
-const Group: FC<GroupProps> = ({ children }) => {
+const Group: FC<GroupProps> = ({ children, allowVertical = true }) => {
   const groupRef = useRef<HTMLDivElement>(null);
 
   KeyboardNavigationHooks.useFlowKeyNavigation({
     containerRef: groupRef,
     selector: enabledToolbarControlSelector,
+    allowVertical,
     execute: (focused) => {
       focused.dom.click();
       return Optional.some(true);

--- a/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbarTypes.tsx
+++ b/modules/oxide-components/src/main/ts/components/contexttoolbar/ContextToolbarTypes.tsx
@@ -38,4 +38,12 @@ export interface TriggerProps {
 
 export interface GroupProps {
   readonly children: ReactNode;
+  /**
+   * Whether the group's arrow-key flow navigation responds to vertical arrows.
+   * Defaults to `true`. Set to `false` when the host has its own ArrowUp/ArrowDown
+   * semantics (e.g. navigating between items above/below the toolbar), so those
+   * keys reach the host handler instead of being consumed for focus movement
+   * between buttons within the group.
+   */
+  readonly allowVertical?: boolean;
 }


### PR DESCRIPTION
Related Ticket: TINY-14275

Description of Changes:
* Add `allowVertical?: boolean` prop to `ContextToolbar.Group` (defaults to `true`, preserves existing behavior).
* Forwards into `useFlowKeyNavigation` so hosts can disable vertical arrow-key focus movement when they own ArrowUp/ArrowDown semantics. With `allowVertical={false}`, vertical arrows bubble past the group instead of being consumed for between-button focus.

Companion premium PR: tinymce/tinymce-premium#1599 (passes `allowVertical={false}` from `PreviewContextToolbar` so its host shortcut handler receives ArrowUp/ArrowDown to navigate between proposed changes).

Pre-checks:
* [ ] Changelog entry added (oxide-components is not currently listed as a project in `.changie.yaml`, so no changie fragment generated; happy to add the project in this PR if reviewers prefer)
* [x] Tests have been added (if applicable) (consumer test covered in companion premium PR)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context toolbar groups now support configurable vertical navigation behavior. Developers can control whether vertical arrow keys are consumed for focus navigation or delegated to parent containers. Default behavior remains unchanged for full backward compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->