### PR TITLE
TINY-14296: fix bogus content on print

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14296-2026-05-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-14296-2026-05-11.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The content of bogus was always hidden in print, even when it shouldn't be.
+time: 2026-05-11T13:06:17.044648272+02:00
+custom:
+    Issue: TINY-14296

--- a/.changes/unreleased/tinymce-TINY-14296-2026-05-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-14296-2026-05-11.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: The content of bogus was always hidden in print, even when it shouldn't be.
+body: Some elements were hidden when printed even if the content should be shown.
 time: 2026-05-11T13:06:17.044648272+02:00
 custom:
     Issue: TINY-14296

--- a/.changes/unreleased/tinymce-TINY-14296-2026-05-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-14296-2026-05-11.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Some elements were hidden when printed even if the content should be shown.
+body: Some annotated text was hidden when printed even though it should have been visible.
 time: 2026-05-11T13:06:17.044648272+02:00
 custom:
     Issue: TINY-14296

--- a/modules/oxide/src/less/theme/content/print/print.less
+++ b/modules/oxide/src/less/theme/content/print/print.less
@@ -5,7 +5,7 @@
       display: none !important;
     }
 
-    [data-mce-bogus] {
+    [data-mce-bogus]:not([data-mce-bogus=all]) {
       display: contents !important;
     }
 

--- a/modules/oxide/src/less/theme/content/print/print.less
+++ b/modules/oxide/src/less/theme/content/print/print.less
@@ -1,9 +1,12 @@
 @media print {
   .mce-content-body {
     .mce-placeholder,
-    [data-mce-bogus=all],
-    [data-mce-bogus] {
+    [data-mce-bogus=all] {
       display: none !important;
+    }
+
+    [data-mce-bogus] {
+      display: contents !important;
     }
 
     .mce-visual-caret {


### PR DESCRIPTION
Related Ticket: TINY-14296

Description of Changes:
The problem was that we were removing all kind of bogus element but we should remove the `data-mce-bogus=all` and unwrap the others as you can see in [ContentCleanup.ts](https://github.com/tinymce/tinymce/blob/main/modules/tinymce/src/core/main/ts/content/ContentCleanup.ts)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed print behavior so placeholder/bogus elements remain hidden when printing.
  * Restored previously suppressed content so valid elements now appear correctly in printed output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11105)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->