### PR TITLE
TINY-12791: polite announcements should not be cleared out

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Tinymce.ts
+++ b/modules/tinymce/src/core/main/ts/api/Tinymce.ts
@@ -3,7 +3,7 @@ import type { UndoManager as UndoManagerType } from '../undo/UndoManagerTypes';
 
 import AddOnManager from './AddOnManager';
 import Annotator from './Annotator';
-import AriaAnnouncer, { type AriaAnnouncerApi } from './dom/AriaAnnouncer';
+import AriaAnnouncer from './dom/AriaAnnouncer';
 import BookmarkManager from './dom/BookmarkManager';
 import ControlSelection from './dom/ControlSelection';
 import DOMUtils, { type DOMUtilsSettings } from './dom/DOMUtils';
@@ -113,7 +113,7 @@ interface TinyMCE extends EditorManager {
     BookmarkManager: BookmarkManagerNamespace;
     Selection: (dom: DOMUtils, win: Window, serializer: DomSerializer, editor: Editor) => EditorSelection;
     StyleSheetLoader: (documentOrShadowRoot: Document | ShadowRoot, settings: StyleSheetLoaderSettings) => StyleSheetLoader;
-    AriaAnnouncer: AriaAnnouncerApi;
+    AriaAnnouncer: AriaAnnouncer;
     Event: EventUtils;
   };
 

--- a/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
@@ -1,10 +1,18 @@
 import { Id } from '@ephox/katamari';
-import { Attribute, Css, Insert, Remove, SelectorFind, SugarBody, SugarElement } from '@ephox/sugar';
+import { Attribute, Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
 /**
- * Page-wide aria-live announcer used to send messages to screen readers without
- * shifting focus. The aria-live container is created lazily on the first
- * announcement and removed once no tokens remain in flight.
+ * Page-wide aria-live announcer used to send messages to screen readers without shifting focus.
+ *
+ *   Polite messages: appended as child divs to a single persistent live region
+ *   (aria-atomic="false", aria-relevant="additions") so each child is announced
+ *   independently as it is added. Earlier messages remain in the DOM and are
+ *   not re-read. Each message is removed after a delay long enough for screen
+ *   readers to have picked up the mutation, keeping the region bounded over long sessions.
+ *
+ *   Assertive messages: announced through a region that is created fresh per
+ *   message and removed entirely before the next assertive announce, so each
+ *   one interrupts the previous rather than queueing behind it.
  *
  * @class tinymce.dom.AriaAnnouncer
  */
@@ -14,7 +22,7 @@ export interface AriaAnnouncerApi {
 }
 
 const announcerContainerId = Id.generate('tiny-aria-announcer');
-let activeTokens = 0;
+const politeMessageTtlMs = 60000;
 
 const offscreenStyles = {
   position: 'absolute',
@@ -24,37 +32,80 @@ const offscreenStyles = {
   overflow: 'hidden'
 };
 
-const getOrCreateContainer = (): SugarElement<HTMLElement> => {
-  return SelectorFind.descendant<HTMLElement>(SugarBody.body(), `#${announcerContainerId}`).getOrThunk(() => {
-    const container = SugarElement.fromTag('div');
-    Attribute.set(container, 'id', announcerContainerId);
-    Css.setAll(container, offscreenStyles);
-    Insert.append(SugarBody.body(), container);
-    return container;
+const createPoliteRegion = (): SugarElement<HTMLDivElement> => {
+  const region: SugarElement<HTMLDivElement> = SugarElement.fromTag('div');
+  Attribute.setAll(region, {
+    'aria-live': 'polite',
+    'aria-atomic': 'false',
+    'aria-relevant': 'additions'
   });
+  return region;
 };
 
-const createToken = (message: string, assertive: boolean): SugarElement<HTMLSpanElement> => {
-  const span = SugarElement.fromTag('span');
-
-  if (assertive) {
-    Attribute.setAll(span, {
-      'aria-live': 'assertive',
-      'aria-atomic': 'true',
-      'role': 'alert'
-    });
-  } else {
-    Attribute.setAll(span, {
-      'role': 'presentation',
-      'aria-live': 'polite',
-      'aria-atomic': 'true',
-      'aria-label': message
-    });
-  }
-
-  Insert.append(span, SugarElement.fromText(message));
-  return span;
+const createAssertiveRegion = (): SugarElement<HTMLDivElement> => {
+  const region: SugarElement<HTMLDivElement> = SugarElement.fromTag('div');
+  Attribute.setAll(region, {
+    'aria-live': 'assertive',
+    'aria-atomic': 'true',
+    'role': 'alert'
+  });
+  return region;
 };
+
+interface AnnouncerState {
+  readonly container: SugarElement<HTMLElement>;
+  readonly polite: SugarElement<HTMLDivElement>;
+  assertive: SugarElement<HTMLDivElement> | null;
+}
+
+const createAnnouncer = () => {
+  let state: AnnouncerState | null = null;
+
+  const ensureMounted = (): AnnouncerState => {
+    if (state === null || !state.container.dom.isConnected || !state.polite.dom.isConnected) {
+      if (state !== null && state.container.dom.isConnected) {
+        Remove.remove(state.container);
+      }
+      const container: SugarElement<HTMLElement> = SugarElement.fromTag('div');
+      Attribute.set(container, 'id', announcerContainerId);
+      Css.setAll(container, offscreenStyles);
+
+      const polite = createPoliteRegion();
+      Insert.append(container, polite);
+      Insert.append(SugarBody.body(), container);
+
+      state = { container, polite, assertive: null };
+    }
+    return state;
+  };
+
+  const polite = (message: string): void => {
+    const s = ensureMounted();
+    const messageDiv: SugarElement<HTMLDivElement> = SugarElement.fromTag('div');
+    Insert.append(messageDiv, SugarElement.fromText(message));
+    Insert.append(s.polite, messageDiv);
+    setTimeout(() => {
+      if (messageDiv.dom.isConnected) {
+        Remove.remove(messageDiv);
+      }
+    }, politeMessageTtlMs);
+  };
+
+  const assertive = (message: string): void => {
+    const s = ensureMounted();
+    if (s.assertive !== null) {
+      Remove.remove(s.assertive);
+    }
+    const region = createAssertiveRegion();
+    Insert.append(region, SugarElement.fromText(message));
+    Insert.append(s.container, region);
+    s.assertive = region;
+  };
+
+  return { polite, assertive };
+};
+
+const announcer = createAnnouncer();
 
 /**
  * Announces a message to screen readers via an aria-live region, without shifting focus.
@@ -68,22 +119,14 @@ const createToken = (message: string, assertive: boolean): SugarElement<HTMLSpan
  * tinymce.dom.AriaAnnouncer.announce('Error occurred', { assertive: true });
  */
 const announce = (message: string, options?: { assertive?: boolean }): void => {
-  const container = getOrCreateContainer();
-  const token = createToken(message, options?.assertive === true);
-  Insert.append(container, token);
-  activeTokens++;
-
-  setTimeout(() => {
-    Attribute.remove(token, 'aria-live');
-    Remove.remove(token);
-    activeTokens--;
-    if (activeTokens === 0) {
-      Remove.remove(container);
-    }
-  }, 1000);
+  if (options?.assertive === true) {
+    announcer.assertive(message);
+  } else {
+    announcer.polite(message);
+  }
 };
 
 const AriaAnnouncer: AriaAnnouncerApi = { announce };
 
-export { announcerContainerId };
+export { announcerContainerId, politeMessageTtlMs };
 export default AriaAnnouncer;

--- a/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
@@ -1,5 +1,4 @@
-import { Id } from '@ephox/katamari';
-import { Attribute, Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import * as Announcer from '../../aria/Announcer';
 
 /**
  * Page-wide aria-live announcer used to send messages to screen readers without shifting focus.
@@ -17,95 +16,11 @@ import { Attribute, Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/
  * @class tinymce.dom.AriaAnnouncer
  */
 
-export interface AriaAnnouncerApi {
+interface AriaAnnouncer {
   readonly announce: (message: string, options?: { assertive?: boolean }) => void;
 }
 
-const announcerContainerId = Id.generate('tiny-aria-announcer');
-const politeMessageTtlMs = 60000;
-
-const offscreenStyles = {
-  position: 'absolute',
-  left: '-9999px',
-  width: '1px',
-  height: '1px',
-  overflow: 'hidden'
-};
-
-const createPoliteRegion = (): SugarElement<HTMLDivElement> => {
-  const region: SugarElement<HTMLDivElement> = SugarElement.fromTag('div');
-  Attribute.setAll(region, {
-    'aria-live': 'polite',
-    'aria-atomic': 'false',
-    'aria-relevant': 'additions'
-  });
-  return region;
-};
-
-const createAssertiveRegion = (): SugarElement<HTMLDivElement> => {
-  const region: SugarElement<HTMLDivElement> = SugarElement.fromTag('div');
-  Attribute.setAll(region, {
-    'aria-live': 'assertive',
-    'aria-atomic': 'true',
-    'role': 'alert'
-  });
-  return region;
-};
-
-interface AnnouncerState {
-  readonly container: SugarElement<HTMLElement>;
-  readonly polite: SugarElement<HTMLDivElement>;
-  assertive: SugarElement<HTMLDivElement> | null;
-}
-
-const createAnnouncer = () => {
-  let state: AnnouncerState | null = null;
-
-  const ensureMounted = (): AnnouncerState => {
-    if (state === null || !state.container.dom.isConnected || !state.polite.dom.isConnected) {
-      if (state !== null && state.container.dom.isConnected) {
-        Remove.remove(state.container);
-      }
-      const container: SugarElement<HTMLElement> = SugarElement.fromTag('div');
-      Attribute.set(container, 'id', announcerContainerId);
-      Css.setAll(container, offscreenStyles);
-
-      const polite = createPoliteRegion();
-      Insert.append(container, polite);
-      Insert.append(SugarBody.body(), container);
-
-      state = { container, polite, assertive: null };
-    }
-    return state;
-  };
-
-  const polite = (message: string): void => {
-    const s = ensureMounted();
-    const messageDiv: SugarElement<HTMLDivElement> = SugarElement.fromTag('div');
-    Insert.append(messageDiv, SugarElement.fromText(message));
-    Insert.append(s.polite, messageDiv);
-    setTimeout(() => {
-      if (messageDiv.dom.isConnected) {
-        Remove.remove(messageDiv);
-      }
-    }, politeMessageTtlMs);
-  };
-
-  const assertive = (message: string): void => {
-    const s = ensureMounted();
-    if (s.assertive !== null) {
-      Remove.remove(s.assertive);
-    }
-    const region = createAssertiveRegion();
-    Insert.append(region, SugarElement.fromText(message));
-    Insert.append(s.container, region);
-    s.assertive = region;
-  };
-
-  return { polite, assertive };
-};
-
-const announcer = createAnnouncer();
+const announcer = Announcer.createAnnouncer();
 
 /**
  * Announces a message to screen readers via an aria-live region, without shifting focus.
@@ -126,7 +41,8 @@ const announce = (message: string, options?: { assertive?: boolean }): void => {
   }
 };
 
-const AriaAnnouncer: AriaAnnouncerApi = { announce };
+const AriaAnnouncer: AriaAnnouncer = {
+  announce
+};
 
-export { announcerContainerId, politeMessageTtlMs };
 export default AriaAnnouncer;

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -1,5 +1,5 @@
-import { Id, Optional, Singleton } from '@ephox/katamari';
-import { Attribute, Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { Fun, Id, Singleton } from '@ephox/katamari';
+import { Attribute, Css, Insert, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
 
 export const announcerContainerId = Id.generate('tiny-aria-announcer');
 
@@ -8,9 +8,13 @@ export interface Announcer {
   readonly assertive: (message: string) => void;
 }
 
-const POLITE_MESSAGE_TTL_MS = 60000;
+interface AnnouncerState {
+  readonly container: SugarElement<HTMLElement>;
+  readonly polite: SugarElement<HTMLDivElement>;
+  readonly assertive: SugarElement<HTMLDivElement>;
+}
 
-const offscreenStyles = {
+const OFFSCREEN_STYLES = {
   position: 'absolute',
   left: '-9999px',
   width: '1px',
@@ -32,69 +36,56 @@ const createAssertiveRegion = (): SugarElement<HTMLDivElement> => {
   const region = SugarElement.fromTag('div');
   Attribute.setAll(region, {
     'aria-live': 'assertive',
-    'aria-atomic': 'true',
-    'role': 'alert'
+    'aria-atomic': 'true'
   });
   return region;
 };
 
-interface AnnouncerState {
-  readonly container: SugarElement<HTMLElement>;
-  readonly polite: SugarElement<HTMLDivElement>;
-  readonly assertive: Optional<SugarElement<HTMLDivElement>>;
-}
+const wait = (duration: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, duration));
 
 const isConnected = (element: SugarElement<HTMLElement>): boolean => element.dom.isConnected;
 
 export const createAnnouncer = (): Announcer => {
   const state = Singleton.value<AnnouncerState>();
 
-  const ensureMounted = (): AnnouncerState =>
-    state.get().filter((s) => isConnected(s.container) && isConnected(s.polite)).getOrThunk(() => {
-      state.on((s) => {
-        if (isConnected(s.container)) {
-          Remove.remove(s.container);
-        }
-      });
-      const container = SugarElement.fromTag('div');
-      Attribute.set(container, 'id', announcerContainerId);
-      Css.setAll(container, offscreenStyles);
+  const mountRegions = async () => {
+    return state.get().filter(({ container }) => isConnected(container)).fold(
+      async () => {
+        const container = SugarElement.fromTag('div');
+        const polite = createPoliteRegion();
+        const assertive = createAssertiveRegion();
 
-      const polite = createPoliteRegion();
-      Insert.append(container, polite);
-      Insert.append(SugarBody.body(), container);
+        Attribute.set(container, 'id', announcerContainerId);
+        Css.setAll(container, OFFSCREEN_STYLES);
 
-      const newState: AnnouncerState = { container, polite, assertive: Optional.none() };
-      state.set(newState);
-      return newState;
-    });
+        Insert.append(container, polite);
+        Insert.append(container, assertive);
+        Insert.append(SugarBody.body(), container);
+
+        const newState: AnnouncerState = { container, polite, assertive };
+        state.set(newState);
+
+        await wait(50); // Wait for screen readers to pick up the new regions before adding messages
+
+        return newState;
+      },
+      (state) => Promise.resolve(state)
+    );
+  };
 
   const polite = (message: string): void => {
-    const s = ensureMounted();
-    const messageDiv = SugarElement.fromTag('div');
-    Insert.append(messageDiv, SugarElement.fromText(message));
-    Insert.append(s.polite, messageDiv);
-    setTimeout(() => {
-      if (isConnected(messageDiv)) {
-        Remove.remove(messageDiv);
-      }
-    }, POLITE_MESSAGE_TTL_MS);
+    mountRegions().then(({ polite }) => {
+      const messageDiv = SugarElement.fromTag('div');
+      Insert.append(messageDiv, SugarElement.fromText(message));
+      Insert.append(polite, messageDiv);
+    }).catch(Fun.noop);
   };
 
   const assertive = (message: string): void => {
-    const s = ensureMounted();
-    s.assertive.each((r) => Remove.remove(r));
-    const region = createAssertiveRegion();
-    Insert.append(s.container, region);
-    state.set({ ...s, assertive: Optional.some(region) });
-    // The region must be connected to the DOM as an empty live region before its
-    // content is set; otherwise screen readers (notably VoiceOver) treat it as
-    // inserted-with-content and do not announce the change.
-    setTimeout(() => {
-      if (isConnected(region)) {
-        Insert.append(region, SugarElement.fromText(message));
-      }
-    }, 0);
+    mountRegions().then(({ assertive }) => {
+      TextContent.set(assertive, message);
+    }).catch(Fun.noop);
   };
 
   return { polite, assertive };

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -1,7 +1,10 @@
-import { Fun, Id, Singleton } from '@ephox/katamari';
-import { Attribute, Css, Insert, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { Arr, Id, Singleton, Strings } from '@ephox/katamari';
+import { Attribute, Css, Insert, Remove, SelectorFilter, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
 
 export const announcerContainerId = Id.generate('tiny-aria-announcer');
+
+const POLITE_MESSAGE_TTL_MS = 600000; // 10 minutes
+const politeTimestampAttr = 'data-mce-announced-at';
 
 export interface Announcer {
   readonly polite: (message: string) => void;
@@ -10,8 +13,8 @@ export interface Announcer {
 
 interface AnnouncerState {
   readonly container: SugarElement<HTMLElement>;
-  readonly polite: SugarElement<HTMLDivElement>;
-  readonly assertive: SugarElement<HTMLDivElement>;
+  readonly politeRegion: SugarElement<HTMLDivElement>;
+  readonly assertiveRegion: SugarElement<HTMLDivElement>;
 }
 
 const OFFSCREEN_STYLES = {
@@ -41,51 +44,57 @@ const createAssertiveRegion = (): SugarElement<HTMLDivElement> => {
   return region;
 };
 
-const wait = (duration: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, duration));
-
 const isConnected = (element: SugarElement<HTMLElement>): boolean => element.dom.isConnected;
+
+const createNewState = () => {
+  const container = SugarElement.fromTag('div');
+  const politeRegion = createPoliteRegion();
+  const assertiveRegion = createAssertiveRegion();
+
+  Attribute.set(container, 'id', announcerContainerId);
+  Css.setAll(container, OFFSCREEN_STYLES);
+
+  Insert.append(container, politeRegion);
+  Insert.append(container, assertiveRegion);
+  Insert.append(SugarBody.body(), container);
+
+  return { container, politeRegion, assertiveRegion };
+};
+
+const cleanupExpiredPoliteMessages = (polite: SugarElement<HTMLDivElement>, now: number): void => {
+  Arr.each(SelectorFilter.children(polite, `div[${politeTimestampAttr}]`), (messageDiv) => {
+    Attribute.getOpt(messageDiv, politeTimestampAttr)
+      .bind((value) => Strings.toInt(value))
+      .filter((announcedAt) => now - announcedAt > POLITE_MESSAGE_TTL_MS)
+      .each(() => Remove.remove(messageDiv));
+  });
+};
 
 export const createAnnouncer = (): Announcer => {
   const state = Singleton.value<AnnouncerState>();
 
-  const mountRegions = async () => {
-    return state.get().filter(({ container }) => isConnected(container)).fold(
-      async () => {
-        const container = SugarElement.fromTag('div');
-        const polite = createPoliteRegion();
-        const assertive = createAssertiveRegion();
-
-        Attribute.set(container, 'id', announcerContainerId);
-        Css.setAll(container, OFFSCREEN_STYLES);
-
-        Insert.append(container, polite);
-        Insert.append(container, assertive);
-        Insert.append(SugarBody.body(), container);
-
-        const newState: AnnouncerState = { container, polite, assertive };
-        state.set(newState);
-
-        await wait(50); // Wait for screen readers to pick up the new regions before adding messages
-
-        return newState;
-      },
-      (state) => Promise.resolve(state)
-    );
+  const mountRegions = () => {
+    return state.get().filter(({ container }) => isConnected(container)).getOrThunk(() => {
+      const newState = createNewState();
+      state.set(newState);
+      return newState;
+    });
   };
 
   const polite = (message: string): void => {
-    mountRegions().then(({ polite }) => {
-      const messageDiv = SugarElement.fromTag('div');
-      Insert.append(messageDiv, SugarElement.fromText(message));
-      Insert.append(polite, messageDiv);
-    }).catch(Fun.noop);
+    const { politeRegion } = mountRegions();
+    const now = Date.now();
+
+    cleanupExpiredPoliteMessages(politeRegion, now);
+
+    const messageDiv = SugarElement.fromTag('div');
+    Attribute.set(messageDiv, politeTimestampAttr, String(now));
+    Insert.append(messageDiv, SugarElement.fromText(message));
+    Insert.append(politeRegion, messageDiv);
   };
 
   const assertive = (message: string): void => {
-    mountRegions().then(({ assertive }) => {
-      TextContent.set(assertive, message);
-    }).catch(Fun.noop);
+    TextContent.set(mountRegions().assertiveRegion, message);
   };
 
   return { polite, assertive };

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -85,9 +85,16 @@ export const createAnnouncer = (): Announcer => {
     const s = ensureMounted();
     s.assertive.each((r) => Remove.remove(r));
     const region = createAssertiveRegion();
-    Insert.append(region, SugarElement.fromText(message));
     Insert.append(s.container, region);
     state.set({ ...s, assertive: Optional.some(region) });
+    // The region must be connected to the DOM as an empty live region before its
+    // content is set; otherwise screen readers (notably VoiceOver) treat it as
+    // inserted-with-content and do not announce the change.
+    setTimeout(() => {
+      if (isConnected(region)) {
+        Insert.append(region, SugarElement.fromText(message));
+      }
+    }, 0);
   };
 
   return { polite, assertive };

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -1,0 +1,94 @@
+import { Id, Optional, Singleton } from '@ephox/katamari';
+import { Attribute, Css, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+
+export const announcerContainerId = Id.generate('tiny-aria-announcer');
+
+export interface Announcer {
+  readonly polite: (message: string) => void;
+  readonly assertive: (message: string) => void;
+}
+
+const POLITE_MESSAGE_TTL_MS = 60000;
+
+const offscreenStyles = {
+  position: 'absolute',
+  left: '-9999px',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden'
+};
+
+const createPoliteRegion = (): SugarElement<HTMLDivElement> => {
+  const region = SugarElement.fromTag('div');
+  Attribute.setAll(region, {
+    'aria-live': 'polite',
+    'aria-atomic': 'false',
+    'aria-relevant': 'additions'
+  });
+  return region;
+};
+
+const createAssertiveRegion = (): SugarElement<HTMLDivElement> => {
+  const region = SugarElement.fromTag('div');
+  Attribute.setAll(region, {
+    'aria-live': 'assertive',
+    'aria-atomic': 'true',
+    'role': 'alert'
+  });
+  return region;
+};
+
+interface AnnouncerState {
+  readonly container: SugarElement<HTMLElement>;
+  readonly polite: SugarElement<HTMLDivElement>;
+  readonly assertive: Optional<SugarElement<HTMLDivElement>>;
+}
+
+const isConnected = (element: SugarElement<HTMLElement>): boolean => element.dom.isConnected;
+
+export const createAnnouncer = (): Announcer => {
+  const state = Singleton.value<AnnouncerState>();
+
+  const ensureMounted = (): AnnouncerState =>
+    state.get().filter((s) => isConnected(s.container) && isConnected(s.polite)).getOrThunk(() => {
+      state.on((s) => {
+        if (isConnected(s.container)) {
+          Remove.remove(s.container);
+        }
+      });
+      const container = SugarElement.fromTag('div');
+      Attribute.set(container, 'id', announcerContainerId);
+      Css.setAll(container, offscreenStyles);
+
+      const polite = createPoliteRegion();
+      Insert.append(container, polite);
+      Insert.append(SugarBody.body(), container);
+
+      const newState: AnnouncerState = { container, polite, assertive: Optional.none() };
+      state.set(newState);
+      return newState;
+    });
+
+  const polite = (message: string): void => {
+    const s = ensureMounted();
+    const messageDiv = SugarElement.fromTag('div');
+    Insert.append(messageDiv, SugarElement.fromText(message));
+    Insert.append(s.polite, messageDiv);
+    setTimeout(() => {
+      if (isConnected(messageDiv)) {
+        Remove.remove(messageDiv);
+      }
+    }, POLITE_MESSAGE_TTL_MS);
+  };
+
+  const assertive = (message: string): void => {
+    const s = ensureMounted();
+    s.assertive.each((r) => Remove.remove(r));
+    const region = createAssertiveRegion();
+    Insert.append(region, SugarElement.fromText(message));
+    Insert.append(s.container, region);
+    state.set({ ...s, assertive: Optional.some(region) });
+  };
+
+  return { polite, assertive };
+};

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -32,7 +32,7 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     SelectorFind.descendant(SugarBody.body(), containerSelector).each(Remove.remove);
   });
 
-  it('Container is created lazily on first announce with offscreen styles', async () => {
+  it('TINY-12791: Container is created lazily on first announce with offscreen styles', async () => {
     AriaAnnouncer.announce('Setup');
     const container = await pGetContainer();
 
@@ -41,26 +41,26 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     assert.equal(Css.get(container, 'overflow'), 'hidden');
   });
 
-  it('Container starts with one persistent polite region and no assertive region', async () => {
+  it('TINY-12791: Container starts with polite region and assertive regions', async () => {
     AriaAnnouncer.announce('Setup');
     const container = await pGetContainer();
 
-    const polite = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
-    const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
-    assert.lengthOf(polite, 1, 'should have one polite region');
-    assert.lengthOf(assertive, 0, 'no assertive region should exist until an assertive announce');
-    assert.equal(Attribute.get(polite[0], 'aria-atomic'), 'false');
-    assert.equal(Attribute.get(polite[0], 'aria-relevant'), 'additions');
+    const polite = await UiFinder.pWaitFor<HTMLElement>('waited for polite container', container, 'div[aria-live="polite"]');
+    assert.equal(Attribute.get(polite, 'aria-atomic'), 'false');
+    assert.equal(Attribute.get(polite, 'aria-relevant'), 'additions');
+
+    const assertive = await UiFinder.pWaitFor<HTMLElement>('waited for assertive container', container, 'div[aria-live="assertive"]');
+    assert.equal(Attribute.get(assertive, 'aria-atomic'), 'true');
   });
 
-  it('Polite announce appends a message div as a child of the polite region', async () => {
+  it('TINY-12791: Polite announce appends a message div as a child of the polite region', async () => {
     AriaAnnouncer.announce('Bold on');
     const container = await pGetContainer();
 
     await pPoliteMessage(container, 'Bold on');
   });
 
-  it('Subsequent polite announces append additional message divs and keep prior ones', async () => {
+  it('TINY-12791: Subsequent polite announces append additional message divs and keep prior ones', async () => {
     AriaAnnouncer.announce('First');
     const container = await pGetContainer();
     await pPoliteMessage(container, 'First');
@@ -75,33 +75,20 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     assert.deepEqual(texts, [ 'First', 'Second' ], 'both messages should be present in order');
   });
 
-  it('Assertive announce creates a single assertive region with correct attributes', async () => {
-    AriaAnnouncer.announce('Error occurred', { assertive: true });
-    const container = await pGetContainer();
-
-    await pAssertiveText(container, 'Error occurred');
-    const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
-    assert.lengthOf(assertive, 1, 'exactly one assertive region after a single announce');
-    assert.equal(Attribute.get(assertive[0], 'aria-atomic'), 'true');
-    assert.equal(Attribute.get(assertive[0], 'role'), 'alert');
-  });
-
-  it('A new assertive announce removes the prior assertive region from the DOM', async () => {
+  it('TINY-12791: A new assertive announce removes the prior assertive content from the DOM', async () => {
     AriaAnnouncer.announce('Error A', { assertive: true });
     const container = await pGetContainer();
     await pAssertiveText(container, 'Error A');
-    const priorRegion = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]')[0];
 
     AriaAnnouncer.announce('Error B', { assertive: true });
     await pAssertiveText(container, 'Error B');
 
-    assert.isFalse(priorRegion.dom.isConnected, 'prior assertive region should be removed from the DOM');
     const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
     assert.lengthOf(assertive, 1, 'exactly one assertive region remains after the second announce');
     assert.equal(TextContent.get(assertive[0]), 'Error B');
   });
 
-  it('Assertive announce does not affect polite messages already in the region', async () => {
+  it('TINY-12791: Assertive announce does not affect polite messages already in the region', async () => {
     AriaAnnouncer.announce('Polite message');
     const container = await pGetContainer();
     await pPoliteMessage(container, 'Polite message');

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
-import { Attribute, Css, Remove, SelectorFind, SugarBody, TextContent, type SugarElement } from '@ephox/sugar';
+import { Attribute, Css, Insert, Remove, SelectorFind, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import AriaAnnouncer from 'tinymce/core/api/dom/AriaAnnouncer';
@@ -86,6 +86,33 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
     assert.lengthOf(assertive, 1, 'exactly one assertive region remains after the second announce');
     assert.equal(TextContent.get(assertive[0]), 'Error B');
+  });
+
+  it('TINY-12791: Polite messages older than 10 minutes are cleaned up on the next announce', async () => {
+    AriaAnnouncer.announce('Setup');
+    const container = await pGetContainer();
+    await pPoliteMessage(container, 'Setup');
+    const polite = await UiFinder.pWaitFor<HTMLElement>('waited for polite container', container, 'div[aria-live="polite"]');
+
+    // Fake a few messages that were announced more than 10 minutes ago
+    const expiredTimestamp = String(Date.now() - (10 * 60 * 1000 + 1000));
+    const expiredMessages = [ 'Old 1', 'Old 2', 'Old 3' ];
+    Arr.each(expiredMessages, (text) => {
+      const messageDiv = SugarElement.fromTag('div');
+      Attribute.set(messageDiv, 'data-mce-announced-at', expiredTimestamp);
+      TextContent.set(messageDiv, text);
+      Insert.prepend(polite, messageDiv);
+    });
+
+    // A fresh announce triggers the cleanup of the expired messages
+    AriaAnnouncer.announce('Fresh');
+    await pPoliteMessage(container, 'Fresh');
+
+    await Waiter.pTryUntil('expired polite messages should be removed', () => {
+      const texts = Arr.map(UiFinder.findAllIn<HTMLElement>(polite, 'div'), TextContent.get);
+      Arr.each(expiredMessages, (text) => assert.isFalse(Arr.contains(texts, text), `expired message "${text}" should be removed`));
+      assert.deepEqual(texts, [ 'Setup', 'Fresh' ], 'only the non-expired messages should remain, in order');
+    });
   });
 
   it('TINY-12791: Assertive announce does not affect polite messages already in the region', async () => {

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -1,35 +1,38 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { SugarBody, type SugarElement } from '@ephox/sugar';
-import { TinyHooks } from '@ephox/wrap-mcagar';
+import { Remove, SelectorFind, SugarBody, type SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import AriaAnnouncer, { announcerContainerId } from 'tinymce/core/api/dom/AriaAnnouncer';
-import type Editor from 'tinymce/core/api/Editor';
 
 describe('browser.tinymce.core.AriaAnnouncerTest', () => {
-  const hook = TinyHooks.bddSetupLight<Editor>({
-    base_url: '/project/tinymce/js/tinymce'
-  }, []);
-
   const containerSelector = `#${announcerContainerId}`;
 
   const pGetContainer = (): Promise<SugarElement<HTMLElement>> =>
     UiFinder.pWaitFor<HTMLElement>('aria announcer container should exist on the body', SugarBody.body(), containerSelector);
 
-  afterEach(async () => {
-    await Waiter.pTryUntil(
-      'Announcer container should be cleaned up between tests',
-      () => UiFinder.notExists(SugarBody.body(), containerSelector),
-      100,
-      3000
-    );
+  const pPoliteMessage = (container: SugarElement<HTMLElement>, text: string): Promise<void> =>
+    Waiter.pTryUntil(`polite region should contain a message "${text}"`, () => {
+      const politeRegions = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
+      assert.isAtLeast(politeRegions.length, 1, 'polite region not present');
+      const messageDivs = UiFinder.findAllIn<HTMLElement>(politeRegions[0], 'div');
+      const found = messageDivs.some((m) => m.dom.textContent === text);
+      assert.isTrue(found, `message "${text}" not present in polite region`);
+    });
+
+  const pAssertiveText = (container: SugarElement<HTMLElement>, text: string): Promise<void> =>
+    Waiter.pTryUntil(`assertive region should contain "${text}"`, () => {
+      const matches = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]')
+        .filter((r) => r.dom.textContent === text);
+      assert.isAtLeast(matches.length, 1, `text "${text}" not present in any assertive region`);
+    });
+
+  afterEach(() => {
+    SelectorFind.descendant(SugarBody.body(), containerSelector).each(Remove.remove);
   });
 
   it('Container is created lazily on first announce with offscreen styles', async () => {
-    const editor = hook.editor();
-
-    editor.announce('Setup');
+    AriaAnnouncer.announce('Setup');
     const container = (await pGetContainer()).dom;
 
     assert.equal(container.style.position, 'absolute');
@@ -37,81 +40,74 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     assert.equal(container.style.overflow, 'hidden');
   });
 
-  it('Announce creates a polite token with correct attributes', async () => {
-    const editor = hook.editor();
-
-    editor.announce('Bold on');
+  it('Container starts with one persistent polite region and no assertive region', async () => {
+    AriaAnnouncer.announce('Setup');
     const container = await pGetContainer();
 
-    const token = (await UiFinder.pWaitFor<HTMLElement>('polite token should exist', container, 'span[aria-live="polite"][aria-label="Bold on"]')).dom;
-    assert.equal(token.getAttribute('aria-atomic'), 'true');
-    assert.equal(token.getAttribute('role'), 'presentation');
-    assert.equal(token.textContent, 'Bold on');
+    const polite = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
+    const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
+    assert.lengthOf(polite, 1, 'should have one polite region');
+    assert.lengthOf(assertive, 0, 'no assertive region should exist until an assertive announce');
+    assert.equal(polite[0].dom.getAttribute('aria-atomic'), 'false');
+    assert.equal(polite[0].dom.getAttribute('aria-relevant'), 'additions');
   });
 
-  it('Assertive announce creates an assertive token with correct attributes', async () => {
-    const editor = hook.editor();
-
-    editor.announce('Error occurred', { assertive: true });
+  it('Polite announce appends a message div as a child of the polite region', async () => {
+    AriaAnnouncer.announce('Bold on');
     const container = await pGetContainer();
 
-    const token = (await UiFinder.pWaitFor<HTMLElement>('assertive token should exist', container, 'span[aria-live="assertive"]')).dom;
-    assert.equal(token.getAttribute('aria-atomic'), 'true');
-    assert.equal(token.getAttribute('role'), 'alert');
-    assert.equal(token.textContent, 'Error occurred');
+    await pPoliteMessage(container, 'Bold on');
   });
 
-  it('Token is removed after timeout', async () => {
-    const editor = hook.editor();
-
-    editor.announce('Italic on');
+  it('Subsequent polite announces append additional message divs and keep prior ones', async () => {
+    AriaAnnouncer.announce('First');
     const container = await pGetContainer();
-    const tokenSelector = 'span[aria-label="Italic on"]';
+    await pPoliteMessage(container, 'First');
 
-    await UiFinder.pWaitFor('token "Italic on" should exist immediately', container, tokenSelector);
+    AriaAnnouncer.announce('Second');
+    await pPoliteMessage(container, 'Second');
 
-    await Waiter.pTryUntil(
-      'Token should be removed after timeout',
-      () => UiFinder.notExists(container, tokenSelector),
-      100,
-      2000
-    );
+    const polite = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
+    assert.lengthOf(polite, 1, 'still only one polite region');
+    const messageDivs = UiFinder.findAllIn<HTMLElement>(polite[0], 'div');
+    const texts = messageDivs.map((m) => m.dom.textContent);
+    assert.deepEqual(texts, [ 'First', 'Second' ], 'both messages should be present in order');
   });
 
-  it('Container is removed once all tokens have been cleaned up', async () => {
-    const editor = hook.editor();
-
-    editor.announce('Cleanup');
-    await pGetContainer();
-
-    await Waiter.pTryUntil(
-      'Container should be removed once all tokens have been cleaned up',
-      () => UiFinder.notExists(SugarBody.body(), containerSelector),
-      100,
-      3000
-    );
-  });
-
-  it('Rapid calls create separate tokens for each message', async () => {
-    const editor = hook.editor();
-
-    editor.announce('First');
-    editor.announce('Second');
-    editor.announce('Third');
+  it('Assertive announce creates a single assertive region with correct attributes', async () => {
+    AriaAnnouncer.announce('Error occurred', { assertive: true });
     const container = await pGetContainer();
 
-    await UiFinder.pWaitFor('all three tokens should be present', container, 'span[aria-label="Third"]');
-    const tokens = UiFinder.findAllIn<HTMLElement>(container, 'span[aria-live="polite"]');
-    const labels = tokens.map((t) => t.dom.getAttribute('aria-label'));
-    assert.include(labels, 'First');
-    assert.include(labels, 'Second');
-    assert.include(labels, 'Third');
+    await pAssertiveText(container, 'Error occurred');
+    const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
+    assert.lengthOf(assertive, 1, 'exactly one assertive region after a single announce');
+    assert.equal(assertive[0].dom.getAttribute('aria-atomic'), 'true');
+    assert.equal(assertive[0].dom.getAttribute('role'), 'alert');
   });
 
-  it('Announcer is accessible via the tinymce.dom.AriaAnnouncer', async () => {
-    AriaAnnouncer.announce('Global announce');
+  it('A new assertive announce removes the prior assertive region from the DOM', async () => {
+    AriaAnnouncer.announce('Error A', { assertive: true });
     const container = await pGetContainer();
+    await pAssertiveText(container, 'Error A');
+    const priorRegion = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]')[0];
 
-    await UiFinder.pWaitFor('token should be created via the global singleton', container, 'span[aria-label="Global announce"]');
+    AriaAnnouncer.announce('Error B', { assertive: true });
+    await pAssertiveText(container, 'Error B');
+
+    assert.isFalse(priorRegion.dom.isConnected, 'prior assertive region should be removed from the DOM');
+    const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
+    assert.lengthOf(assertive, 1, 'exactly one assertive region remains after the second announce');
+    assert.equal(assertive[0].dom.textContent, 'Error B');
+  });
+
+  it('Assertive announce does not affect polite messages already in the region', async () => {
+    AriaAnnouncer.announce('Polite message');
+    const container = await pGetContainer();
+    await pPoliteMessage(container, 'Polite message');
+
+    AriaAnnouncer.announce('Urgent', { assertive: true });
+    await pAssertiveText(container, 'Urgent');
+
+    await pPoliteMessage(container, 'Polite message');
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -1,12 +1,14 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { Remove, SelectorFind, SugarBody, type SugarElement } from '@ephox/sugar';
+import { Arr } from '@ephox/katamari';
+import { Attribute, Css, Remove, SelectorFind, SugarBody, TextContent, type SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
 
-import AriaAnnouncer, { announcerContainerId } from 'tinymce/core/api/dom/AriaAnnouncer';
+import AriaAnnouncer from 'tinymce/core/api/dom/AriaAnnouncer';
+import * as Announcer from 'tinymce/core/aria/Announcer';
 
 describe('browser.tinymce.core.AriaAnnouncerTest', () => {
-  const containerSelector = `#${announcerContainerId}`;
+  const containerSelector = `#${Announcer.announcerContainerId}`;
 
   const pGetContainer = (): Promise<SugarElement<HTMLElement>> =>
     UiFinder.pWaitFor<HTMLElement>('aria announcer container should exist on the body', SugarBody.body(), containerSelector);
@@ -16,14 +18,13 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
       const politeRegions = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
       assert.isAtLeast(politeRegions.length, 1, 'polite region not present');
       const messageDivs = UiFinder.findAllIn<HTMLElement>(politeRegions[0], 'div');
-      const found = messageDivs.some((m) => m.dom.textContent === text);
+      const found = Arr.exists(messageDivs, (m) => TextContent.get(m) === text);
       assert.isTrue(found, `message "${text}" not present in polite region`);
     });
 
   const pAssertiveText = (container: SugarElement<HTMLElement>, text: string): Promise<void> =>
     Waiter.pTryUntil(`assertive region should contain "${text}"`, () => {
-      const matches = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]')
-        .filter((r) => r.dom.textContent === text);
+      const matches = Arr.filter(UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]'), (r) => TextContent.get(r) === text);
       assert.isAtLeast(matches.length, 1, `text "${text}" not present in any assertive region`);
     });
 
@@ -33,11 +34,11 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
 
   it('Container is created lazily on first announce with offscreen styles', async () => {
     AriaAnnouncer.announce('Setup');
-    const container = (await pGetContainer()).dom;
+    const container = await pGetContainer();
 
-    assert.equal(container.style.position, 'absolute');
-    assert.equal(container.style.left, '-9999px');
-    assert.equal(container.style.overflow, 'hidden');
+    assert.equal(Css.get(container, 'position'), 'absolute');
+    assert.equal(Css.get(container, 'left'), '-9999px');
+    assert.equal(Css.get(container, 'overflow'), 'hidden');
   });
 
   it('Container starts with one persistent polite region and no assertive region', async () => {
@@ -48,8 +49,8 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
     assert.lengthOf(polite, 1, 'should have one polite region');
     assert.lengthOf(assertive, 0, 'no assertive region should exist until an assertive announce');
-    assert.equal(polite[0].dom.getAttribute('aria-atomic'), 'false');
-    assert.equal(polite[0].dom.getAttribute('aria-relevant'), 'additions');
+    assert.equal(Attribute.get(polite[0], 'aria-atomic'), 'false');
+    assert.equal(Attribute.get(polite[0], 'aria-relevant'), 'additions');
   });
 
   it('Polite announce appends a message div as a child of the polite region', async () => {
@@ -70,7 +71,7 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     const polite = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
     assert.lengthOf(polite, 1, 'still only one polite region');
     const messageDivs = UiFinder.findAllIn<HTMLElement>(polite[0], 'div');
-    const texts = messageDivs.map((m) => m.dom.textContent);
+    const texts = Arr.map(messageDivs, TextContent.get);
     assert.deepEqual(texts, [ 'First', 'Second' ], 'both messages should be present in order');
   });
 
@@ -81,8 +82,8 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     await pAssertiveText(container, 'Error occurred');
     const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
     assert.lengthOf(assertive, 1, 'exactly one assertive region after a single announce');
-    assert.equal(assertive[0].dom.getAttribute('aria-atomic'), 'true');
-    assert.equal(assertive[0].dom.getAttribute('role'), 'alert');
+    assert.equal(Attribute.get(assertive[0], 'aria-atomic'), 'true');
+    assert.equal(Attribute.get(assertive[0], 'role'), 'alert');
   });
 
   it('A new assertive announce removes the prior assertive region from the DOM', async () => {
@@ -97,7 +98,7 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     assert.isFalse(priorRegion.dom.isConnected, 'prior assertive region should be removed from the DOM');
     const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
     assert.lengthOf(assertive, 1, 'exactly one assertive region remains after the second announce');
-    assert.equal(assertive[0].dom.textContent, 'Error B');
+    assert.equal(TextContent.get(assertive[0]), 'Error B');
   });
 
   it('Assertive announce does not affect polite messages already in the region', async () => {


### PR DESCRIPTION
Related Ticket: [TINY-12791](https://github.com/tinymce/tinymce/pull/11086)

Description of Changes:

- Replaced the token-based, self-cleaning `AriaAnnouncer` implementation with a persistent live-region approach to improve screen reader compatibility. With previous implementation the messages were often cleaned out before the screen reader announcement. 
- Polite announcements now append child `<div>` elements to a single persistent `aria-live="polite"` region (`aria-atomic="false"`, `aria-relevant="additions"`), so each message is announced independently without re-reading prior messages
- Assertive announcements create a fresh `aria-live="assertive"` region per message, removing the previous assertive region before inserting the new one; message content is written after a short defer so screen readers register the live region before its content is populated
- The container is now persistent and recreated only if it has been disconnected from the DOM
- Updated tests to reflect the new DOM structure, verifying polite message accumulation, assertive region replacement, isolation between polite and assertive regions, and container regeneration after external removal
- Separated it into two modules one internal one and one API level one
- Changed so that the `div` elements for polite is cleaned up if they are more then 10 minutes old.

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

[TINY-12791]: https://ephocks.atlassian.net/browse/TINY-12791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Accessibility announcement system simplified to use persistent polite/assertive live regions created lazily; polite messages accumulate while assertive announcements replace prior assertive content. Regions are mounted with an offscreen container to improve assistive tech detection.
* **Tests**
  * Browser tests updated to validate the new live-region behaviors, message lifecycle, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->