### PR TITLE
TINY-13292: Only delete newline in empty list item

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13292-2026-05-15.yaml
+++ b/.changes/unreleased/tinymce-TINY-13292-2026-05-15.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Deleting a newline within a list item would delete the list item.
+time: 2026-05-15T10:14:50.676617+10:00
+custom:
+    Issue: TINY-13292

--- a/modules/tinymce/src/core/main/ts/lists/actions/Delete.ts
+++ b/modules/tinymce/src/core/main/ts/lists/actions/Delete.ts
@@ -236,7 +236,7 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
     const nextCaretContainer = findNextCaretContainer(editor, rng, isForward, root);
     const otherLi = dom.getParent(nextCaretContainer, 'LI', root);
 
-    if (nextCaretContainer && otherLi) {
+    if (nextCaretContainer && otherLi && (isForward || !dom.isChildOf(nextCaretContainer, block))) {
       const findValidElement = (element: SugarElement<Node>) => Arr.contains([ 'td', 'th', 'caption' ], SugarNode.name(element));
       const findRoot = (node: SugarElement<Node>) => node.dom === root;
       const otherLiCell = PredicateFind.closest(SugarElement.fromDom(otherLi), findValidElement, findRoot);

--- a/modules/tinymce/src/core/test/ts/browser/lists/BackspaceDeleteFromBlockIntoLiTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/lists/BackspaceDeleteFromBlockIntoLiTest.ts
@@ -285,4 +285,50 @@ describe('browser.tinymce.core.lists.BackspaceDeleteFromBlockIntoLiTest', () => 
     editor.off('beforeinput', beforeInputHandler);
     editor.off('input', inputHandler);
   });
+
+  it('TINY-13292: backspace after br in list item should remove the br, not the list item', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>' +
+        '<li>a</li>' +
+        '<li>b</li>' +
+        '<li><br><br data-mce-bogus="1"></li>' +
+      '</ul>',
+      { format: 'raw' }
+    );
+    TinySelections.setCursor(editor, [ 0, 2 ], 1);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+    TinyAssertions.assertContent(editor,
+      '<ul>' +
+        '<li>a</li>' +
+        '<li>b</li>' +
+        '<li>&nbsp;</li>' +
+      '</ul>'
+    );
+  });
+
+  it('TINY-13292: backspace after br in nested list item should remove the br, not the list item', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>' +
+        '<li>a' +
+          '<ul>' +
+            '<li><br><br data-mce-bogus="1"></li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>',
+      { format: 'raw' }
+    );
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0 ], 1);
+    TinyContentActions.keystroke(editor, Keys.backspace());
+    TinyAssertions.assertContent(editor,
+      '<ul>' +
+        '<li>a' +
+          '<ul>' +
+            '<li>&nbsp;</li>' +
+          '</ul>' +
+        '</li>' +
+      '</ul>'
+    );
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-13292

Description of Changes:
* Fixed issue where deleting a newline within an empty list item would delete the whole list item rather than just the newline

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): #10051 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where deleting a newline within a list item would delete the entire list item instead of just the newline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->