### PR TITLE
TINY-14255: fix undo shortcut selection

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14255-2026-04-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-14255-2026-04-24.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Using the undo keyboard shortcut would not restore selection like the toolbar button would.
+time: 2026-04-24T09:14:17.578652+02:00
+custom:
+    Issue: TINY-14255

--- a/.changes/unreleased/tinymce-TINY-14255-2026-04-24.yaml
+++ b/.changes/unreleased/tinymce-TINY-14255-2026-04-24.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Using the undo keyboard shortcut would not restore selection like the toolbar button would.
+body: Using the undo keyboard shortcut did not restore editor selection correctly.
 time: 2026-04-24T09:14:17.578652+02:00
 custom:
     Issue: TINY-14255

--- a/modules/agar/src/main/ts/ephox/agar/api/Keys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Keys.ts
@@ -14,5 +14,7 @@ export const Keys = {
   home: Fun.constant(36),
   end: Fun.constant(35),
   pageUp: Fun.constant(33),
-  pageDown: Fun.constant(34)
+  pageDown: Fun.constant(34),
+  control: Fun.constant(17),
+  cmdMac: Fun.constant(91)
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/Keys.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Keys.ts
@@ -16,5 +16,5 @@ export const Keys = {
   pageUp: Fun.constant(33),
   pageDown: Fun.constant(34),
   control: Fun.constant(17),
-  cmdMac: Fun.constant(91)
+  meta: Fun.constant(91)
 };

--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -119,11 +119,6 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       isFirstTypedCharacter.set(true);
       return;
     }
-
-    const hasOnlyMetaOrCtrlModifier = Env.os.isMacOS() ? e.metaKey : e.ctrlKey && !e.altKey;
-    if (hasOnlyMetaOrCtrlModifier) {
-      undoManager.beforeChange();
-    }
   });
 
   editor.on('mousedown', (e) => {

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -42,7 +42,7 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
 
   const undoKeystrokeRealistic = (editor: Editor) => {
     const isMac = platform.os.isMacOS();
-    const modKeyCode = isMac ? Keys.cmdMac() : Keys.control();
+    const modKeyCode = isMac ? Keys.meta() : Keys.control();
     const modifier = isMac ? { metaKey: true } : { ctrl: true };
 
     TinyContentActions.keydown(editor, modKeyCode, modifier);

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -1,6 +1,7 @@
+import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyContentActions, TinyHooks } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
 
@@ -37,5 +38,45 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
     TinyAssertions.assertContent(editor, '<p>abc</p>');
     redoKeystroke(editor);
     TinyAssertions.assertContent(editor, '');
+  });
+
+  const undoKeystrokeRealistic = (editor: Editor) => {
+    const isMac = platform.os.isMacOS();
+    const modKeyCode = isMac ? Keys.cmdMac() : Keys.control();
+    const modifier = isMac ? { metaKey: true } : { ctrl: true };
+
+    TinyContentActions.keydown(editor, modKeyCode, modifier);
+    TinyContentActions.keydown(editor, 'Z'.charCodeAt(0), modifier);
+    TinyContentActions.keyup(editor, 'Z'.charCodeAt(0), modifier);
+    TinyContentActions.keyup(editor, modKeyCode, {});
+  };
+
+  const simulateRealDeleteViaKeyboard = (editor: Editor) => {
+    TinyContentActions.keydown(editor, Keys.delete());
+    // The browser would now delete "bc" itself. Reproduce that DOM mutation:
+    (editor.getBody().firstChild as HTMLElement).textContent = 'a';
+    TinySelections.setCursor(editor, [ 0, 0 ], 1);
+    TinyContentActions.keyup(editor, Keys.delete());
+  };
+
+  it('TINY-14255: undo shortcut should have the same selection has the undo button after a partial delection', () => {
+    const editor = hook.editor();
+    editor.resetContent('<p>abc</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 3);
+
+    simulateRealDeleteViaKeyboard(editor);
+    TinyAssertions.assertContent(editor, '<p>a</p>');
+    undoKeystrokeRealistic(editor);
+    TinyAssertions.assertContent(editor, '<p>abc</p>');
+    TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 3);
+
+    editor.resetContent('<p>abc</p>');
+    TinySelections.setSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 3);
+
+    simulateRealDeleteViaKeyboard(editor);
+    TinyAssertions.assertContent(editor, '<p>a</p>');
+    editor.execCommand('Undo');
+    TinyAssertions.assertContent(editor, '<p>abc</p>');
+    TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 3);
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-14255

Description of Changes:
This was solved by Hannes I just put the test in it, there is a better description of his solution in the Jira.

About the test to simulate the same scenario, we cannot use `delete` command nor direct `ctrl+z`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the undo keyboard shortcut so it correctly restores text selection and cursor position, matching the toolbar undo behavior.

* **Tests**
  * Added browser tests to verify undo restores selection across platform modifier keys and after partial deletions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->