### PR TITLE
TINY-14310: Gate AI preview selection styling behind a class

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -30,10 +30,8 @@
   display: revert;
 }
 
-.tox-tinymceai__annotation--added__highlight,
-.tox-tinymceai__annotation--modified__highlight,
-.tox-tinymceai__annotation--removed__highlight {
-  cursor: pointer;
+.tox-tinymceai-preview {
+  display: block;
 }
 
 div[tinymceai-data-pending-diff="true"],
@@ -43,63 +41,19 @@ span[tinymceai-data-pending-diff="true"] {
   background: @color-white;
 }
 
+.tox-tinymceai__annotation--added__highlight,
+.tox-tinymceai__annotation--modified__highlight,
+.tox-tinymceai__annotation--removed__highlight {
+  cursor: pointer;
+}
+
 .tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
 .tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
-  cursor: pointer;
   background-position: bottom;
   background-image: linear-gradient(
     transparent calc(100% - 3px),
     @color-tint calc(100% - 3px)
   );
-}
-
-.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
-.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
-  background-image: none;
-  background-color: fade(@color-tint, 20%);
-  box-shadow: @tinymceai-selected-box-shadow;
-}
-
-// TEMP: Show deleted content when its review card is selected.
-// Makes deletions visible and scrollable in preview mode.
-// TODO: Replace with a proper visual marker that doesn't reveal full deleted content.
-.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
-  display: revert;
-  text-decoration: line-through;
-  background-image: none;
-  background-color: fade(@color-error, 20%);
-  box-shadow: @tinymceai-selected-box-shadow;
-}
-
-// ins/del elements only contain text and inline formatting, so they can safely use
-// the 1lh background-image approach for tighter inline selection styling
-ins, del {
-  &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
-  &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
-    background-color: transparent;
-    box-shadow: none;
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(
-      @color-tint 3px,
-      fade(@color-tint, 20%) 3px,
-      fade(@color-tint, 20%) calc(100% - 3px),
-      @color-tint calc(100% - 3px)
-    );
-  }
-
-  &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
-    background-color: transparent;
-    box-shadow: none;
-    background-position: center;
-    background-size: 100% calc(1lh + 3px);
-    background-image: linear-gradient(
-      @color-error 3px,
-      fade(@color-error, 20%) 3px,
-      fade(@color-error, 20%) calc(100% - 3px),
-      @color-error calc(100% - 3px)
-    );
-  }
 }
 
 img, video, iframe {
@@ -109,22 +63,88 @@ img, video, iframe {
     outline: 0.25em solid fade(@color-tint, 20%);
     padding: 0.25em;
   }
+}
 
-  &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
-  &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
-    background-image: none;
-    border: 0.25em solid fade(@color-tint, 20%);
-    outline: 0.125em solid @color-tint;
-    padding: 0;
+body.tox-tinymceai-preview--selectable {
+  .tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
+  .tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
+    cursor: pointer;
   }
 
-  &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
-    display: inline;
+  .tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
+  .tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
     background-image: none;
-    border: 0.25em solid fade(@color-error, 20%);
-    outline: 0.125em solid @color-error;
-    padding: 0;
+    background-color: fade(@color-tint, 20%);
+    box-shadow: @tinymceai-selected-box-shadow;
   }
+
+  // TEMP: Show deleted content when its review card is selected.
+  // Makes deletions visible and scrollable in preview mode.
+  // TODO: Replace with a proper visual marker that doesn't reveal full deleted content.
+  .tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+    display: revert;
+    text-decoration: line-through;
+    background-image: none;
+    background-color: fade(@color-error, 20%);
+    box-shadow: @tinymceai-selected-box-shadow;
+  }
+
+  // ins/del elements only contain text and inline formatting, so they can safely use
+  // the 1lh background-image approach for tighter inline selection styling
+  ins, del {
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(
+        @color-tint 3px,
+        fade(@color-tint, 20%) 3px,
+        fade(@color-tint, 20%) calc(100% - 3px),
+        @color-tint calc(100% - 3px)
+      );
+    }
+
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+      background-color: transparent;
+      box-shadow: none;
+      background-position: center;
+      background-size: 100% calc(1lh + 3px);
+      background-image: linear-gradient(
+        @color-error 3px,
+        fade(@color-error, 20%) 3px,
+        fade(@color-error, 20%) calc(100% - 3px),
+        @color-error calc(100% - 3px)
+      );
+    }
+  }
+
+  img, video, iframe {
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
+      background-image: none;
+      border: 0.25em solid fade(@color-tint, 20%);
+      outline: 0.125em solid @color-tint;
+      padding: 0;
+    }
+
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+      display: inline;
+      background-image: none;
+      border: 0.25em solid fade(@color-error, 20%);
+      outline: 0.125em solid @color-error;
+      padding: 0;
+    }
+  }
+}
+
+.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
+.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected,
+.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+  background-color: transparent;
+  box-shadow: none;
+  border: 0;
 }
 
 .tox-tinymceai__diff-focus-overlay {


### PR DESCRIPTION
Related Ticket: TINY-14310

Description of Changes:
* Move `cursor: pointer` and all `--*__selected` styling into `body.tox-tinymceai-preview--selectable`.
* The base highlight (underline for text/blocks, outline for media) stays the same, so suggestions are still underlined for visibility in both Chat/Actions and Review preview.
* Remove fill in preview mode for body without `tox-tinymceai-preview--selectable`, so it won't show the selected diff styles, only underline

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Refined TinyMCE AI preview annotation styling for better interaction clarity. The preview container now renders consistently, selectable annotations show an appropriate pointer cursor, and selected states for added/modified/removed annotations no longer carry the previous highlight background and shadow treatment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->