### PR TITLE
TINY-14378: Make Tooltip overflow detection reactive to Trigger children changes

### DIFF
--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -1,16 +1,16 @@
-import { Id, Type } from '@ephox/katamari';
+import { Arr, Id, Type } from '@ephox/katamari';
 import { PredicateExists, SugarElement, SugarNode } from '@ephox/sugar';
 import { Bem } from 'oxide-components/main';
 import {
   Children, cloneElement, forwardRef, isValidElement, useCallback,
+  useContext,
   useLayoutEffect, useMemo, useRef, useState, type FC, type HTMLAttributes,
-  type PropsWithChildren, type ReactNode, useContext,
-  useEffect
+  type PropsWithChildren, type ReactNode
 } from 'react';
 
 import { DropdownContext } from '../dropdown/internals/Context';
 
-import { useTooltip, TooltipContext } from './internals/Context';
+import { TooltipContext, useTooltip } from './internals/Context';
 
 interface RootProps extends PropsWithChildren {
   readonly showCondition?: 'always' | 'overflow';
@@ -18,47 +18,56 @@ interface RootProps extends PropsWithChildren {
 
 interface TriggerInternalProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> { }
 
-// Certain elements have an overflow of 1 even when not overflowing. Ignore those.
+// Certain elements have an offsetWidth that is 1px larger than scrollWidth even
+// when content fits. Treat that case as non-overflowing.
 const isOverflowing = (element: HTMLElement) => (element.offsetWidth + 1 < element.scrollWidth);
 
+const isOverflowingDeep = (root: HTMLElement) =>
+  isOverflowing(root) || PredicateExists.child(SugarElement.fromDom(root),
+    (child) => SugarNode.isHTMLElement(child) && isOverflowing(child.dom));
+
 const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
-  const { shouldRenderComponents, setIsOpen, showCondition, triggerRef, setRenderComponents, popupAnchor } = useTooltip();
-
-  const shouldRender = useCallback(() => {
-    if (showCondition === 'overflow') {
-      const trigger = triggerRef.current;
-
-      if (Type.isNonNullable(trigger)) {
-        return isOverflowing(trigger) || PredicateExists.child(SugarElement.fromDom(trigger), (child) => SugarNode.isHTMLElement(child) && isOverflowing(child.dom));
-      }
-    }
-
-    return true;
-  }, [ triggerRef, showCondition ]);
+  const { setIsOpen, showCondition, triggerRef, setCanShow, popupAnchor } = useTooltip();
 
   useLayoutEffect(() => {
-    const shouldRerender = shouldRender();
-    if (shouldRenderComponents === shouldRerender) {
+    if (showCondition === 'always') {
+      setCanShow(true);
       return;
     }
-    setRenderComponents(shouldRerender);
-  }, [ shouldRenderComponents, showCondition, shouldRender, setRenderComponents ]);
 
-  useEffect(() => {
-    const handleResize = () => {
-      const shouldRerender = shouldRender();
-      if (shouldRenderComponents === shouldRerender) {
-        return;
-      }
-      setRenderComponents(shouldRerender);
+    const trigger = triggerRef.current;
+    if (Type.isNullable(trigger)) {
+      return;
+    }
+
+    const recomputeCanShow = () => setCanShow(isOverflowingDeep(trigger));
+
+    let observedChildren: Element[] = [];
+    const resizeObserver = new window.ResizeObserver(recomputeCanShow);
+    resizeObserver.observe(trigger);
+
+    // Children of the trigger can resize without resizing the trigger itself
+    // (e.g. when the trigger has overflow: hidden). Observe each child too, and
+    // resync whenever the child set changes so newly-added children are tracked.
+    const observeChildren = () => {
+      Arr.each(observedChildren, (child) => resizeObserver.unobserve(child));
+      observedChildren = Array.from(trigger.children);
+      Arr.each(observedChildren, (child) => resizeObserver.observe(child));
     };
+    observeChildren();
+    recomputeCanShow();
 
-    window.addEventListener('resize', handleResize);
+    const mutationObserver = new window.MutationObserver(() => {
+      observeChildren();
+      recomputeCanShow();
+    });
+    mutationObserver.observe(trigger, { childList: true, subtree: true, characterData: true });
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
     };
-  }, [ shouldRenderComponents, showCondition, shouldRender, setRenderComponents ]);
+  }, [ showCondition, triggerRef, setCanShow ]);
 
   const count = Children.count(children);
   if (count === 0) {
@@ -90,50 +99,43 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
     }
   };
 
-  if (shouldRenderComponents) {
-    return cloneElement(theChild, {
-      ...props,
-      style: {
-        ...theChild.props.style,
-        anchorName: popupAnchor
-      },
-      ref: refCallback,
-      onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
-        if (!e.isDefaultPrevented()) {
-          theChild.props.onMouseEnter?.(e);
-          props.onMouseEnter?.(e);
-          setIsOpen(true);
-        }
-      },
-      onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
-        if (!e.isDefaultPrevented()) {
-          theChild.props.onMouseLeave?.(e);
-          props.onMouseLeave?.(e);
-          setIsOpen(false);
-        }
-      },
-      // TODO: Disabled render on focus for now see #TINY-14178
-      // onFocus: (e: React.FocusEvent<HTMLElement>) => {
-      //   if (!e.isDefaultPrevented()) {
-      //     theChild.props.onFocus?.(e);
-      //     props.onFocus?.(e);
-      //     setIsOpen(true);
-      //   }
-      // },
-      // onBlur: (e: React.FocusEvent<HTMLElement>) => {
-      //   if (!e.isDefaultPrevented()) {
-      //     theChild.props.onBlur?.(e);
-      //     props.onBlur?.(e);
-      //     setIsOpen(false);
-      //   }
-      // },
-    });
-  } else {
-    return cloneElement(theChild, {
-      ...props,
-      ref: refCallback,
-    });
-  }
+  return cloneElement(theChild, {
+    ...props,
+    style: {
+      ...theChild.props.style,
+      anchorName: popupAnchor
+    },
+    ref: refCallback,
+    onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
+      theChild.props.onMouseEnter?.(e);
+      props.onMouseEnter?.(e);
+      if (!e.isDefaultPrevented()) {
+        setIsOpen(true);
+      }
+    },
+    onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
+      theChild.props.onMouseLeave?.(e);
+      props.onMouseLeave?.(e);
+      if (!e.isDefaultPrevented()) {
+        setIsOpen(false);
+      }
+    },
+    // TODO: Disabled render on focus for now see #TINY-14178
+    // onFocus: (e: React.FocusEvent<HTMLElement>) => {
+    //   if (!e.isDefaultPrevented()) {
+    //     theChild.props.onFocus?.(e);
+    //     props.onFocus?.(e);
+    //     setIsOpen(true);
+    //   }
+    // },
+    // onBlur: (e: React.FocusEvent<HTMLElement>) => {
+    //   if (!e.isDefaultPrevented()) {
+    //     theChild.props.onBlur?.(e);
+    //     props.onBlur?.(e);
+    //     setIsOpen(false);
+    //   }
+    // },
+  });
 });
 
 const Trigger: React.ForwardRefExoticComponent<
@@ -156,13 +158,12 @@ const hideContentPopover = (content: HTMLElement) => {
 };
 
 const Content = forwardRef<HTMLDivElement, ContentProps>(({ text }, ref) => {
-  const { shouldRenderComponents, setRenderComponents, isOpen, contentRef, triggerRef, delayForShow, delayForHide, popupAnchor } = useTooltip();
-
-  useEffect(() => {
-    setRenderComponents(true);
-  }, [ text, setRenderComponents ]);
+  const { canShow, isOpen, contentRef, delayForShow, delayForHide, popupAnchor } = useTooltip();
 
   useLayoutEffect(() => {
+    if (!canShow) {
+      return;
+    }
     if (Type.isNonNullable(contentRef.current)) {
       const content = contentRef.current;
       if (isOpen) {
@@ -177,9 +178,9 @@ const Content = forwardRef<HTMLDivElement, ContentProps>(({ text }, ref) => {
         };
       }
     }
-  }, [ shouldRenderComponents, isOpen, contentRef, triggerRef, delayForShow, delayForHide ]);
+  }, [ canShow, isOpen, contentRef, delayForShow, delayForHide ]);
 
-  if (!shouldRenderComponents) {
+  if (!canShow) {
     return null;
   }
 
@@ -204,10 +205,10 @@ const Content = forwardRef<HTMLDivElement, ContentProps>(({ text }, ref) => {
   );
 });
 
-const Root: FC<RootProps> = ({ children, showCondition }) => {
+const Root: FC<RootProps> = ({ children, showCondition = 'always' }) => {
   const [ state, setState ] = useState({
     isOpen: false,
-    shouldRenderComponents: true,
+    canShow: showCondition === 'always',
     delayForShow: 300,
     delayForHide: 100,
   });
@@ -218,35 +219,42 @@ const Root: FC<RootProps> = ({ children, showCondition }) => {
     setState((prevState) => ({ ...prevState, isOpen }));
   }, []);
 
-  const setRenderComponents = useCallback((shouldRenderComponents: boolean) => {
-    if (shouldRenderComponents) {
-      setState((prevState) => ({ ...prevState, isOpen: false, shouldRenderComponents }));
-    } else {
-      setState((prevState) => ({ ...prevState, shouldRenderComponents }));
-    }
+  const setCanShow = useCallback((canShow: boolean) => {
+    setState((prevState) => {
+      if (prevState.canShow === canShow) {
+        return prevState;
+      }
+      // When transitioning to "cannot show", also clear isOpen so that a later
+      // transition back to canShow=true does not pick up stale open state.
+      return canShow
+        ? { ...prevState, canShow }
+        : { ...prevState, canShow, isOpen: false };
+    });
   }, []);
-  const context = useContext(DropdownContext);
+
+  const dropdownContext = useContext(DropdownContext);
   const popupAnchor = useMemo(() => {
-    if (context !== null) {
+    if (Type.isNonNullable(dropdownContext)) {
       // if the tooltip is in a dropdown context, use the dropdown anchor that's already on the trigger instead of overwriting it
-      return context.popupAnchor;
+      return dropdownContext.popupAnchor;
     } else {
       return `--${Id.generate('tooltip')}`;
     }
   // generate one ID per trigger/content combination, not every time
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ context, triggerRef, contentRef ]);
+  }, [ dropdownContext, triggerRef, contentRef ]);
+
   const contextValue = useMemo(() => {
     return ({
       ...state,
       setIsOpen,
+      setCanShow,
       contentRef,
       triggerRef,
-      showCondition: showCondition || 'always',
-      setRenderComponents,
+      showCondition,
       popupAnchor
     });
-  }, [ state, setIsOpen, popupAnchor, setRenderComponents, showCondition ]);
+  }, [ state, setIsOpen, setCanShow, popupAnchor, showCondition ]);
 
   return <TooltipContext.Provider value={contextValue}>{children}</TooltipContext.Provider>;
 };

--- a/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
@@ -2,11 +2,11 @@ import { createContext, useContext } from 'react';
 
 export interface TooltipContext {
   readonly isOpen: boolean;
-  readonly shouldRenderComponents: boolean;
+  readonly canShow: boolean;
   readonly delayForShow: number;
   readonly delayForHide: number;
   readonly setIsOpen: (isOpen: boolean) => void;
-  readonly setRenderComponents: (isOpen: boolean) => void;
+  readonly setCanShow: (canShow: boolean) => void;
   readonly contentRef: React.MutableRefObject<HTMLDivElement | null>;
   readonly triggerRef: React.MutableRefObject<HTMLDivElement | null>;
   readonly showCondition: 'always' | 'overflow';

--- a/modules/oxide-components/src/test/ts/browser/components/Tooltip.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Tooltip.spec.tsx
@@ -1,6 +1,6 @@
 import * as Tooltip from 'oxide-components/components/tooltip/Tooltip';
 import * as Bem from 'oxide-components/utils/Bem';
-import { createRef } from 'react';
+import { createRef, useState, type FC } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
@@ -70,6 +70,102 @@ describe('browser.TooltipTest', () => {
 
       await userEvent.unhover(getByText('Hover me'));
       expect(childOnMouseLeave).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('TINY-14072: showCondition prop', () => {
+    const tooltipSelector = Bem.blockSelector('tox-tooltip');
+
+    it('should render Content by default (showCondition defaults to "always")', async () => {
+      render(
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <div style={{ width: '200px', overflow: 'hidden', whiteSpace: 'nowrap' }}>Short</div>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
+    });
+
+    it('should not mount Content when showCondition is "overflow" and trigger does not overflow', async () => {
+      render(
+        <Tooltip.Root showCondition='overflow'>
+          <Tooltip.Trigger>
+            <div style={{ width: '200px', overflow: 'hidden', whiteSpace: 'nowrap' }}>Short</div>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).toBeNull();
+    });
+
+    it('should mount Content when showCondition is "overflow" and trigger overflows', async () => {
+      render(
+        <Tooltip.Root showCondition='overflow'>
+          <Tooltip.Trigger>
+            <div style={{ width: '50px', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+              This text is much longer than the trigger width
+            </div>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
+    });
+  });
+
+  describe('TINY-14378: Reacts to changes in the Trigger children', () => {
+    const tooltipSelector = Bem.blockSelector('tox-tooltip');
+
+    const ReactiveHarness: FC<{ initialText: string; nextText: string }> = ({ initialText, nextText }) => {
+      const [ text, setText ] = useState(initialText);
+      return (
+        <>
+          <button data-testid='swap' onClick={() => setText(nextText)}>swap</button>
+          <Tooltip.Root showCondition='overflow'>
+            <Tooltip.Trigger>
+              <div style={{ width: '50px', overflow: 'hidden', whiteSpace: 'nowrap' }}>{text}</div>
+            </Tooltip.Trigger>
+            <Tooltip.Content text='Tooltip' />
+          </Tooltip.Root>
+        </>
+      );
+    };
+
+    it('unmounts Content when trigger text shrinks from overflowing to fitting', async () => {
+      const { getByTestId } = render(
+        <ReactiveHarness initialText='This text is much longer than the trigger width' nextText='Hi' />,
+        { wrapper }
+      );
+
+      // Popover is mounted while the trigger overflows.
+      await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
+
+      // Shrink the text; the MutationObserver should fire and unmount the popover.
+      await userEvent.click(getByTestId('swap'));
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).toBeNull();
+    });
+
+    it('mounts Content when trigger text grows from fitting to overflowing', async () => {
+      const { getByTestId } = render(
+        <ReactiveHarness initialText='Hi' nextText='This text is much longer than the trigger width' />,
+        { wrapper }
+      );
+
+      // Initially not overflowing — popover is not in the DOM.
+      await expect.poll(() => document.querySelector(tooltipSelector)).toBeNull();
+
+      await userEvent.click(getByTestId('swap'));
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-14072, TINY-14378

Description of Changes:

- Renamed `shouldRenderComponents`/`setRenderComponents` to `canShow`/`setCanShow` in the tooltip context for clearer intent
- Replaced the global `window` resize event listener with a `ResizeObserver` that targets the trigger element and its direct children, providing more precise and efficient overflow detection
- Added a `MutationObserver` on the trigger so that changes to child text or DOM structure (e.g. text growing or shrinking) are detected and `canShow` is updated reactively without requiring a window resize
- Extracted overflow detection into a standalone `isOverflowingDeep` helper that checks both the trigger root and its children
- The trigger element now always receives mouse event handlers and anchor name styling regardless of `canShow` state; only the `Content` popover is conditionally rendered based on `canShow`
- `setCanShow` guards against redundant state updates and clears `isOpen` when transitioning to `canShow: false` to avoid stale open state
- `showCondition` defaults to `'always'` at the `Root` level, and `canShow` is initialised to `true` immediately when `showCondition === 'always'` rather than waiting for a layout effect
- Added browser tests covering: default `showCondition` behaviour, non-overflowing and overflowing triggers under `showCondition="overflow"`, and dynamic content changes that cause the tooltip to mount or unmount reactively

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tooltip component now uses DOM-based overflow detection to determine visibility
  * Added support for conditional tooltip display based on content overflow state

* **Tests**
  * Expanded test coverage for overflow detection scenarios and dynamic content changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->