### PR TITLE
TINY-13333: Allow block formatting on parent when ce=false inline is selected

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13333-2026-05-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-13333-2026-05-19.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Block-level formatting now works on parent blocks when a contenteditable="false" inline element (such as an iframe) is selected.
+body: Block-level formatting did not work on parent blocks when a contenteditable="false" inline element (such as an iframe) was selected.
 time: 2026-05-19T09:35:09.378088+10:00
 custom:
     Issue: TINY-13333

--- a/.changes/unreleased/tinymce-TINY-13333-2026-05-19.yaml
+++ b/.changes/unreleased/tinymce-TINY-13333-2026-05-19.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Block-level formatting now works on parent blocks when a contenteditable="false" inline element (such as an iframe) is selected.
+time: 2026-05-19T09:35:09.378088+10:00
+custom:
+    Issue: TINY-13333

--- a/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/DOMUtils.ts
@@ -201,7 +201,7 @@ interface DOMUtils {
   dispatch: (target: Node | Window, name: string, evt?: {}) => EventUtils;
   getContentEditable: (node: Node) => string | null;
   getContentEditableParent: (node: Node) => string | null;
-  isEditable: (node: Node | null | undefined) => boolean;
+  isEditable: (node: Node | null | undefined) => node is HTMLElement;
   destroy: () => void;
   isChildOf: (node: Node, parent: Node) => boolean;
   dumpRng: (r: Range) => string;
@@ -1069,7 +1069,7 @@ const DOMUtils = (doc: Document, settings: Partial<DOMUtilsSettings> = {}): DOMU
     return state;
   };
 
-  const isEditable = (node: Node | null | undefined) => {
+  const isEditable = (node: Node | null | undefined): node is HTMLElement => {
     if (Type.isNonNullable(node)) {
       const scope = NodeType.isElement(node) ? node : node.parentElement;
       return Type.isNonNullable(scope) && NodeType.isHTMLElement(scope) && ContentEditable.isEditable(SugarElement.fromDom(scope));

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -295,7 +295,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
     applyNodeStyle(formatList, node);
     if (FormatUtils.isBlockFormat(format) && !dom.isBlock(targetNode)) {
       const parentBlock = dom.getParent(targetNode, dom.isBlock);
-      if (Type.isNonNullable(parentBlock) && dom.isEditable(parentBlock)) {
+      if (dom.isEditable(parentBlock)) {
         const wrapperElementName = format.block;
         if (parentBlock.nodeName.toLowerCase() === wrapperElementName.toLowerCase()) {
           ApplyElementFormat.setElementFormat(ed, parentBlock, format, vars, node);

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -293,6 +293,15 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
     // node variable is used by other functions above in the same scope so need to set it here
     node = targetNode;
     applyNodeStyle(formatList, node);
+    if (FormatUtils.isBlockFormat(format) && !dom.isBlock(targetNode)) {
+      const parentBlock = dom.getParent(targetNode, dom.isBlock);
+      if (Type.isNonNullable(parentBlock) && dom.isEditable(parentBlock)) {
+        const wrapperElementName = format.block;
+        if (parentBlock.nodeName.toLowerCase() === wrapperElementName.toLowerCase()) {
+          ApplyElementFormat.setElementFormat(ed, parentBlock, format, vars, node);
+        }
+      }
+    }
     Events.fireFormatApply(ed, name, node, vars);
     return;
   }

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -299,6 +299,9 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
         const wrapperElementName = format.block;
         if (parentBlock.nodeName.toLowerCase() === wrapperElementName.toLowerCase()) {
           ApplyElementFormat.setElementFormat(ed, parentBlock, format, vars, node);
+        } else if (!FormatUtils.isWrappingBlockFormat(format)) {
+          const elm = dom.rename(parentBlock, wrapperElementName);
+          ApplyElementFormat.setElementFormat(ed, elm, format, vars, node);
         }
       }
     }

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -809,6 +809,14 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
         editor.formatter.apply('wrapper');
         TinyAssertions.assertContent(editor, `<p class="wrapper"><span class="mce-preview-object mce-object-iframe" contenteditable="false" data-mce-object="iframe"><iframe src="https://www.youtube.com/embed/test"></iframe></span></p>`);
       });
+
+      it('TINY-13333: should change parent block tag when ce=false inline element is selected', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('h1');
+        TinyAssertions.assertContent(editor, `<h1>a<span contenteditable="false">CEF</span>b</h1>`);
+      });
     });
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -761,6 +761,54 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
         TinyAssertions.assertContent(editor, `<p style="text-align: right;">a<span contenteditable="false">C<span contenteditable="true">E</span>F</span>b</p>`);
         TinyAssertions.assertCursor(editor, [ 0, 1, 1, 0 ], 0);
       });
+
+      it('TINY-13333: should apply block format with class to parent when ce=false inline element is selected', () => {
+        const editor = hook.editor();
+        editor.formatter.register('wrapper', { block: 'p', classes: 'wrapper' });
+        editor.setContent(`<p>a<span contenteditable="false">iframe</span>b</p>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('wrapper');
+        TinyAssertions.assertContent(editor, `<p class="wrapper">a<span contenteditable="false">iframe</span>b</p>`);
+      });
+
+      it('TINY-13333: should apply block format with styles to parent when ce=false inline element is selected', () => {
+        const editor = hook.editor();
+        editor.formatter.register('highlight', { block: 'p', styles: { backgroundColor: 'yellow' }});
+        editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('highlight');
+        TinyAssertions.assertContent(editor, `<p style="background-color: yellow;">a<span contenteditable="false">CEF</span>b</p>`);
+      });
+
+      it('TINY-13333: should apply block format to different block types (h1, div, etc)', () => {
+        const editor = hook.editor();
+        editor.formatter.register('wrapper', { block: 'h1', classes: 'wrapper' });
+        editor.setContent(`<h1>a<span contenteditable="false">CEF</span>b</h1>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('wrapper');
+        TinyAssertions.assertContent(editor, `<h1 class="wrapper">a<span contenteditable="false">CEF</span>b</h1>`);
+      });
+
+      it('TINY-13333: should toggle block format when applied twice', () => {
+        const editor = hook.editor();
+        editor.formatter.register('wrapper', { block: 'p', classes: 'wrapper' });
+        editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('wrapper');
+        TinyAssertions.assertContent(editor, `<p class="wrapper">a<span contenteditable="false">CEF</span>b</p>`);
+        // Toggle it off
+        editor.formatter.remove('wrapper');
+        TinyAssertions.assertContent(editor, `<p>a<span contenteditable="false">CEF</span>b</p>`);
+      });
+
+      it('TINY-13333: should work with media plugin iframe wrapper', () => {
+        const editor = hook.editor();
+        editor.formatter.register('wrapper', { block: 'p', classes: 'wrapper' });
+        editor.setContent(`<p><span class="mce-preview-object mce-object-iframe" contenteditable="false" data-mce-object="iframe"><iframe src="https://www.youtube.com/embed/test"></iframe></span></p>`);
+        TinySelections.select(editor, 'span[data-mce-object="iframe"]', []);
+        editor.formatter.apply('wrapper');
+        TinyAssertions.assertContent(editor, `<p class="wrapper"><span class="mce-preview-object mce-object-iframe" contenteditable="false" data-mce-object="iframe"><iframe src="https://www.youtube.com/embed/test"></iframe></span></p>`);
+      });
     });
   });
 });


### PR DESCRIPTION
Related Ticket: [TINY-13333](https://ephocks.atlassian.net/browse/TINY-13333)

Description of Changes:
* When a `contenteditable="false"` inline element (like an iframe) is selected, block formats would fail because the formatter's early-return only handled selector formats.
* Now we detect this case and apply block formats to the nearest editable parent block instead.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): https://github.com/tinymce/tinymce/issues/10111


[TINY-13333]: https://ephocks.atlassian.net/browse/TINY-13333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Block-level formatting now correctly applies to the parent block when the selected inline element is non-editable (e.g., embedded iframes), including when destination block tags change, restoring expected formatting behavior across affected scenarios.
* **Tests**
  * Added browser tests covering non-editable inline selections, wrapper class and inline-style handling, toggling formats on/off, different destination block tags, and media-iframe wrapper cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->