### PR TITLE
TINY-14376: Add fallback to quickbars with 'position: line' if overflow

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14376-2026-05-18.yaml
+++ b/.changes/unreleased/tinymce-TINY-14376-2026-05-18.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Context toolbar with position 'line' was not repositioning to the opposite side when overflowing the viewport.
+time: 2026-05-18T16:16:12.869449+02:00
+custom:
+    Issue: TINY-14376

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
@@ -125,8 +125,8 @@ const getAnchorLayout = (editor: Editor, position: InlineContent.ContextPosition
     return {
       bubble: Bubble.nu(bubbleSize, 0, bubbleAlignments),
       layouts: {
-        onLtr: () => [ Layout.east ],
-        onRtl: () => [ Layout.west ]
+        onLtr: () => [ Layout.east, Layout.west ],
+        onRtl: () => [ Layout.west, Layout.east ]
       },
       overrides: anchorOverrides
     };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLinePositionTest.ts
@@ -6,7 +6,7 @@ import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
 
-describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLinePosition test', () => {
+describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLinePositionTest', () => {
   const rightSelector = '.tox-pop.tox-pop--left:not(.tox-pop--inset):not(.tox-pop--transition)';
   const leftSelector = '.tox-pop.tox-pop--right:not(.tox-pop--inset):not(.tox-pop--transition)';
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLinePositionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarLinePositionTest.ts
@@ -1,0 +1,65 @@
+import { UiFinder } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+import { SugarBody } from '@ephox/sugar';
+import { TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarLinePosition test', () => {
+  const rightSelector = '.tox-pop.tox-pop--left:not(.tox-pop--inset):not(.tox-pop--transition)';
+  const leftSelector = '.tox-pop.tox-pop--right:not(.tox-pop--inset):not(.tox-pop--transition)';
+
+  const setupHook = (directionality: 'ltr' | 'rtl') => TinyHooks.bddSetup<Editor>({
+    directionality,
+    height: 400,
+    base_url: '/project/tinymce/js/tinymce',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addButton('alpha', {
+        text: 'Alpha',
+        onAction: Fun.noop
+      });
+      ed.ui.registry.addContextToolbar('test-line-toolbar', {
+        predicate: (node) => node.nodeName.toLowerCase() === 'div',
+        items: 'alpha',
+        position: 'line'
+      });
+    }
+  }, [], true);
+
+  context('LTR', () => {
+    const ltrHook = setupHook('ltr');
+
+    it('TINY-14376: Line context toolbar uses east layout by default', async () => {
+      const editor = ltrHook.editor();
+      editor.setContent('<div style="height: 25px;"></div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear to the right of cursor', SugarBody.body(), rightSelector);
+    });
+
+    it('TINY-14376: Line context toolbar falls back to west layout when right-aligned content would cause overflow', async () => {
+      const editor = ltrHook.editor();
+      editor.setContent('<div style="height: 25px; text-align: right;"></div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear to the left of cursor', SugarBody.body(), leftSelector);
+    });
+  });
+
+  context('RTL', () => {
+    const rtlHook = setupHook('rtl');
+
+    it('TINY-14376: Line context toolbar uses west layout by default', async () => {
+      const editor = rtlHook.editor();
+      editor.setContent('<div style="height: 25px;"></div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear to the left of cursor', SugarBody.body(), leftSelector);
+    });
+
+    it('TINY-14376: Line context toolbar falls back to east layout when left-aligned content would cause overflow', async () => {
+      const editor = rtlHook.editor();
+      editor.setContent('<div style="height: 25px; text-align: left;"></div>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 0);
+      await UiFinder.pWaitForVisible('Waiting for toolbar to appear to the right of cursor', SugarBody.body(), rightSelector);
+    });
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-14376

Description of Changes:

- Fixed context toolbar with `position: 'line'` not repositioning to the opposite side when the toolbar would overflow the viewport. In LTR mode, the toolbar now falls back to the west (left) layout if the east (right) layout overflows, and vice versa in RTL mode.
- The idea is to flip the quickbar to the other side, when there is not enough space to show the full quickbar. The disadvantage of this could be that the quickbar can hide some content underneath as you're typing. 

**Before:**

<img width="422" height="172" alt="image" src="https://github.com/user-attachments/assets/2c412c71-0361-4004-848f-af3ed09f8ef7" />

<img width="456" height="184" alt="image" src="https://github.com/user-attachments/assets/3c6646ed-a944-4f4f-9b72-8867f708f986" />

**After:**

<img width="431" height="232" alt="image" src="https://github.com/user-attachments/assets/d7fd2d39-2f88-42dd-91cc-36cf56b0a91e" />

<img width="453" height="236" alt="image" src="https://github.com/user-attachments/assets/7e084bd9-52a6-4a3b-8546-9f430014d85a" />


Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context toolbar with "line" positioning now flips to the opposite side when it would overflow, preserving visibility in both LTR and RTL.

* **Tests**
  * Added browser UI tests validating toolbar placement and fallback behavior in LTR and RTL.

* **Chores**
  * Added an unreleased changelog entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->