### PR TITLE
TINY-14255: fix regression

### DIFF
--- a/modules/tinymce/src/core/main/ts/undo/Setup.ts
+++ b/modules/tinymce/src/core/main/ts/undo/Setup.ts
@@ -119,6 +119,11 @@ export const registerEvents = (editor: Editor, undoManager: UndoManager, locks: 
       isFirstTypedCharacter.set(true);
       return;
     }
+
+    const hasMetaOrCtrlModifier = Env.os.isMacOS() ? e.metaKey : e.ctrlKey && !e.altKey;
+    if (hasMetaOrCtrlModifier && (e.key === 'Backspace' || e.key === 'Delete')) {
+      undoManager.beforeChange();
+    }
   });
 
   editor.on('mousedown', (e) => {

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -82,22 +82,26 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
 
   const simulateRealBackspaceViaKeyboardWithCtrl = (editor: Editor) => {
     const isMac = platform.os.isMacOS();
+    const modKeyCode = isMac ? Keys.meta() : Keys.control();
     const modifier = isMac ? { meta: true, metaKey: true } : { ctrl: true, ctrlKey: true };
     TinyContentActions.keydown(editor, Keys.backspace(), modifier);
     // The browser would now delete "def" itself. Reproduce that DOM mutation:
     (editor.getBody().firstChild as HTMLElement).textContent = 'abc ';
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
     TinyContentActions.keyup(editor, Keys.backspace(), modifier);
+    TinyContentActions.keyup(editor, modKeyCode, {});
   };
 
   const simulateRealDeleteViaKeyboardWithCtrl = (editor: Editor) => {
     const isMac = platform.os.isMacOS();
+    const modKeyCode = isMac ? Keys.meta() : Keys.control();
     const modifier = isMac ? { meta: true, metaKey: true } : { ctrl: true, ctrlKey: true };
     TinyContentActions.keydown(editor, Keys.delete(), modifier);
     // The browser would now delete "def" itself. Reproduce that DOM mutation:
     (editor.getBody().firstChild as HTMLElement).textContent = 'abc ';
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
     TinyContentActions.keyup(editor, Keys.delete(), modifier);
+    TinyContentActions.keyup(editor, modKeyCode, {});
   };
 
   // this is refered to the case in `TINY-8910`

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -81,19 +81,23 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
   });
 
   const simulateRealBackspaceViaKeyboardWithCtrl = (editor: Editor) => {
-    TinyContentActions.keydown(editor, Keys.backspace(), { ctrl: true, ctrlKey: true });
+    const isMac = platform.os.isMacOS();
+    const modifier = isMac ? { meta: true, metaKey: true } : { ctrl: true, ctrlKey: true };
+    TinyContentActions.keydown(editor, Keys.backspace(), modifier);
     // The browser would now delete "def" itself. Reproduce that DOM mutation:
     (editor.getBody().firstChild as HTMLElement).textContent = 'abc ';
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
-    TinyContentActions.keyup(editor, Keys.backspace(), { ctrl: true, ctrlKey: true });
+    TinyContentActions.keyup(editor, Keys.backspace(), modifier);
   };
 
   const simulateRealDeleteViaKeyboardWithCtrl = (editor: Editor) => {
-    TinyContentActions.keydown(editor, Keys.delete(), { ctrl: true, ctrlKey: true });
+    const isMac = platform.os.isMacOS();
+    const modifier = isMac ? { meta: true, metaKey: true } : { ctrl: true, ctrlKey: true };
+    TinyContentActions.keydown(editor, Keys.delete(), modifier);
     // The browser would now delete "def" itself. Reproduce that DOM mutation:
     (editor.getBody().firstChild as HTMLElement).textContent = 'abc ';
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
-    TinyContentActions.keyup(editor, Keys.delete(), { ctrl: true, ctrlKey: true });
+    TinyContentActions.keyup(editor, Keys.delete(), modifier);
   };
 
   // this is refered to the case in `TINY-8910`

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -104,37 +104,37 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
   it('TINY-14255: undo after ctrl+backspace/delete should put the caret in the correct position', async () => {
     // backspace
     const editor = hook.editor();
-    editor.resetContent('<p>abc def</p>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 'abc def'.length);
+    editor.resetContent('<p>abc 001</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc 001'.length);
     simulateRealBackspaceViaKeyboardWithCtrl(editor);
     TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     editor.execCommand('Undo');
-    TinyAssertions.assertContent(editor, '<p>abc def</p>');
-    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc def'.length);
+    TinyAssertions.assertContent(editor, '<p>abc 001</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc 001'.length);
 
-    editor.resetContent('<p>abc def</p>');
-    TinySelections.setCursor(editor, [ 0, 0 ], 'abc def'.length);
+    editor.resetContent('<p>abc 002</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc 002'.length);
     simulateRealBackspaceViaKeyboardWithCtrl(editor);
     TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     undoKeystrokeRealistic(editor);
-    TinyAssertions.assertContent(editor, '<p>abc def</p>');
-    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc def'.length);
+    TinyAssertions.assertContent(editor, '<p>abc 002</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc 002'.length);
 
     // delete
-    editor.resetContent('<p>abc def</p>');
+    editor.resetContent('<p>abc 003</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
     simulateRealDeleteViaKeyboardWithCtrl(editor);
     TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     editor.execCommand('Undo');
-    TinyAssertions.assertContent(editor, '<p>abc def</p>');
+    TinyAssertions.assertContent(editor, '<p>abc 003</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc '.length);
 
-    editor.resetContent('<p>abc def</p>');
+    editor.resetContent('<p>abc 004</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
     simulateRealDeleteViaKeyboardWithCtrl(editor);
     TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     undoKeystrokeRealistic(editor);
-    TinyAssertions.assertContent(editor, '<p>abc def</p>');
+    TinyAssertions.assertContent(editor, '<p>abc 004</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc '.length);
   });
 });

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -79,4 +79,58 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
     TinyAssertions.assertContent(editor, '<p>abc</p>');
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 3);
   });
+
+  const simulateRealBackspaceViaKeyboardWithCtrl = (editor: Editor) => {
+    TinyContentActions.keydown(editor, Keys.backspace(), { ctrl: true, ctrlKey: true });
+    // The browser would now delete "def" itself. Reproduce that DOM mutation:
+    (editor.getBody().firstChild as HTMLElement).textContent = 'abc ';
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
+    TinyContentActions.keyup(editor, Keys.backspace(), { ctrl: true, ctrlKey: true });
+  };
+
+  const simulateRealDeleteViaKeyboardWithCtrl = (editor: Editor) => {
+    TinyContentActions.keydown(editor, Keys.delete(), { ctrl: true, ctrlKey: true });
+    // The browser would now delete "def" itself. Reproduce that DOM mutation:
+    (editor.getBody().firstChild as HTMLElement).textContent = 'abc ';
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
+    TinyContentActions.keyup(editor, Keys.delete(), { ctrl: true, ctrlKey: true });
+  };
+
+  // this is refered to the case in `TINY-8910`
+  it('TINY-14255: undo after ctrl+backspace/delete should put the caret in the correct position', async () => {
+    // backspace
+    const editor = hook.editor();
+    editor.resetContent('<p>abc def</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc def'.length);
+    simulateRealBackspaceViaKeyboardWithCtrl(editor);
+    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    editor.execCommand('Undo');
+    TinyAssertions.assertContent(editor, '<p>abc def</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc def'.length);
+
+    editor.resetContent('<p>abc def</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc def'.length);
+    simulateRealBackspaceViaKeyboardWithCtrl(editor);
+    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    undoKeystrokeRealistic(editor);
+    TinyAssertions.assertContent(editor, '<p>abc def</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc def'.length);
+
+    // delete
+    editor.resetContent('<p>abc def</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
+    simulateRealDeleteViaKeyboardWithCtrl(editor);
+    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    editor.execCommand('Undo');
+    TinyAssertions.assertContent(editor, '<p>abc def</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc '.length);
+
+    editor.resetContent('<p>abc def</p>');
+    TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
+    simulateRealDeleteViaKeyboardWithCtrl(editor);
+    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    undoKeystrokeRealistic(editor);
+    TinyAssertions.assertContent(editor, '<p>abc def</p>');
+    TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc '.length);
+  });
 });

--- a/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/undo/UndoKeyboardShortcutsTest.ts
@@ -107,7 +107,7 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
     editor.resetContent('<p>abc def</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc def'.length);
     simulateRealBackspaceViaKeyboardWithCtrl(editor);
-    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     editor.execCommand('Undo');
     TinyAssertions.assertContent(editor, '<p>abc def</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc def'.length);
@@ -115,7 +115,7 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
     editor.resetContent('<p>abc def</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc def'.length);
     simulateRealBackspaceViaKeyboardWithCtrl(editor);
-    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     undoKeystrokeRealistic(editor);
     TinyAssertions.assertContent(editor, '<p>abc def</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc def'.length);
@@ -124,7 +124,7 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
     editor.resetContent('<p>abc def</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
     simulateRealDeleteViaKeyboardWithCtrl(editor);
-    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     editor.execCommand('Undo');
     TinyAssertions.assertContent(editor, '<p>abc def</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc '.length);
@@ -132,7 +132,7 @@ describe('browser.tinymce.core.undo.UndoKeyboardShortcutTest', () => {
     editor.resetContent('<p>abc def</p>');
     TinySelections.setCursor(editor, [ 0, 0 ], 'abc '.length);
     simulateRealDeleteViaKeyboardWithCtrl(editor);
-    TinyAssertions.assertContent(editor, '<p>abc </p>', { format: 'html' });
+    TinyAssertions.assertContent(editor, 'abc ', { format: 'text' });
     undoKeystrokeRealistic(editor);
     TinyAssertions.assertContent(editor, '<p>abc def</p>');
     TinyAssertions.assertCursor(editor, [ 0, 0 ], 'abc '.length);


### PR DESCRIPTION
Related Ticket: TINY-14255

Description of Changes:
the [previous PR](https://github.com/tinymce/tinymce/pull/11110) created a regression for the case in `TINY-8910`, this fixes it 

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl/Meta+Backspace and Ctrl/Meta+Delete now trigger undo preparation so Undo correctly restores content and the caret position.

* **Tests**
  * Added OS-aware keyboard simulation helpers and an async test that verifies Undo restores both content and cursor when invoked via the Undo command or Ctrl/Meta+Z.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->