### PR TITLE
TINY-14430: Updated dompurify to 3.4.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -362,7 +362,7 @@
         "@tinymce/oxide-icons-default": "^4.0.0",
         "@tinymce/persona": "^1.0.0",
         "@types/prismjs": "^1.16.6",
-        "dompurify": "3.3.2",
+        "dompurify": "3.4.5",
         "prismjs": "^1.27.0",
       },
       "devDependencies": {
@@ -1860,7 +1860,7 @@
 
     "domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
 
-    "dompurify": ["dompurify@3.3.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ=="],
+    "dompurify": ["dompurify@3.4.5", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA=="],
 
     "domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -36,7 +36,7 @@
     "@tinymce/oxide-icons-default": "^4.0.0",
     "@tinymce/persona": "^1.0.0",
     "@types/prismjs": "^1.16.6",
-    "dompurify": "3.3.2",
+    "dompurify": "3.4.5",
     "prismjs": "^1.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related Ticket: TINY-14430

Description of Changes:
* Bumps the dompurify version to 3.4.5 in the bun lock since the `release/8` is still using yarn we need two PRs or some nasty conflict resolution later.

Pre-checks:
* [x] ~~Changelog entry added~~ changelog is in the 8.6 hotfix PR
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies in the tinymce module to latest compatible versions for improved stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->