### PR TITLE
TINY-14032: Do not show tooltip component when showCondition overflow on Safari

### DIFF
--- a/modules/oxide-components/package.json
+++ b/modules/oxide-components/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@ephox/katamari": "^11.0.0",
+    "@ephox/sand": "^8.0.0",
     "@ephox/sugar": "^11.0.0"
   }
 }

--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
   type PropsWithChildren, type ReactNode
 } from 'react';
 
+import { isSafari } from '../../utils/Browser';
 import { DropdownContext } from '../dropdown/internals/Context';
 
 import { TooltipContext, useTooltip } from './internals/Context';
@@ -32,6 +33,11 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
   useLayoutEffect(() => {
     if (showCondition === 'always') {
       setCanShow(true);
+      return;
+    } else if (showCondition === 'overflow' && isSafari()) {
+      // Safari draws its own native tooltip when text is ellipsised; suppress
+      // the custom one here so the user doesn't see two tooltips stacked.
+      setCanShow(false);
       return;
     }
 

--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -8,7 +8,7 @@ import {
   type PropsWithChildren, type ReactNode
 } from 'react';
 
-import { isSafari } from '../../utils/Browser';
+import * as Browser from '../../utils/Browser';
 import { DropdownContext } from '../dropdown/internals/Context';
 
 import { TooltipContext, useTooltip } from './internals/Context';
@@ -34,7 +34,7 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
     if (showCondition === 'always') {
       setCanShow(true);
       return;
-    } else if (showCondition === 'overflow' && isSafari()) {
+    } else if (showCondition === 'overflow' && Browser.isSafari()) {
       // Safari draws its own native tooltip when text is ellipsised; suppress
       // the custom one here so the user doesn't see two tooltips stacked.
       setCanShow(false);

--- a/modules/oxide-components/src/main/ts/utils/Browser.ts
+++ b/modules/oxide-components/src/main/ts/utils/Browser.ts
@@ -1,0 +1,3 @@
+import { PlatformDetection } from '@ephox/sand';
+
+export const isSafari = (): boolean => PlatformDetection.detect().browser.isSafari();

--- a/modules/oxide-components/src/test/ts/browser/components/Tooltip.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Tooltip.spec.tsx
@@ -1,9 +1,19 @@
+import { Fun } from '@ephox/katamari';
 import * as Tooltip from 'oxide-components/components/tooltip/Tooltip';
 import * as Bem from 'oxide-components/utils/Bem';
+import * as Browser from 'oxide-components/utils/Browser';
 import { createRef, useState, type FC } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
+
+vi.mock(import('oxide-components/utils/Browser'), () => ({
+  isSafari: vi.fn(Fun.never)
+}));
+
+beforeEach(() => {
+  vi.mocked(Browser.isSafari).mockReturnValue(false);
+});
 
 describe('browser.TooltipTest', () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => {
@@ -164,6 +174,62 @@ describe('browser.TooltipTest', () => {
       await expect.poll(() => document.querySelector(tooltipSelector)).toBeNull();
 
       await userEvent.click(getByTestId('swap'));
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
+    });
+  });
+
+  describe('TINY-14032: showCondition overflow gate', () => {
+    const tooltipSelector = Bem.blockSelector('tox-tooltip');
+
+    it('should not mount Content on Safari when showCondition is "overflow" and trigger overflows', async () => {
+      vi.mocked(Browser.isSafari).mockReturnValue(true);
+
+      render(
+        <Tooltip.Root showCondition='overflow'>
+          <Tooltip.Trigger>
+            <div style={{ width: '50px', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+              This text is much longer than the trigger width
+            </div>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      expect(document.querySelector(tooltipSelector)).toBeNull();
+    });
+
+    it('should mount Content on non-Safari when showCondition is "overflow" and trigger overflows', async () => {
+      vi.mocked(Browser.isSafari).mockReturnValue(false);
+
+      render(
+        <Tooltip.Root showCondition='overflow'>
+          <Tooltip.Trigger>
+            <div style={{ width: '50px', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+              This text is much longer than the trigger width
+            </div>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
+
+      await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
+    });
+
+    it('should mount Content on Safari when showCondition is "always"', async () => {
+      vi.mocked(Browser.isSafari).mockReturnValue(true);
+
+      render(
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <div>Short</div>
+          </Tooltip.Trigger>
+          <Tooltip.Content text='Tooltip' />
+        </Tooltip.Root>,
+        { wrapper }
+      );
 
       await expect.poll(() => document.querySelector(tooltipSelector)).not.toBeNull();
     });

--- a/modules/oxide-components/src/test/ts/visual.spec.ts
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts
@@ -60,9 +60,14 @@ for (const story of dropdownStories) {
 }
 
 // This component has custom visual tests as the trigger button needs to be hovered over before the screenshot
+
 const hoveroverStories = Object.values(storybook.entries).filter(
   (e) => e.type === 'story' && e.tags.includes('hover-visual-testing')
 );
+
+// The React Tooltip component delays rendering by ~300 ms after hover. We wait up to this
+// timeout for the tooltip to appear before taking the screenshot.
+const TOOLTIP_APPEARANCE_TIMEOUT_MS = 1_000;
 
 for (const story of hoveroverStories) {
   test(`${story.title} ${story.name} should not have visual hover regressions`, async ({
@@ -70,7 +75,12 @@ for (const story of hoveroverStories) {
   }, workerInfo) => {
     await visualTest(story, page, workerInfo, async () => {
       await page.getByTitle('hover').hover();
-      await expect(page.getByText('Message')).toBeVisible();
+
+      // If the tooltip is not present after the timeout (e.g. on Safari when the tooltip's showCondition detects overflow
+      // and suppresses rendering), we continue the test anyway — the screenshot still captures
+      // the correct visual state without the tooltip.
+      // eslint-disable-next-line @tinymce/prefer-fun
+      await page.getByText('Message').waitFor({ state: 'visible', timeout: TOOLTIP_APPEARANCE_TIMEOUT_MS }).catch(() => {});
     });
   });
 }

--- a/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-tooltip--overflowing-tooltip-desktop-safari-linux-desktop-safari-linux.png
+++ b/modules/oxide-components/src/test/ts/visual.spec.ts-snapshots/components-tooltip--overflowing-tooltip-desktop-safari-linux-desktop-safari-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:661d97bbd2d68d7b98cc05832a33a964e90eb8c5f3e8dd62c8821d0936c41a24
-size 10190
+oid sha256:c634003f790efa304bb67dc5e85201c567c02b5e58b403e70e0473b3b0016429
+size 8238


### PR DESCRIPTION
Related Ticket: TINY-14032

Description of Changes:

- Safari natively renders its own tooltip when text is ellipsised, causing a duplicate tooltip to appear alongside the custom one. When `showCondition` is `"overflow"` and the browser is Safari, the custom tooltip is now suppressed to prevent this double-tooltip issue.
- Added a `Browser` utility module using `@ephox/sand`'s `PlatformDetection` to expose an `isSafari` helper, and added `@ephox/sand` as a dependency.



Pre-checks:

~~- [ ] Changelog entry added~~ Changelog entry added where Tooltip component is used
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevent duplicate/stacked tooltips in Safari when tooltip is configured to appear only on overflow; default tooltip behavior unchanged.
- **Tests**
  - Added and updated tests covering tooltip behavior on Safari vs other browsers and adjusted visual hover tests to tolerate suppressed tooltip rendering.
- **Chores**
  - Declared an additional runtime dependency for the components package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->