### PR TITLE
TINY-14425: new `Arr.findLast`

### DIFF
--- a/.changes/unreleased/katamari-TINY-14425-2026-05-27.yaml
+++ b/.changes/unreleased/katamari-TINY-14425-2026-05-27.yaml
@@ -1,0 +1,6 @@
+project: katamari
+kind: Added
+body: New `Arr` function `findLast`.
+time: 2026-05-27T08:11:36.408396476+02:00
+custom:
+    Issue: TINY-14425

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -196,15 +196,21 @@ export const findIndex = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optiona
   return Optional.none();
 };
 
-export const findLastIndex = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<number> => {
+const filndLastByPredicate = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<{ v: T; i: number }> => {
   for (let i = arr.length - 1; i >= 0; i--) {
     if (pred(arr[i], i)) {
-      return Optional.some(i);
+      return Optional.some({ v: arr[i], i });
     }
   }
 
   return Optional.none();
 };
+
+export const findLast = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<T> =>
+  filndLastByPredicate(arr, pred).map((r) => r.v);
+
+export const findLastIndex = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<number> =>
+  filndLastByPredicate(arr, pred).map((r) => r.i);
 
 export const flatten = <T>(xs: ArrayLike<T[]>): T[] => {
   // Note, this is possible because push supports multiple arguments:

--- a/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
+++ b/modules/katamari/src/main/ts/ephox/katamari/api/Arr.ts
@@ -196,7 +196,7 @@ export const findIndex = <T>(xs: ArrayLike<T>, pred: ArrayPredicate<T>): Optiona
   return Optional.none();
 };
 
-const filndLastByPredicate = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<{ v: T; i: number }> => {
+const findLastByPredicate = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<{ v: T; i: number }> => {
   for (let i = arr.length - 1; i >= 0; i--) {
     if (pred(arr[i], i)) {
       return Optional.some({ v: arr[i], i });
@@ -207,10 +207,10 @@ const filndLastByPredicate = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Op
 };
 
 export const findLast = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<T> =>
-  filndLastByPredicate(arr, pred).map((r) => r.v);
+  findLastByPredicate(arr, pred).map((r) => r.v);
 
 export const findLastIndex = <T>(arr: ArrayLike<T>, pred: ArrayPredicate<T>): Optional<number> =>
-  filndLastByPredicate(arr, pred).map((r) => r.i);
+  findLastByPredicate(arr, pred).map((r) => r.i);
 
 export const flatten = <T>(xs: ArrayLike<T[]>): T[] => {
   // Note, this is possible because push supports multiple arguments:

--- a/modules/katamari/src/test/ts/atomic/api/arr/FindLastTest.ts
+++ b/modules/katamari/src/test/ts/atomic/api/arr/FindLastTest.ts
@@ -1,0 +1,33 @@
+import { describe, it } from '@ephox/bedrock-client';
+
+import * as Arr from 'ephox/katamari/api/Arr';
+import { assertNone, assertSome } from 'ephox/katamari/test/AssertOptional';
+
+describe('atomic.katamari.api.arr.FindLastTest', () => {
+  it('TINY-14425: unit tests', () => {
+    const checkNoneHelper = (input: ArrayLike<number>, pred: (x: number) => boolean): void => {
+      assertNone(Arr.findLast(input, pred));
+    };
+
+    const checkNone = (input: number[], pred: (x: number) => boolean): void => {
+      checkNoneHelper(input, pred);
+      checkNoneHelper(Object.freeze(input.slice()), pred);
+    };
+
+    const checkHelper = (expected: number, input: ArrayLike<number>, pred: (x: number) => boolean): void => {
+      assertSome(Arr.findLast(input, pred), expected);
+    };
+
+    const check = (expected: number, input: number[], pred: (x: number) => boolean): void => {
+      checkHelper(expected, input, pred);
+      checkHelper(expected, Object.freeze(input), pred);
+    };
+
+    checkNone([], (x) => x > 0);
+    checkNone([ -1 ], (x) => x > 0);
+    check(1, [ 1 ], (x) => x > 0);
+    check(3, [ 4, 2, 10, 41, 3 ], (x) => x > 2);
+    check(100, [ 4, 2, 10, 41, 3, 100 ], (x) => x > 80);
+    checkNone([ 4, 2, 10, 412, 3 ], (x) => x === 41);
+  });
+});


### PR DESCRIPTION
Related Ticket: TINY-14425

Description of Changes:
I created one function that returns both to not duplicate the logic, but since is just a cycle if you want I can duplicate it

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new array utility to find the last element matching a given predicate, returning the matching value when found or none when not.

* **Tests**
  * Added comprehensive tests covering empty arrays, no-match scenarios, single and multiple matches, and behavior with immutable (frozen) arrays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->