### PR TITLE
TINY-14448: Make use prompt text white-space: pre-wrap

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -106,6 +106,7 @@
     max-width: 80%;
     align-self: flex-end;
     color: var(--tox-private-text-color, @text-color);
+    white-space: pre-wrap;
 
     &:focus-visible:not(:disabled) {
        outline: 2px solid var(--tox-private-color-tint, @color-tint);


### PR DESCRIPTION
Related Ticket: TINY-14448

Description of Changes:
* Switched chat bubble rendering to pre-wrap so linebreaks and spaces are retained in chat threads.

Pre-checks:
* [x] ~~Changelog entry added~~ in the premium PR
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text formatting in AI chat prompts to properly preserve whitespace and line breaks, ensuring user input displays correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->