### PR TITLE
TINY-13902: Add Menu.Divider component to oxide-components

### DIFF
--- a/modules/oxide-components/src/main/ts/components/menu/Menu.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.stories.tsx
@@ -94,6 +94,7 @@ const menu: JSX.Element = (
     >
       <span>Menu <span style={{ textDecoration: 'underline' }}>item  2</span></span>
     </Menu.ToggleItem>
+    <Menu.Divider />
     <Menu.SubmenuItem
       key={Id.generate('menu-item')}
       icon={'item'}
@@ -119,6 +120,7 @@ const menu: JSX.Element = (
           >
             {'Nested menu item 2'}
           </Menu.ToggleItem>
+          <Menu.Divider />
           <Menu.SubmenuItem
             key={Id.generate('menu-item')}
             icon={'item'}

--- a/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/Menu.tsx
@@ -5,6 +5,7 @@ import { forwardRef, useEffect, useRef, type MutableRefObject, type PropsWithChi
 import * as KeyboardNavigationHooks from '../../keynav/KeyboardNavigationHooks';
 import * as Bem from '../../utils/Bem';
 
+import { Divider } from './components/Divider';
 import { Item } from './components/Item';
 import { SubmenuItem } from './components/SubmenuItem';
 import { ToggleItem } from './components/ToggleItem';
@@ -54,5 +55,6 @@ export {
   Item,
   Root,
   SubmenuItem,
-  ToggleItem
+  ToggleItem,
+  Divider
 };

--- a/modules/oxide-components/src/main/ts/components/menu/components/Divider.tsx
+++ b/modules/oxide-components/src/main/ts/components/menu/components/Divider.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent } from 'react';
+
+import * as Bem from '../../../utils/Bem';
+
+export const Divider: FunctionComponent = () => {
+  return (
+    <div
+      role='separator'
+      className={Bem.element('tox-collection', 'item-separator')}
+    />
+  );
+};

--- a/modules/oxide-components/src/test/ts/browser/components/MenuDivider.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/MenuDivider.spec.tsx
@@ -1,0 +1,76 @@
+import { Fun } from '@ephox/katamari';
+import * as Menu from 'oxide-components/components/menu/Menu';
+import { UniverseProvider } from 'oxide-components/contexts/UniverseContext/UniverseProvider';
+import * as Bem from 'oxide-components/utils/Bem';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+const mockUniverse = {
+  getIcon: Fun.constant(''),
+};
+
+describe('browser.MenuDividerTest', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <div className={Bem.block('tox')}>
+        {children}
+      </div>
+    );
+  };
+
+  it('Should render with role="separator"', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.Divider />
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { container } = render(<TestComponent />, { wrapper });
+    const separator = container.querySelector('[role="separator"]') as HTMLElement;
+
+    expect(separator).toBeDefined();
+    expect(separator.getAttribute('role')).toBe('separator');
+  });
+
+  it('Should render with correct CSS class', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.Divider />
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { container } = render(<TestComponent />, { wrapper });
+    const separator = container.querySelector('[role="separator"]') as HTMLElement;
+
+    expect(separator.className).toBe('tox-collection__item-separator');
+  });
+
+  it('Should render between menu items', async () => {
+    const TestComponent = () => {
+      return (
+        <UniverseProvider resources={mockUniverse}>
+          <Menu.Root>
+            <Menu.Item onAction={Fun.noop}>Item 1</Menu.Item>
+            <Menu.Divider />
+            <Menu.Item onAction={Fun.noop}>Item 2</Menu.Item>
+          </Menu.Root>
+        </UniverseProvider>
+      );
+    };
+
+    const { container } = render(<TestComponent />, { wrapper });
+    const separator = container.querySelector('[role="separator"]') as HTMLElement;
+    const menuItems = container.querySelectorAll('[role="menuitem"]');
+
+    expect(separator).toBeDefined();
+    expect(menuItems.length).toBe(2);
+  });
+});

--- a/modules/oxide-components/src/test/ts/browser/components/MenuDivider.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/MenuDivider.spec.tsx
@@ -32,7 +32,7 @@ describe('browser.MenuDividerTest', () => {
     const { container } = render(<TestComponent />, { wrapper });
     const separator = container.querySelector('[role="separator"]') as HTMLElement;
 
-    expect(separator).toBeDefined();
+    expect(separator).not.toBeNull();
     expect(separator.getAttribute('role')).toBe('separator');
   });
 
@@ -50,6 +50,7 @@ describe('browser.MenuDividerTest', () => {
     const { container } = render(<TestComponent />, { wrapper });
     const separator = container.querySelector('[role="separator"]') as HTMLElement;
 
+    expect(separator).not.toBeNull();
     expect(separator.className).toBe('tox-collection__item-separator');
   });
 
@@ -70,7 +71,7 @@ describe('browser.MenuDividerTest', () => {
     const separator = container.querySelector('[role="separator"]') as HTMLElement;
     const menuItems = container.querySelectorAll('[role="menuitem"]');
 
-    expect(separator).toBeDefined();
+    expect(separator).not.toBeNull();
     expect(menuItems.length).toBe(2);
   });
 });

--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -70,12 +70,6 @@
       padding-left: var(--tox-private-pad-md, @pad-md);
       padding-right: var(--tox-private-pad-md, @pad-md);
     }
-
-    .tox-ai__review-menu-separator {
-      border-bottom: 1px solid @collection-item-separator-color;
-      height: 0;
-      margin: @collection-item-separator-margin-y 0;
-    }
   }
 
   .tox-ai__user-prompt {

--- a/modules/oxide/src/less/theme/components/collection/collection.less
+++ b/modules/oxide/src/less/theme/components/collection/collection.less
@@ -293,6 +293,12 @@
     word-break: break-all;
   }
 
+  .tox-collection__item-separator {
+    border-bottom: 1px solid @collection-item-separator-color;
+    height: 0;
+    margin: @collection-item-separator-margin-y 0;
+  }
+
   .tox-collection__item-accessory {
     color: currentColor;
     display: inline-block;


### PR DESCRIPTION
Related Ticket: [TINY-13902](https://ephocks.atlassian.net/browse/TINY-13902)

Description of Changes:
* Added `Menu.Divider` component to provide a standard way to visually separate groups of menu items in the `Menu` compound component.
* Enables replacing custom separator divs with a reusable, accessible component that follows the existing Menu API pattern

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINY-13902]: https://ephocks.atlassian.net/browse/TINY-13902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visual menu divider component to separate menu items and included it in examples.

* **Tests**
  * Added browser tests verifying divider rendering, accessibility (role="separator"), CSS class, and correct placement between items.

* **Style**
  * Added theme styles for the new menu divider (appearance and spacing) and removed an older review-menu separator rule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->