### PR TITLE
TINY-14370: fix multiple TDs indentation

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14370-2026-05-27.yaml
+++ b/.changes/unreleased/tinymce-TINY-14370-2026-05-27.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Selecting multiple TDs and applying indentation didn't apply it to all the selected TDs.
+body: Selecting multiple table cells and applying indentation did not apply to the entire selection.
 time: 2026-05-27T16:03:12.522069852+02:00
 custom:
     Issue: TINY-14370

--- a/.changes/unreleased/tinymce-TINY-14370-2026-05-27.yaml
+++ b/.changes/unreleased/tinymce-TINY-14370-2026-05-27.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Selecting multiple TDs and applying indentation didn't apply it to all the selected TDs.
+time: 2026-05-27T16:03:12.522069852+02:00
+custom:
+    Issue: TINY-14370

--- a/modules/tinymce/src/core/main/ts/commands/IndentOutdent.ts
+++ b/modules/tinymce/src/core/main/ts/commands/IndentOutdent.ts
@@ -61,13 +61,11 @@ const parentIsListComponent = (el: SugarElement<Node>): boolean =>
   Traverse.parent(el).exists(isListComponent);
 
 const getBlocksToIndent = (editor: Editor): SugarElement<HTMLElement>[] => {
-  if (TableCellSelection.getCellsFromEditor(editor).length === 0) {
-    return Arr.filter(SugarElements.fromDom(editor.selection.getSelectedBlocks()), (el): el is SugarElement<HTMLElement> =>
+  const selectedCells = TableCellSelection.getCellsFromEditor(editor);
+  return selectedCells.length === 0 ?
+    Arr.filter(SugarElements.fromDom(editor.selection.getSelectedBlocks()), (el): el is SugarElement<HTMLElement> =>
       !isListComponent(el) && !parentIsListComponent(el) && isEditable(el)
-    );
-  } else {
-    return TableCellSelection.getCellsFromEditor(editor);
-  }
+    ) : selectedCells;
 };
 
 const handle = (editor: Editor, command: string): void => {

--- a/modules/tinymce/src/core/main/ts/commands/IndentOutdent.ts
+++ b/modules/tinymce/src/core/main/ts/commands/IndentOutdent.ts
@@ -8,6 +8,7 @@ import { isList, isListItem, isTable } from '../dom/ElementType';
 import * as NodeType from '../dom/NodeType';
 import { indentListSelection, outdentListSelection } from '../lists/actions/Indentation';
 import * as ListIndentation from '../lists/listmodel/ListsIndendation';
+import * as TableCellSelection from '../selection/TableCellSelection';
 
 type IndentStyle = 'margin-left' | 'margin-right' | 'padding-left' | 'padding-right';
 
@@ -59,10 +60,15 @@ const isListComponent = (el: SugarElement<Node>): boolean =>
 const parentIsListComponent = (el: SugarElement<Node>): boolean =>
   Traverse.parent(el).exists(isListComponent);
 
-const getBlocksToIndent = (editor: Editor): SugarElement<HTMLElement>[] =>
-  Arr.filter(SugarElements.fromDom(editor.selection.getSelectedBlocks()), (el): el is SugarElement<HTMLElement> =>
-    !isListComponent(el) && !parentIsListComponent(el) && isEditable(el)
-  );
+const getBlocksToIndent = (editor: Editor): SugarElement<HTMLElement>[] => {
+  if (TableCellSelection.getCellsFromEditor(editor).length === 0) {
+    return Arr.filter(SugarElements.fromDom(editor.selection.getSelectedBlocks()), (el): el is SugarElement<HTMLElement> =>
+      !isListComponent(el) && !parentIsListComponent(el) && isEditable(el)
+    );
+  } else {
+    return TableCellSelection.getCellsFromEditor(editor);
+  }
+};
 
 const handle = (editor: Editor, command: string): void => {
   if (editor.mode.isReadOnly()) {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
@@ -39,11 +39,11 @@ describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () =>
       Mouse.mouseDown(firstTd, { button: 0 });
       Mouse.mouseOver(lastTd, { button: 0 });
       Mouse.mouseUp(lastTd, { button: 0 });
-      // this enabled even if there is no indentation to have the same behavior as the test:
+      // this is enabled even if there is no indentation to have the same behavior as the test:
       // `"Outdent on multiple paragraphs without margin/padding"` in `OutdentCommandTest.ts`
-      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="true"]`);
+      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="false"]`);
       editor.execCommand('indent');
-      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="true"]`);
+      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="false"]`);
       const tds = UiFinder.findAllIn(TinyDom.body(editor), 'td');
       Arr.each(tds, (td) => {
         assert.isTrue(Css.getRaw(td, 'padding-left').isSome(), `td ${td.dom.innerHTML} should be indented`);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
@@ -1,7 +1,9 @@
-import { UiFinder } from '@ephox/agar';
+import { Mouse, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { SugarBody } from '@ephox/sugar';
-import { TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { Arr } from '@ephox/katamari';
+import { Css, SugarBody } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinySelections, TinyState } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
 
 import type Editor from 'tinymce/core/api/Editor';
 
@@ -24,6 +26,29 @@ describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () =>
 
     it('TINY-9669: Disable outdent on noneditable content', testDisableOnNoneditable('Increase indent'));
     it('TINY-9669: Disable indent on noneditable content', testDisableOnNoneditable('Decrease indent'));
+    it('TINY-14370: applying indent to multiple tds selection should apply the indentetion to all of them', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr>' +
+        '<td class="first">1</td>' +
+        '<td>2</td>' +
+        '<td class="last">3</td>' +
+      '</tr></tbody></table>');
+
+      const firstTd = UiFinder.findIn(TinyDom.body(editor), '.first').getOrDie();
+      const lastTd = UiFinder.findIn(TinyDom.body(editor), '.last').getOrDie();
+      Mouse.mouseDown(firstTd, { button: 0 });
+      Mouse.mouseOver(lastTd, { button: 0 });
+      Mouse.mouseUp(lastTd, { button: 0 });
+      // this enabled even if there is no indentation to have the same behavior as the test:
+      // `"Outdent on multiple paragraphs without margin/padding"` in `OutdentCommandTest.ts`
+      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="true"]`);
+      editor.execCommand('indent');
+      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="true"]`);
+      const tds = UiFinder.findAllIn(TinyDom.body(editor), 'td');
+      Arr.each(tds, (td) => {
+        assert.isTrue(Css.getRaw(td, 'padding-left').isSome(), `td ${td.dom.innerHTML} should be indented`);
+      });
+    });
   });
 });
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/IndentOutdentTest.ts
@@ -26,7 +26,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () =>
 
     it('TINY-9669: Disable outdent on noneditable content', testDisableOnNoneditable('Increase indent'));
     it('TINY-9669: Disable indent on noneditable content', testDisableOnNoneditable('Decrease indent'));
-    it('TINY-14370: applying indent to multiple tds selection should apply the indentetion to all of them', () => {
+    it('TINY-14370: applying indent to multiple tds selection should apply the indentation to all of them', () => {
       const editor = hook.editor();
       editor.setContent('<table><tbody><tr>' +
         '<td class="first">1</td>' +
@@ -43,7 +43,6 @@ describe('browser.tinymce.themes.silver.editor.toolbar.IndentOutdentTest', () =>
       // `"Outdent on multiple paragraphs without margin/padding"` in `OutdentCommandTest.ts`
       UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="false"]`);
       editor.execCommand('indent');
-      UiFinder.exists(SugarBody.body(), `[aria-label="Decrease indent"][aria-disabled="false"]`);
       const tds = UiFinder.findAllIn(TinyDom.body(editor), 'td');
       Arr.each(tds, (td) => {
         assert.isTrue(Css.getRaw(td, 'padding-left').isSome(), `td ${td.dom.innerHTML} should be indented`);


### PR DESCRIPTION
Related Ticket: TINY-14370

Description of Changes:
the function that gets the blocks to indent (`getBlocksToIndent`) didn't consider the multiple TDs selection which is not the native one but a custom one, so I used `TableCellSelection` to manage this case.

P.S. I also found a behaviour that seems a little odd to me while I was writing the test, it seems that selecting more that 1 element always enable the `outdent` button even if nothing selected is "outdentable", I decided not to change this behaviour for the case of multiple TDs

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indentation so applying indent/outdent correctly affects all selected table cells.
* **Tests**
  * Added browser test verifying multi-cell table indentation behavior.
* **Documentation**
  * Added an unreleased changelog entry recording the selection/indentation fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinymce/tinymce/pull/11132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->