### PR TITLE
TINY-14425: refactor with `Arr.findLast`

### DIFF
--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -747,16 +747,15 @@ const Quirks = (editor: Editor): Quirks => {
         firstBlockChildOrNewLine(target).each((firstBlock) => {
           const prevSiblings = Traverse.prevSiblings(firstBlock);
 
-          Arr.findLastIndex(prevSiblings, isValidSibling).bind((lastI) => Arr.get(prevSiblings, lastI))
-            .each((lastInlineBeforeBlock) => {
-              if (Arr.get(getClientRects([ lastInlineBeforeBlock.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
-                CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => {
-                  e.preventDefault();
-                  editor.focus();
-                  editor.selection.setRng(pos.toRange());
-                });
-              }
-            });
+          Arr.findLast(prevSiblings, isValidSibling).each((lastInlineBeforeBlock) => {
+            if (Arr.get(getClientRects([ lastInlineBeforeBlock.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
+              CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => {
+                e.preventDefault();
+                editor.focus();
+                editor.selection.setRng(pos.toRange());
+              });
+            }
+          });
         });
       }
     });


### PR DESCRIPTION
Related Ticket: TINY-14425

Description of Changes:
previous PR introduced `Arr.findLast`, this just refactor the piece of code that caused the creation of this new function

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization for improved maintainability and performance with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->