### PR TITLE
TINY-14385: fix multiple TDs formats application

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14385-2026-06-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-14385-2026-06-03.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Selecting multiple table cells and applying multiple formats could result in unexpected results.
+time: 2026-06-03T15:41:35.60700498+02:00
+custom:
+    Issue: TINY-14385

--- a/.changes/unreleased/tinymce-TINY-14385-2026-06-03.yaml
+++ b/.changes/unreleased/tinymce-TINY-14385-2026-06-03.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Selecting multiple table cells and applying multiple formats could result in unexpected results.
+body: Selecting multiple table cells and applying multiple formats could incorrectly nest formatting tags.
 time: 2026-06-03T15:41:35.60700498+02:00
 custom:
     Issue: TINY-14385

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Type } from '@ephox/katamari';
-import { PredicateExists, PredicateFilter, SugarElement, SugarElements } from '@ephox/sugar';
+import { PredicateExists, SugarElement, SugarElements } from '@ephox/sugar';
 
 import type DOMUtils from '../api/dom/DOMUtils';
 import type Editor from '../api/Editor';
@@ -10,7 +10,6 @@ import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
-import * as RangeNodes from '../selection/RangeNodes';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
 import type { RangeLikeObject } from '../selection/RangeTypes';
 import * as RangeWalk from '../selection/RangeWalk';
@@ -44,41 +43,26 @@ const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, p
   }
 };
 
-const cellContentRange = (dom: DOMUtils, fakeRng: Range): Range => {
-  const td = RangeNodes.getNode(fakeRng.startContainer, fakeRng.startOffset);
-  if (!NodeType.isElement(td) || !td.hasChildNodes()) {
-    return fakeRng;
-  }
-
-  const leaf = (n: Node, kind: 'first' | 'last'): Node => {
-    let currentNode = n;
-    const childType = kind === 'first' ? 'firstChild' : 'lastChild';
-    while (NodeType.isElement(currentNode) && currentNode[childType]) {
-      if (Bookmarks.isBookmarkNode(currentNode[childType])) {
-        const nonBookmarkSiblings = PredicateFilter.siblings(SugarElement.fromDom(currentNode[childType]), (el) => !Bookmarks.isBookmarkNode(el.dom)).map((el) => el.dom);
-        currentNode = Arr[kind === 'first' ? 'head' : 'last'](nonBookmarkSiblings).getOr(currentNode[childType]);
+const cellContentRange = (dom: DOMUtils, fakeRng: Range): Range =>
+  SelectionUtils.getStartNode(fakeRng).fold(
+    () => fakeRng,
+    (td) => {
+      const start = Arr.last(SelectionUtils.getFirstChildren(td)).getOr(td).dom;
+      const end = Arr.last(SelectionUtils.getLastChildren(td)).getOr(td).dom;
+      const rng = dom.createRng();
+      if (NodeType.isText(start)) {
+        rng.setStart(start, 0);
       } else {
-        currentNode = currentNode[childType];
+        rng.setStartBefore(start);
       }
+      if (NodeType.isText(end)) {
+        rng.setEnd(end, end.data.length);
+      } else {
+        rng.setEndAfter(end);
+      }
+      return rng;
     }
-    return currentNode;
-  };
-
-  const start = leaf(td, 'first');
-  const end = leaf(td, 'last');
-  const rng = dom.createRng();
-  if (NodeType.isText(start)) {
-    rng.setStart(start, 0);
-  } else {
-    rng.setStartBefore(start);
-  }
-  if (NodeType.isText(end)) {
-    rng.setEnd(end, end.data.length);
-  } else {
-    rng.setEndAfter(end);
-  }
-  return rng;
-};
+  );
 
 const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
   const formatList = ed.formatter.get(name) as ApplyFormat[];

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -43,27 +43,6 @@ const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, p
   }
 };
 
-const cellContentRange = (dom: DOMUtils, fakeRng: Range): Range =>
-  SelectionUtils.getStartNode(fakeRng).fold(
-    () => fakeRng,
-    (td) => {
-      const start = Arr.last(SelectionUtils.getFirstChildren(td)).getOr(td).dom;
-      const end = Arr.last(SelectionUtils.getLastChildren(td)).getOr(td).dom;
-      const rng = dom.createRng();
-      if (NodeType.isText(start)) {
-        rng.setStart(start, 0);
-      } else {
-        rng.setStartBefore(start);
-      }
-      if (NodeType.isText(end)) {
-        rng.setEnd(end, end.data.length);
-      } else {
-        rng.setEndAfter(end);
-      }
-      return rng;
-    }
-  );
-
 const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
   const formatList = ed.formatter.get(name) as ApplyFormat[];
   const format = formatList[0];
@@ -123,11 +102,15 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
     const isMatchingWrappingBlock = (node: Node) =>
       FormatUtils.isWrappingBlockFormat(format) && MatchFormat.matchNode(ed, node, name, vars);
 
+    const canRenameChildBlocks = (node: Node) =>
+      Arr.forall(node.childNodes, (child) => !FormatUtils.isTextBlock(ed.schema, child) || FormatUtils.isValid(ed, wrapName, child.nodeName.toLowerCase()));
+
     const canRenameBlock = (node: Node, parentName: string, isEditableDescendant: boolean) => {
       const isValidBlockFormatForNode =
         FormatUtils.isNonWrappingBlockFormat(format) &&
         FormatUtils.isTextBlock(ed.schema, node) &&
-        FormatUtils.isValid(ed, parentName, wrapName);
+        FormatUtils.isValid(ed, parentName, wrapName) &&
+        canRenameChildBlocks(node);
       return isEditableDescendant && isValidBlockFormatForNode;
     };
 
@@ -351,8 +334,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
           ed,
           () => {
             SelectionUtils.runOnRanges(ed, (selectionRng, fake) => {
-              const rngToExpand = fake ? cellContentRange(dom, selectionRng) : selectionRng;
-              const expandedRng = ExpandRange.expandRng(dom, rngToExpand, formatList);
+              const expandedRng = fake ? selectionRng : ExpandRange.expandRng(dom, selectionRng, formatList);
               applyRngStyle(dom, expandedRng, false);
             });
           },

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -1,5 +1,5 @@
 import { Arr, Fun, Obj, Type } from '@ephox/katamari';
-import { PredicateExists, SugarElement, SugarElements } from '@ephox/sugar';
+import { PredicateExists, PredicateFilter, SugarElement, SugarElements } from '@ephox/sugar';
 
 import type DOMUtils from '../api/dom/DOMUtils';
 import type Editor from '../api/Editor';
@@ -10,6 +10,7 @@ import Tools from '../api/util/Tools';
 import * as Bookmarks from '../bookmark/Bookmarks';
 import * as Empty from '../dom/Empty';
 import * as NodeType from '../dom/NodeType';
+import * as RangeNodes from '../selection/RangeNodes';
 import * as RangeNormalizer from '../selection/RangeNormalizer';
 import type { RangeLikeObject } from '../selection/RangeTypes';
 import * as RangeWalk from '../selection/RangeWalk';
@@ -41,6 +42,42 @@ const canFormatBR = (editor: Editor, format: ApplyFormat, node: HTMLBRElement, p
   } else {
     return false;
   }
+};
+
+const cellContentRange = (dom: DOMUtils, fakeRng: Range): Range => {
+  const td = RangeNodes.getNode(fakeRng.startContainer, fakeRng.startOffset);
+  if (!NodeType.isElement(td) || !td.hasChildNodes()) {
+    return fakeRng;
+  }
+
+  const leaf = (n: Node, kind: 'first' | 'last'): Node => {
+    let currentNode = n;
+    const childType = kind === 'first' ? 'firstChild' : 'lastChild';
+    while (NodeType.isElement(currentNode) && currentNode[childType]) {
+      if (Bookmarks.isBookmarkNode(currentNode[childType])) {
+        const nonBookmarkSiblings = PredicateFilter.siblings(SugarElement.fromDom(currentNode[childType]), (el) => !Bookmarks.isBookmarkNode(el.dom)).map((el) => el.dom);
+        currentNode = Arr[kind === 'first' ? 'head' : 'last'](nonBookmarkSiblings).getOr(currentNode[childType]);
+      } else {
+        currentNode = currentNode[childType];
+      }
+    }
+    return currentNode;
+  };
+
+  const start = leaf(td, 'first');
+  const end = leaf(td, 'last');
+  const rng = dom.createRng();
+  if (NodeType.isText(start)) {
+    rng.setStart(start, 0);
+  } else {
+    rng.setStartBefore(start);
+  }
+  if (NodeType.isText(end)) {
+    rng.setEnd(end, end.data.length);
+  } else {
+    rng.setEndAfter(end);
+  }
+  return rng;
 };
 
 const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: Node | RangeLikeObject | null): void => {
@@ -330,7 +367,8 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
           ed,
           () => {
             SelectionUtils.runOnRanges(ed, (selectionRng, fake) => {
-              const expandedRng = fake ? selectionRng : ExpandRange.expandRng(dom, selectionRng, formatList);
+              const rngToExpand = fake ? cellContentRange(dom, selectionRng) : selectionRng;
+              const expandedRng = ExpandRange.expandRng(dom, rngToExpand, formatList);
               applyRngStyle(dom, expandedRng, false);
             });
           },

--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -12,7 +12,7 @@ import * as NodeType from '../dom/NodeType';
 
 import * as TableCellSelection from './TableCellSelection';
 
-const getStartNode = (rng: Range): Optional<SugarElement<ChildNode>> => {
+const getStartNode = (rng: Range) => {
   const sc = rng.startContainer, so = rng.startOffset;
   if (NodeType.isText(sc)) {
     return so === 0 ? Optional.some(SugarElement.fromDom(sc)) : Optional.none();
@@ -149,9 +149,6 @@ const isSelectionOverWholeAnchor = (range: Range): boolean => isSelectionOverWho
 
 export {
   hasAllContentsSelected,
-  getFirstChildren,
-  getLastChildren,
-  getStartNode,
   moveEndPoint,
   hasAnyRanges,
   runOnRanges,

--- a/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
+++ b/modules/tinymce/src/core/main/ts/selection/SelectionUtils.ts
@@ -12,7 +12,7 @@ import * as NodeType from '../dom/NodeType';
 
 import * as TableCellSelection from './TableCellSelection';
 
-const getStartNode = (rng: Range) => {
+const getStartNode = (rng: Range): Optional<SugarElement<ChildNode>> => {
   const sc = rng.startContainer, so = rng.startOffset;
   if (NodeType.isText(sc)) {
     return so === 0 ? Optional.some(SugarElement.fromDom(sc)) : Optional.none();
@@ -149,6 +149,9 @@ const isSelectionOverWholeAnchor = (range: Range): boolean => isSelectionOverWho
 
 export {
   hasAllContentsSelected,
+  getFirstChildren,
+  getLastChildren,
+  getStartNode,
   moveEndPoint,
   hasAnyRanges,
   runOnRanges,

--- a/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/FormatterApplyTest.ts
@@ -1,4 +1,4 @@
-import { Assertions } from '@ephox/agar';
+import { Assertions, Mouse, UiFinder } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { Obj } from '@ephox/katamari';
 import { Hierarchy } from '@ephox/sugar';
@@ -2612,6 +2612,32 @@ describe('browser.tinymce.core.FormatterApplyTest', () => {
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
       editor.formatter.apply('blockquote');
       TinyAssertions.assertContent(editor, '<ul><li><blockquote>a bc d</blockquote></li></ul>');
+    });
+  });
+
+  context('TINY-14385: multiple TD selection formats apply', () => {
+    it('TINY-14385: applying H1 -> Blockquote -> H2 should replace the `H1` with the `H2`', () => {
+      const editor = hook.editor();
+      editor.setContent('<table><tbody><tr>' +
+        '<td class="first">One</td>' +
+        '<td>Two</td>' +
+        '<td class="last">Three</td>' +
+      '</tr></tbody></table>');
+
+      const firstTd = UiFinder.findIn(TinyDom.body(editor), '.first').getOrDie();
+      const lastTd = UiFinder.findIn(TinyDom.body(editor), '.last').getOrDie();
+      Mouse.mouseDown(firstTd, { button: 0 });
+      Mouse.mouseOver(lastTd, { button: 0 });
+      Mouse.mouseUp(lastTd, { button: 0 });
+
+      editor.formatter.apply('h1');
+      editor.formatter.apply('blockquote');
+      editor.formatter.apply('h2');
+      TinyAssertions.assertContent(editor, '<table><tbody><tr>' +
+        '<td class="first"><blockquote><h2>One</h2></blockquote></td>' +
+        '<td><blockquote><h2>Two</h2></blockquote></td>' +
+        '<td class="last"><blockquote><h2>Three</h2></blockquote></td>' +
+      '</tr></tbody></table>');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-14385

Description of Changes:
the problem was that when we have a multiple TD selection we applied the formats directly to the range returned from `SelectionUtils.runOnRanges` skipping `ExpandRange.expandRng`, to fix it now there is a function that set that range to a correct representation of what would we have selecting a TD and pass it to `ExpandRange.expandRng`.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where selecting multiple table cells and applying multiple formats could result in incorrectly nested formatting tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->