### PR TITLE
TINY-12791: Changed so both regions are appending

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
@@ -3,15 +3,16 @@ import * as Announcer from '../../aria/Announcer';
 /**
  * Page-wide aria-live announcer used to send messages to screen readers without shifting focus.
  *
- *   Polite messages: appended as child divs to a single persistent live region
- *   (aria-atomic="false", aria-relevant="additions") so each child is announced
- *   independently as it is added. Earlier messages remain in the DOM and are
- *   not re-read. Each message is removed after a delay long enough for screen
- *   readers to have picked up the mutation, keeping the region bounded over long sessions.
+ * Messages are appended as child divs to one of two persistent live regions,
+ * polite or assertive (both aria-atomic="false", aria-relevant="additions"), so
+ * each child is announced independently as it is added. Earlier messages remain
+ * in the DOM and are not re-read. Each message is removed after a delay long
+ * enough for screen readers to have picked up the mutation, keeping the regions
+ * bounded over long sessions.
  *
- *   Assertive messages: announced through a region that is created fresh per
- *   message and removed entirely before the next assertive announce, so each
- *   one interrupts the previous rather than queueing behind it.
+ * The polite and assertive regions differ only in their aria-live politeness:
+ * assertive announcements interrupt the screen reader's current speech, while
+ * polite ones wait for it to finish.
  *
  * @class tinymce.dom.AriaAnnouncer
  */
@@ -28,7 +29,7 @@ const announcer = Announcer.createAnnouncer();
  * @method announce
  * @param {String} message The message to announce to screen readers.
  * @param {Object} options Optional settings.
- * @param {Boolean} options.assertive If true, uses aria-live="assertive" (role="alert") instead of polite.
+ * @param {Boolean} options.assertive If true, uses aria-live="assertive" instead of polite.
  * @example
  * tinymce.dom.AriaAnnouncer.announce('Bold on');
  * tinymce.dom.AriaAnnouncer.announce('Error occurred', { assertive: true });

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -1,5 +1,5 @@
 import { Arr, Id, Singleton, Strings } from '@ephox/katamari';
-import { Attribute, Css, Insert, Remove, SelectorFilter, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { Attribute, Css, Insert, Remove, SelectorFilter, SugarBody, SugarElement } from '@ephox/sugar';
 
 export const announcerContainerId = Id.generate('tiny-aria-announcer');
 
@@ -25,21 +25,12 @@ const OFFSCREEN_STYLES = {
   overflow: 'hidden'
 };
 
-const createPoliteRegion = (): SugarElement<HTMLDivElement> => {
+const createRegion = (live: 'polite' | 'assertive'): SugarElement<HTMLDivElement> => {
   const region = SugarElement.fromTag('div');
   Attribute.setAll(region, {
-    'aria-live': 'polite',
+    'aria-live': live,
     'aria-atomic': 'false',
     'aria-relevant': 'additions'
-  });
-  return region;
-};
-
-const createAssertiveRegion = (): SugarElement<HTMLDivElement> => {
-  const region = SugarElement.fromTag('div');
-  Attribute.setAll(region, {
-    'aria-live': 'assertive',
-    'aria-atomic': 'true'
   });
   return region;
 };
@@ -48,8 +39,8 @@ const isConnected = (element: SugarElement<HTMLElement>): boolean => element.dom
 
 const createNewState = () => {
   const container = SugarElement.fromTag('div');
-  const politeRegion = createPoliteRegion();
-  const assertiveRegion = createAssertiveRegion();
+  const politeRegion = createRegion('polite');
+  const assertiveRegion = createRegion('assertive');
 
   Attribute.set(container, 'id', announcerContainerId);
   Css.setAll(container, OFFSCREEN_STYLES);
@@ -61,7 +52,7 @@ const createNewState = () => {
   return { container, politeRegion, assertiveRegion };
 };
 
-const cleanupExpiredPoliteMessages = (polite: SugarElement<HTMLDivElement>, now: number): void => {
+const cleanupExpiredMessages = (polite: SugarElement<HTMLDivElement>, now: number): void => {
   Arr.each(SelectorFilter.children(polite, `div[${politeTimestampAttr}]`), (messageDiv) => {
     Attribute.getOpt(messageDiv, politeTimestampAttr)
       .bind((value) => Strings.toInt(value))
@@ -81,20 +72,23 @@ export const createAnnouncer = (): Announcer => {
     });
   };
 
-  const polite = (message: string): void => {
-    const { politeRegion } = mountRegions();
+  const addMessage = (region: SugarElement<HTMLDivElement>, message: string): void => {
     const now = Date.now();
 
-    cleanupExpiredPoliteMessages(politeRegion, now);
+    cleanupExpiredMessages(region, now);
 
     const messageDiv = SugarElement.fromTag('div');
     Attribute.set(messageDiv, politeTimestampAttr, String(now));
     Insert.append(messageDiv, SugarElement.fromText(message));
-    Insert.append(politeRegion, messageDiv);
+    Insert.append(region, messageDiv);
+  };
+
+  const polite = (message: string): void => {
+    addMessage(mountRegions().politeRegion, message);
   };
 
   const assertive = (message: string): void => {
-    TextContent.set(mountRegions().assertiveRegion, message);
+    addMessage(mountRegions().assertiveRegion, message);
   };
 
   return { polite, assertive };

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -1,11 +1,13 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
-import { Arr } from '@ephox/katamari';
+import { Arr, Type } from '@ephox/katamari';
 import { Attribute, Css, Insert, Remove, SelectorFind, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import AriaAnnouncer from 'tinymce/core/api/dom/AriaAnnouncer';
 import * as Announcer from 'tinymce/core/aria/Announcer';
+
+type Live = 'polite' | 'assertive';
 
 describe('browser.tinymce.core.AriaAnnouncerTest', () => {
   const containerSelector = `#${Announcer.announcerContainerId}`;
@@ -13,20 +15,38 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
   const pGetContainer = (): Promise<SugarElement<HTMLElement>> =>
     UiFinder.pWaitFor<HTMLElement>('aria announcer container should exist on the body', SugarBody.body(), containerSelector);
 
-  const pPoliteMessage = (container: SugarElement<HTMLElement>, text: string): Promise<void> =>
-    Waiter.pTryUntil(`polite region should contain a message "${text}"`, () => {
-      const politeRegions = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
-      assert.isAtLeast(politeRegions.length, 1, 'polite region not present');
-      const messageDivs = UiFinder.findAllIn<HTMLElement>(politeRegions[0], 'div');
-      const found = Arr.exists(messageDivs, (m) => TextContent.get(m) === text);
-      assert.isTrue(found, `message "${text}" not present in polite region`);
+  const getRegion = (container: SugarElement<HTMLElement>, live: Live): SugarElement<HTMLElement> => {
+    const regions = UiFinder.findAllIn<HTMLElement>(container, `div[aria-live="${live}"]`);
+    assert.lengthOf(regions, 1, `there should be exactly one ${live} region`);
+    return regions[0];
+  };
+
+  const messagesOf = (container: SugarElement<HTMLElement>, live: Live): string[] =>
+    Arr.bind(UiFinder.findAllIn<HTMLElement>(getRegion(container, live), 'div'), (el) => {
+      const content = TextContent.get(el);
+      return Type.isString(content) ? [ content ] : [];
     });
 
-  const pAssertiveText = (container: SugarElement<HTMLElement>, text: string): Promise<void> =>
-    Waiter.pTryUntil(`assertive region should contain "${text}"`, () => {
-      const matches = Arr.filter(UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]'), (r) => TextContent.get(r) === text);
-      assert.isAtLeast(matches.length, 1, `text "${text}" not present in any assertive region`);
+  const pMessage = (container: SugarElement<HTMLElement>, live: Live, text: string): Promise<void> =>
+    Waiter.pTryUntil(`${live} region should contain a message "${text}"`, () => {
+      assert.isTrue(Arr.contains(messagesOf(container, live), text), `message "${text}" not present in ${live} region`);
     });
+
+  const assertLiveAttributes = (region: SugarElement<HTMLElement>, live: Live): void => {
+    assert.equal(Attribute.get(region, 'aria-live'), live);
+    assert.equal(Attribute.get(region, 'aria-atomic'), 'false');
+    assert.equal(Attribute.get(region, 'aria-relevant'), 'additions');
+  };
+
+  const addExpiredMessages = (region: SugarElement<HTMLElement>, texts: string[]): void => {
+    const expiredTimestamp = String(Date.now() - (10 * 60 * 1000 + 1000));
+    Arr.each(texts, (text) => {
+      const messageDiv = SugarElement.fromTag('div');
+      Attribute.set(messageDiv, 'data-mce-announced-at', expiredTimestamp);
+      TextContent.set(messageDiv, text);
+      Insert.prepend(region, messageDiv);
+    });
+  };
 
   afterEach(() => {
     SelectorFind.descendant(SugarBody.body(), containerSelector).each(Remove.remove);
@@ -41,88 +61,104 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     assert.equal(Css.get(container, 'overflow'), 'hidden');
   });
 
-  it('TINY-12791: Container starts with polite region and assertive regions', async () => {
-    AriaAnnouncer.announce('Setup');
-    const container = await pGetContainer();
-
-    const polite = await UiFinder.pWaitFor<HTMLElement>('waited for polite container', container, 'div[aria-live="polite"]');
-    assert.equal(Attribute.get(polite, 'aria-atomic'), 'false');
-    assert.equal(Attribute.get(polite, 'aria-relevant'), 'additions');
-
-    const assertive = await UiFinder.pWaitFor<HTMLElement>('waited for assertive container', container, 'div[aria-live="assertive"]');
-    assert.equal(Attribute.get(assertive, 'aria-atomic'), 'true');
-  });
-
-  it('TINY-12791: Polite announce appends a message div as a child of the polite region', async () => {
-    AriaAnnouncer.announce('Bold on');
-    const container = await pGetContainer();
-
-    await pPoliteMessage(container, 'Bold on');
-  });
-
-  it('TINY-12791: Subsequent polite announces append additional message divs and keep prior ones', async () => {
-    AriaAnnouncer.announce('First');
-    const container = await pGetContainer();
-    await pPoliteMessage(container, 'First');
-
-    AriaAnnouncer.announce('Second');
-    await pPoliteMessage(container, 'Second');
-
-    const polite = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="polite"]');
-    assert.lengthOf(polite, 1, 'still only one polite region');
-    const messageDivs = UiFinder.findAllIn<HTMLElement>(polite[0], 'div');
-    const texts = Arr.map(messageDivs, TextContent.get);
-    assert.deepEqual(texts, [ 'First', 'Second' ], 'both messages should be present in order');
-  });
-
-  it('TINY-12791: A new assertive announce removes the prior assertive content from the DOM', async () => {
-    AriaAnnouncer.announce('Error A', { assertive: true });
-    const container = await pGetContainer();
-    await pAssertiveText(container, 'Error A');
-
-    AriaAnnouncer.announce('Error B', { assertive: true });
-    await pAssertiveText(container, 'Error B');
-
-    const assertive = UiFinder.findAllIn<HTMLElement>(container, 'div[aria-live="assertive"]');
-    assert.lengthOf(assertive, 1, 'exactly one assertive region remains after the second announce');
-    assert.equal(TextContent.get(assertive[0]), 'Error B');
-  });
-
-  it('TINY-12791: Polite messages older than 10 minutes are cleaned up on the next announce', async () => {
-    AriaAnnouncer.announce('Setup');
-    const container = await pGetContainer();
-    await pPoliteMessage(container, 'Setup');
-    const polite = await UiFinder.pWaitFor<HTMLElement>('waited for polite container', container, 'div[aria-live="polite"]');
-
-    // Fake a few messages that were announced more than 10 minutes ago
-    const expiredTimestamp = String(Date.now() - (10 * 60 * 1000 + 1000));
-    const expiredMessages = [ 'Old 1', 'Old 2', 'Old 3' ];
-    Arr.each(expiredMessages, (text) => {
-      const messageDiv = SugarElement.fromTag('div');
-      Attribute.set(messageDiv, 'data-mce-announced-at', expiredTimestamp);
-      TextContent.set(messageDiv, text);
-      Insert.prepend(polite, messageDiv);
-    });
-
-    // A fresh announce triggers the cleanup of the expired messages
-    AriaAnnouncer.announce('Fresh');
-    await pPoliteMessage(container, 'Fresh');
-
-    await Waiter.pTryUntil('expired polite messages should be removed', () => {
-      const texts = Arr.map(UiFinder.findAllIn<HTMLElement>(polite, 'div'), TextContent.get);
-      Arr.each(expiredMessages, (text) => assert.isFalse(Arr.contains(texts, text), `expired message "${text}" should be removed`));
-      assert.deepEqual(texts, [ 'Setup', 'Fresh' ], 'only the non-expired messages should remain, in order');
-    });
-  });
-
   it('TINY-12791: Assertive announce does not affect polite messages already in the region', async () => {
     AriaAnnouncer.announce('Polite message');
     const container = await pGetContainer();
-    await pPoliteMessage(container, 'Polite message');
+    await pMessage(container, 'polite', 'Polite message');
 
     AriaAnnouncer.announce('Urgent', { assertive: true });
-    await pAssertiveText(container, 'Urgent');
+    await pMessage(container, 'assertive', 'Urgent');
 
-    await pPoliteMessage(container, 'Polite message');
+    await pMessage(container, 'polite', 'Polite message');
+  });
+
+  describe('Polite region', () => {
+    const announce = (message: string): void => AriaAnnouncer.announce(message);
+
+    it('TINY-12791: Polite region has the expected live attributes', async () => {
+      announce('Setup');
+      const container = await pGetContainer();
+
+      assertLiveAttributes(getRegion(container, 'polite'), 'polite');
+    });
+
+    it('TINY-12791: Polite announce appends a message div to the polite region only', async () => {
+      announce('Bold on');
+      const container = await pGetContainer();
+
+      await pMessage(container, 'polite', 'Bold on');
+      assert.isFalse(Arr.contains(messagesOf(container, 'assertive'), 'Bold on'), 'message should not be present in the assertive region');
+    });
+
+    it('TINY-12791: Subsequent polite announces append additional message divs and keep prior ones', async () => {
+      announce('First');
+      const container = await pGetContainer();
+      await pMessage(container, 'polite', 'First');
+
+      announce('Second');
+      await pMessage(container, 'polite', 'Second');
+
+      assert.deepEqual(messagesOf(container, 'polite'), [ 'First', 'Second' ], 'both messages should be present in order');
+    });
+
+    it('TINY-12791: Polite messages older than 10 minutes are cleaned up on the next announce', async () => {
+      announce('Setup');
+      const container = await pGetContainer();
+      await pMessage(container, 'polite', 'Setup');
+
+      addExpiredMessages(getRegion(container, 'polite'), [ 'Old 1', 'Old 2', 'Old 3' ]);
+
+      announce('Fresh');
+      await pMessage(container, 'polite', 'Fresh');
+
+      await Waiter.pTryUntil('expired polite messages should be removed', () => {
+        assert.deepEqual(messagesOf(container, 'polite'), [ 'Setup', 'Fresh' ], 'only the non-expired messages should remain, in order');
+      });
+    });
+  });
+
+  describe('Assertive region', () => {
+    const announce = (message: string): void => AriaAnnouncer.announce(message, { assertive: true });
+
+    it('TINY-12791: Assertive region has the expected live attributes', async () => {
+      announce('Setup');
+      const container = await pGetContainer();
+
+      assertLiveAttributes(getRegion(container, 'assertive'), 'assertive');
+    });
+
+    it('TINY-12791: Assertive announce appends a message div to the assertive region only', async () => {
+      announce('Error A');
+      const container = await pGetContainer();
+
+      await pMessage(container, 'assertive', 'Error A');
+      assert.isFalse(Arr.contains(messagesOf(container, 'polite'), 'Error A'), 'message should not be present in the polite region');
+    });
+
+    it('TINY-12791: Subsequent assertive announces append additional message divs and keep prior ones', async () => {
+      announce('Error A');
+      const container = await pGetContainer();
+      await pMessage(container, 'assertive', 'Error A');
+
+      announce('Error B');
+      await pMessage(container, 'assertive', 'Error B');
+
+      assert.deepEqual(messagesOf(container, 'assertive'), [ 'Error A', 'Error B' ], 'both messages should be present in order');
+    });
+
+    it('TINY-12791: Assertive messages older than 10 minutes are cleaned up on the next announce', async () => {
+      announce('Setup');
+      const container = await pGetContainer();
+      await pMessage(container, 'assertive', 'Setup');
+
+      addExpiredMessages(getRegion(container, 'assertive'), [ 'Old 1', 'Old 2', 'Old 3' ]);
+
+      announce('Fresh');
+      await pMessage(container, 'assertive', 'Fresh');
+
+      await Waiter.pTryUntil('expired assertive messages should be removed', () => {
+        assert.deepEqual(messagesOf(container, 'assertive'), [ 'Setup', 'Fresh' ], 'only the non-expired messages should remain, in order');
+      });
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINY-12791

Follow up PR found more issues while self testing with screen readers.

Description of Changes:

- Changed so polite and assertive regions needs to append or it wont speak messages that have the exact same string
- Changed the tests so they are simpler now that both regions are the same behavior
- Changed the code so that it's simpler since now both regions works the same way.

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [ ] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Assertive screen reader announcements now preserve multiple messages instead of replacing prior content
- **Refactor**
    - Unified polite and assertive announcement handling for consistent behavior
    - Automatic cleanup of expired announcement messages on subsequent announcements
- **Documentation**
    - Updated announcer docs to reflect appended live-region message behavior and assertive semantics
- **Tests**
    - Refactored browser tests to cover appended messages, expiry cleanup, and region behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->