### PR TITLE
TINY-14124: add FetchSpy, RequestMatcher, RequestFilter to agar

### DIFF
--- a/.changes/unreleased/agar-TINY-14495-2026-06-09.yaml
+++ b/.changes/unreleased/agar-TINY-14495-2026-06-09.yaml
@@ -1,0 +1,6 @@
+project: agar
+kind: Added
+body: Added new `FetchSpy`, `RequestMatcher` and `RequestFilter` utilities.
+time: 2026-06-09T19:25:54.799533967Z
+custom:
+    Issue: TINY-14495

--- a/modules/agar/src/main/ts/ephox/agar/api/FetchSpy.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/FetchSpy.ts
@@ -1,0 +1,2 @@
+export type { FetchSpyOptions } from '../http/FetchSpy';
+export { pWithFetchSpy } from '../http/FetchSpy';

--- a/modules/agar/src/main/ts/ephox/agar/api/Main.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Main.ts
@@ -10,6 +10,7 @@ import * as Clipboard from './Clipboard';
 import * as ConsoleReader from './ConsoleReader';
 import * as Cursors from './Cursors';
 import * as DragnDrop from './DragnDrop';
+import * as FetchSpy from './FetchSpy';
 import * as FileInput from './FileInput';
 import * as Files from './Files';
 import * as FocusTools from './FocusTools';
@@ -31,6 +32,8 @@ import * as PropertySteps from './PropertySteps';
 import * as RealClipboard from './RealClipboard';
 import { type KeyPressAdt, RealKeys } from './RealKeys';
 import * as RealMouse from './RealMouse';
+import * as RequestFilter from './RequestFilter';
+import * as RequestMatcher from './RequestMatcher';
 import { Step } from './Step';
 import * as StepSequence from './StepSequence';
 import { TestLogs } from './TestLogs';
@@ -58,6 +61,7 @@ export {
   Clipboard,
   Cursors,
   ConsoleReader,
+  FetchSpy,
   FocusTools,
   GeneralSteps,
   StepSequence,
@@ -87,5 +91,7 @@ export {
   DragnDrop,
   Files,
   FileInput,
-  TestStore
+  TestStore,
+  RequestMatcher,
+  RequestFilter
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/Main.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Main.ts
@@ -82,6 +82,8 @@ export {
   RealClipboard,
   RealKeys,
   RealMouse,
+  RequestFilter,
+  RequestMatcher,
   Step,
   TestLogs,
   UiControls,
@@ -91,7 +93,5 @@ export {
   DragnDrop,
   Files,
   FileInput,
-  TestStore,
-  RequestMatcher,
-  RequestFilter
+  TestStore
 };

--- a/modules/agar/src/main/ts/ephox/agar/api/RequestFilter.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RequestFilter.ts
@@ -1,0 +1,1 @@
+export { makeRequestFilter, get, post, put, del, patch } from '../http/RequestFilter';

--- a/modules/agar/src/main/ts/ephox/agar/api/RequestFilter.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RequestFilter.ts
@@ -1,1 +1,1 @@
-export { makeRequestFilter, get, post, put, del, patch } from '../http/RequestFilter';
+export { get, post, put, del, patch } from '../http/RequestFilter';

--- a/modules/agar/src/main/ts/ephox/agar/api/RequestMatcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RequestMatcher.ts
@@ -1,1 +1,1 @@
-export { makeRequestMatcher, get, post, put, del, patch } from '../http/RequestMatcher';
+export { get, post, put, del, patch } from '../http/RequestMatcher';

--- a/modules/agar/src/main/ts/ephox/agar/api/RequestMatcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/RequestMatcher.ts
@@ -1,0 +1,1 @@
+export { makeRequestMatcher, get, post, put, del, patch } from '../http/RequestMatcher';

--- a/modules/agar/src/main/ts/ephox/agar/http/FetchSpy.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/FetchSpy.ts
@@ -1,0 +1,33 @@
+export interface FetchSpyOptions {
+  readonly filter: (request: Request) => boolean;
+  readonly onFetch?: (request: Request) => void;
+  readonly onAbort?: (request: Request) => void;
+}
+
+const pWithFetchSpy = async <T>(
+  options: FetchSpyOptions,
+  callback: () => T | Promise<T>
+): Promise<T> => {
+  const originalFetch = window.fetch;
+
+  window.fetch = (input, init) => {
+    const request = new window.Request(input, init);
+
+    if (options.filter(request)) {
+      options.onFetch?.(request);
+      request.signal.addEventListener('abort', () => options.onAbort?.(request), { once: true });
+    }
+
+    return originalFetch.call(window, input, init);
+  };
+
+  try {
+    return await callback();
+  } finally {
+    window.fetch = originalFetch;
+  }
+};
+
+export {
+  pWithFetchSpy
+};

--- a/modules/agar/src/main/ts/ephox/agar/http/FetchSpy.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/FetchSpy.ts
@@ -12,13 +12,17 @@ const pWithFetchSpy = async <T>(
 
   window.fetch = (input, init) => {
     const request = new window.Request(input, init);
+    const abortHandler = () => options.onAbort?.(request);
 
     if (options.filter(request)) {
       options.onFetch?.(request);
-      request.signal.addEventListener('abort', () => options.onAbort?.(request), { once: true });
+      request.signal.addEventListener('abort', abortHandler, { once: true });
     }
 
-    return originalFetch.call(window, input, init);
+    const resultPromise: ReturnType<typeof originalFetch> = originalFetch.call(window, input, init);
+    return resultPromise.finally(() => {
+      request.signal.removeEventListener('abort', abortHandler);
+    });
   };
 
   try {

--- a/modules/agar/src/main/ts/ephox/agar/http/FetchSpy.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/FetchSpy.ts
@@ -16,7 +16,12 @@ const pWithFetchSpy = async <T>(
 
     if (options.filter(request)) {
       options.onFetch?.(request);
-      request.signal.addEventListener('abort', abortHandler, { once: true });
+
+      if (request.signal.aborted) {
+        options.onAbort?.(request);
+      } else {
+        request.signal.addEventListener('abort', abortHandler, { once: true });
+      }
     }
 
     const resultPromise: ReturnType<typeof originalFetch> = originalFetch.call(window, input, init);

--- a/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
@@ -17,7 +17,7 @@ export type RequestHandler = (requestDetails: RequestHandlerDetails) => Promise<
 
 const hasMockPrefix = (path: string): boolean => path.startsWith(Shared.mockPrefix);
 
-const makeMethodHttpHandler = (method: string) => (pathPattern: string, handler: RequestHandler) => {
+const makeMethodHttpHandler = (method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH') => (pathPattern: string, handler: RequestHandler) => {
   if (!hasMockPrefix(pathPattern)) {
     throw new Error(`Path pattern "${pathPattern}" must start with "${Shared.mockPrefix}"`);
   }

--- a/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
@@ -1,6 +1,6 @@
-import { Arr, Optional } from '@ephox/katamari';
-import { PathPattern } from '@ephox/polaris';
+import { Arr, type Optional } from '@ephox/katamari';
 
+import * as RequestMatcher from './RequestMatcher';
 import * as Shared from './Shared';
 
 export interface RequestHandlerDetails {
@@ -17,24 +17,15 @@ export type RequestHandler = (requestDetails: RequestHandlerDetails) => Promise<
 
 const hasMockPrefix = (path: string): boolean => path.startsWith(Shared.mockPrefix);
 
-const matchMethod = (request: Request, method: string): boolean =>
-  request.method.toUpperCase() === method.toUpperCase();
-
 const makeMethodHttpHandler = (method: string) => (pathPattern: string, handler: RequestHandler) => {
-  const pathMatcher = PathPattern.makePathMatcher(pathPattern);
-
   if (!hasMockPrefix(pathPattern)) {
     throw new Error(`Path pattern "${pathPattern}" must start with "${Shared.mockPrefix}"`);
   }
 
-  return (request: Request, abortSignal: AbortSignal): Optional<Promise<Response>> => {
-    if (matchMethod(request, method)) {
-      const url = new URL(request.url);
-      return pathMatcher(url.pathname).map((params) => handler({ params, request, abortSignal }));
-    } else {
-      return Optional.none();
-    }
-  };
+  const requestMatcher = RequestMatcher.makeRequestMatcher(method, pathPattern);
+
+  return (request: Request, abortSignal: AbortSignal): Optional<Promise<Response>> =>
+    requestMatcher(request).map((params) => handler({ params, request, abortSignal }));
 };
 
 export const get = makeMethodHttpHandler('GET');

--- a/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
@@ -1,5 +1,6 @@
 import { Arr, type Optional } from '@ephox/katamari';
 
+import type { HttpMethod } from './HttpMethod';
 import * as RequestMatcher from './RequestMatcher';
 import * as Shared from './Shared';
 
@@ -17,7 +18,7 @@ export type RequestHandler = (requestDetails: RequestHandlerDetails) => Promise<
 
 const hasMockPrefix = (path: string): boolean => path.startsWith(Shared.mockPrefix);
 
-const makeMethodHttpHandler = (method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH') => (pathPattern: string, handler: RequestHandler) => {
+const makeMethodHttpHandler = (method: HttpMethod) => (pathPattern: string, handler: RequestHandler) => {
   if (!hasMockPrefix(pathPattern)) {
     throw new Error(`Path pattern "${pathPattern}" must start with "${Shared.mockPrefix}"`);
   }

--- a/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/HttpHandler.ts
@@ -29,11 +29,11 @@ const makeMethodHttpHandler = (method: HttpMethod) => (pathPattern: string, hand
     requestMatcher(request).map((params) => handler({ params, request, abortSignal }));
 };
 
-export const get = makeMethodHttpHandler('GET');
-export const post = makeMethodHttpHandler('POST');
-export const put = makeMethodHttpHandler('PUT');
-export const del = makeMethodHttpHandler('DELETE');
-export const patch = makeMethodHttpHandler('PATCH');
+export const get = makeMethodHttpHandler('get');
+export const post = makeMethodHttpHandler('post');
+export const put = makeMethodHttpHandler('put');
+export const del = makeMethodHttpHandler('delete');
+export const patch = makeMethodHttpHandler('patch');
 
 export const defaultHandler: RawRequestHandler = async (_req, _signal) => new window.Response(null, { status: 501, statusText: 'Handler not implemented' });
 

--- a/modules/agar/src/main/ts/ephox/agar/http/HttpMethod.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/HttpMethod.ts
@@ -1,0 +1,2 @@
+type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
+export type HttpMethod = Method | Uppercase<Method>;

--- a/modules/agar/src/main/ts/ephox/agar/http/HttpMethod.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/HttpMethod.ts
@@ -1,2 +1,1 @@
-type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
-export type HttpMethod = Method | Uppercase<Method>;
+export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
@@ -1,0 +1,14 @@
+import { Fun } from '@ephox/katamari';
+
+import * as RequestMatcher from './RequestMatcher';
+
+export const makeRequestFilter = (method: string, pattern: string) => {
+  const matcher = RequestMatcher.makeRequestMatcher(method, pattern);
+  return (request: Request): boolean => matcher(request).isSome();
+};
+
+export const get = Fun.curry(makeRequestFilter, 'GET');
+export const post = Fun.curry(makeRequestFilter, 'POST');
+export const put = Fun.curry(makeRequestFilter, 'PUT');
+export const del = Fun.curry(makeRequestFilter, 'DELETE');
+export const patch = Fun.curry(makeRequestFilter, 'PATCH');

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
@@ -2,7 +2,19 @@ import { Fun } from '@ephox/katamari';
 
 import * as RequestMatcher from './RequestMatcher';
 
-export const makeRequestFilter = (method: string, pattern: string) => {
+type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
+type HttpMethod = Method | Uppercase<Method>;
+
+/**
+ * Builds a filter that tests a `Request` against an HTTP method and URL path pattern.
+ *
+ * The `pattern` is matched against the request URL's pathname only — the protocol,
+ * host, port, and query string of the request are not considered. The pattern may
+ * contain placeholder segments (e.g. `/users/:id`).
+ *
+ * Returns `true` when both the method and path match, otherwise `false`.
+ */
+export const makeRequestFilter = (method: HttpMethod, pattern: string) => {
   const matcher = RequestMatcher.makeRequestMatcher(method, pattern);
   return (request: Request): boolean => matcher(request).isSome();
 };

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
@@ -17,8 +17,8 @@ export const makeRequestFilter = (method: HttpMethod, pattern: string) => {
   return (request: Request): boolean => matcher(request).isSome();
 };
 
-export const get = Fun.curry(makeRequestFilter, 'GET');
-export const post = Fun.curry(makeRequestFilter, 'POST');
-export const put = Fun.curry(makeRequestFilter, 'PUT');
-export const del = Fun.curry(makeRequestFilter, 'DELETE');
-export const patch = Fun.curry(makeRequestFilter, 'PATCH');
+export const get = Fun.curry(makeRequestFilter, 'get');
+export const post = Fun.curry(makeRequestFilter, 'post');
+export const put = Fun.curry(makeRequestFilter, 'put');
+export const del = Fun.curry(makeRequestFilter, 'delete');
+export const patch = Fun.curry(makeRequestFilter, 'patch');

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestFilter.ts
@@ -1,9 +1,7 @@
 import { Fun } from '@ephox/katamari';
 
+import type { HttpMethod } from './HttpMethod';
 import * as RequestMatcher from './RequestMatcher';
-
-type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
-type HttpMethod = Method | Uppercase<Method>;
 
 /**
  * Builds a filter that tests a `Request` against an HTTP method and URL path pattern.

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
@@ -1,8 +1,7 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { PathPattern } from '@ephox/polaris';
 
-type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
-type HttpMethod = Method | Uppercase<Method>;
+import type { HttpMethod } from './HttpMethod';
 
 const matchMethod = (request: Request, method: HttpMethod): boolean =>
   request.method.toUpperCase() === method.toUpperCase();

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
@@ -1,0 +1,23 @@
+import { Fun, Optional } from '@ephox/katamari';
+import { PathPattern } from '@ephox/polaris';
+
+const matchMethod = (request: Request, method: string): boolean =>
+  request.method.toUpperCase() === method.toUpperCase();
+
+export const makeRequestMatcher = (method: string, pattern: string) => {
+  const pathMatcher = PathPattern.makePathMatcher(pattern);
+  return (request: Request): Optional<Record<string, string>> => {
+    if (matchMethod(request, method)) {
+      const url = new URL(request.url);
+      return pathMatcher(url.pathname);
+    } else {
+      return Optional.none();
+    }
+  };
+};
+
+export const get = Fun.curry(makeRequestMatcher, 'GET');
+export const post = Fun.curry(makeRequestMatcher, 'POST');
+export const put = Fun.curry(makeRequestMatcher, 'PUT');
+export const del = Fun.curry(makeRequestMatcher, 'DELETE');
+export const patch = Fun.curry(makeRequestMatcher, 'PATCH');

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
@@ -4,7 +4,7 @@ import { PathPattern } from '@ephox/polaris';
 import type { HttpMethod } from './HttpMethod';
 
 const matchMethod = (request: Request, method: HttpMethod): boolean =>
-  request.method.toUpperCase() === method.toUpperCase();
+  request.method.toLowerCase() === method.toLowerCase();
 
 /**
  * Builds a matcher that tests a `Request` against an HTTP method and URL path pattern.
@@ -28,8 +28,8 @@ export const makeRequestMatcher = (method: HttpMethod, pattern: string) => {
   };
 };
 
-export const get = Fun.curry(makeRequestMatcher, 'GET');
-export const post = Fun.curry(makeRequestMatcher, 'POST');
-export const put = Fun.curry(makeRequestMatcher, 'PUT');
-export const del = Fun.curry(makeRequestMatcher, 'DELETE');
-export const patch = Fun.curry(makeRequestMatcher, 'PATCH');
+export const get = Fun.curry(makeRequestMatcher, 'get');
+export const post = Fun.curry(makeRequestMatcher, 'post');
+export const put = Fun.curry(makeRequestMatcher, 'put');
+export const del = Fun.curry(makeRequestMatcher, 'delete');
+export const patch = Fun.curry(makeRequestMatcher, 'patch');

--- a/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
+++ b/modules/agar/src/main/ts/ephox/agar/http/RequestMatcher.ts
@@ -1,10 +1,23 @@
 import { Fun, Optional } from '@ephox/katamari';
 import { PathPattern } from '@ephox/polaris';
 
-const matchMethod = (request: Request, method: string): boolean =>
+type Method = 'get' | 'post' | 'put' | 'delete' | 'patch';
+type HttpMethod = Method | Uppercase<Method>;
+
+const matchMethod = (request: Request, method: HttpMethod): boolean =>
   request.method.toUpperCase() === method.toUpperCase();
 
-export const makeRequestMatcher = (method: string, pattern: string) => {
+/**
+ * Builds a matcher that tests a `Request` against an HTTP method and URL path pattern.
+ *
+ * The `pattern` is matched against the request URL's pathname only — the protocol,
+ * host, port, and query string of the request are not considered. The pattern may
+ * contain placeholder segments (e.g. `/users/:id`) whose captured values are returned
+ * as a record on match.
+ *
+ * Returns `Optional.some(params)` when both the method and path match, otherwise `Optional.none()`.
+ */
+export const makeRequestMatcher = (method: HttpMethod, pattern: string) => {
   const pathMatcher = PathPattern.makePathMatcher(pattern);
   return (request: Request): Optional<Record<string, string>> => {
     if (matchMethod(request, method)) {

--- a/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
+++ b/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
@@ -127,6 +127,20 @@ describe('browser.agar.http.FetchSpyTest', () => {
     ]);
   });
 
+  it('TINY-14123: Abort should not be emitted, if abort controller fires after request finished executing', async () => {
+    await FetchSpy.pWithFetchSpy({
+      filter: Fun.always,
+      onFetch: (request) => store.add(`fetched ${request.method}`),
+      onAbort: (request) => store.add(`aborted ${request.method}`)
+    }, async () => {
+      const controller = new window.AbortController();
+      await window.fetch('/custom/test', { signal: controller.signal });
+      controller.abort();
+
+      store.assertEq('Spy should not observe abort, after request resolved', [ 'fetched GET' ]);
+    });
+  });
+
   it('TINY-14123: restores window.fetch after callback resolves', async () => {
     const originalFetch = window.fetch;
 

--- a/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
+++ b/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
@@ -141,7 +141,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     });
   });
 
-  it('TINY-14124: onAbort fires for a pre-aborted signal', async () => {
+  it('TINY-14495: onAbort fires for a pre-aborted signal', async () => {
     const controller = new window.AbortController();
     controller.abort();
 

--- a/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
+++ b/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
@@ -1,0 +1,155 @@
+import { Assert, beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Fun } from '@ephox/katamari';
+
+import * as FetchSpy from 'ephox/agar/api/FetchSpy';
+import * as Http from 'ephox/agar/api/Http';
+import * as RequestFilter from 'ephox/agar/api/RequestFilter';
+import { TestStore } from 'ephox/agar/api/TestStore';
+
+describe('browser.agar.http.FetchSpyTest', () => {
+  const store = TestStore<string>();
+
+  Http.mockHttpHook(() => [
+    Http.get('/custom/test', async () => Http.makeResponse('{}', { status: 200, headers: { 'Content-Type': 'application/json' }})),
+    Http.post('/custom/test', async () => Http.makeResponse('{}', { status: 200, headers: { 'Content-Type': 'application/json' }})),
+    Http.put('/custom/test', async () => Http.makeResponse('{}', { status: 200, headers: { 'Content-Type': 'application/json' }})),
+    Http.del('/custom/test', async () => Http.makeResponse('{}', { status: 200, headers: { 'Content-Type': 'application/json' }})),
+    Http.patch('/custom/test', async () => Http.makeResponse('{}', { status: 200, headers: { 'Content-Type': 'application/json' }}))
+  ]);
+
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it('TINY-14123: onFetch fires for each request', async () => {
+    const methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' ];
+
+    await FetchSpy.pWithFetchSpy({
+      filter: Fun.always,
+      onFetch: (request) => store.add(`${request.method} ${new URL(request.url).pathname}`)
+    }, async () => {
+      for (const method of methods) {
+        await window.fetch('/custom/test', { method });
+      }
+    });
+
+    store.assertEq('All fetches should be observed in order', [
+      'GET /custom/test',
+      'POST /custom/test',
+      'PUT /custom/test',
+      'DELETE /custom/test',
+      'PATCH /custom/test'
+    ]);
+  });
+
+  it('TINY-14123: onAbort fires when a request is aborted', async () => {
+    const methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' ];
+
+    await FetchSpy.pWithFetchSpy({
+      filter: Fun.always,
+      onFetch: (request) => store.add(`fetched ${request.method}`),
+      onAbort: (request) => store.add(`aborted ${request.method}`)
+    }, async () => {
+
+      for (const method of methods) {
+        let thrown: Error | undefined;
+        const controller = new window.AbortController();
+        const pending = window.fetch('/custom/test', { method, signal: controller.signal });
+        controller.abort();
+
+        try {
+          await pending;
+        } catch (error) {
+          thrown = error;
+        }
+
+        Assert.eq(
+          `Aborted ${method} fetch should reject with an AbortError`,
+          'AbortError',
+          thrown?.name
+        );
+      }
+    });
+
+    store.assertEq('Spy should observe both fetch and abort for every method', [
+      'fetched GET', 'aborted GET',
+      'fetched POST', 'aborted POST',
+      'fetched PUT', 'aborted PUT',
+      'fetched DELETE', 'aborted DELETE',
+      'fetched PATCH', 'aborted PATCH'
+    ]);
+  });
+
+  it('TINY-14123: Only requests matching filter should be spied on', async () => {
+    await FetchSpy.pWithFetchSpy({
+      filter: RequestFilter.patch('/custom/test'),
+      onFetch: (request) => store.add(`fetched ${request.method}`),
+      onAbort: (request) => store.add(`aborted ${request.method}`)
+    }, async () => {
+
+      const getController = new window.AbortController();
+      const pendingGet = window.fetch('/custom/test', { method: 'GET', signal: getController.signal });
+      let getThrown: Error | undefined;
+      getController.abort();
+
+      try {
+        await pendingGet;
+      } catch (error) {
+        getThrown = error;
+      }
+
+      Assert.eq(
+        `Aborted get fetch should reject with an AbortError`,
+        'AbortError',
+        getThrown?.name
+      );
+
+      const patchController = new window.AbortController();
+      const pendingPatch = window.fetch('/custom/test', { method: 'PATCH', signal: patchController.signal });
+      let patchThrown: Error | undefined;
+      patchController.abort();
+
+      try {
+        await pendingPatch;
+      } catch (error) {
+        patchThrown = error;
+      }
+
+      Assert.eq(
+        `Aborted patch fetch should reject with an AbortError`,
+        'AbortError',
+        patchThrown?.name
+      );
+    });
+
+    store.assertEq('Spy should only observe PATCH requests', [
+      'fetched PATCH', 'aborted PATCH',
+    ]);
+  });
+
+  it('TINY-14123: restores window.fetch after callback resolves', async () => {
+    const originalFetch = window.fetch;
+
+    await FetchSpy.pWithFetchSpy({ filter: Fun.always }, async () => {
+      Assert.eq('fetch should be replaced inside callback', true, window.fetch !== originalFetch);
+    });
+
+    Assert.eq('fetch should be restored after callback resolves', true, window.fetch === originalFetch);
+  });
+
+  it('TINY-14123: restores window.fetch after callback throws', async () => {
+    const originalFetch = window.fetch;
+    let thrown: unknown;
+
+    try {
+      await FetchSpy.pWithFetchSpy({ filter: Fun.always }, async () => {
+        throw new Error('boom');
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    Assert.eq('error should propagate', true, thrown instanceof Error);
+    Assert.eq('fetch should be restored after callback throws', true, window.fetch === originalFetch);
+  });
+});

--- a/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
+++ b/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
@@ -21,7 +21,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     store.clear();
   });
 
-  it('TINY-14123: onFetch fires for each request', async () => {
+  it('TINY-14495: onFetch fires for each request', async () => {
     const methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' ];
 
     await FetchSpy.pWithFetchSpy({
@@ -42,7 +42,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     ]);
   });
 
-  it('TINY-14123: onAbort fires when a request is aborted', async () => {
+  it('TINY-14495: onAbort fires when a request is aborted', async () => {
     const methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' ];
 
     await FetchSpy.pWithFetchSpy({
@@ -80,7 +80,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     ]);
   });
 
-  it('TINY-14123: Only requests matching filter should be spied on', async () => {
+  it('TINY-14495: Only requests matching filter should be spied on', async () => {
     await FetchSpy.pWithFetchSpy({
       filter: RequestFilter.patch('/custom/test'),
       onFetch: (request) => store.add(`fetched ${request.method}`),
@@ -127,7 +127,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     ]);
   });
 
-  it('TINY-14123: Abort should not be emitted, if abort controller fires after request finished executing', async () => {
+  it('TINY-14495: Abort should not be emitted, if abort controller fires after request finished executing', async () => {
     await FetchSpy.pWithFetchSpy({
       filter: Fun.always,
       onFetch: (request) => store.add(`fetched ${request.method}`),
@@ -160,7 +160,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     ]);
   });
 
-  it('TINY-14123: restores window.fetch after callback resolves', async () => {
+  it('TINY-14495: restores window.fetch after callback resolves', async () => {
     const originalFetch = window.fetch;
 
     await FetchSpy.pWithFetchSpy({ filter: Fun.always }, async () => {
@@ -170,7 +170,7 @@ describe('browser.agar.http.FetchSpyTest', () => {
     Assert.eq('fetch should be restored after callback resolves', true, window.fetch === originalFetch);
   });
 
-  it('TINY-14123: restores window.fetch after callback throws', async () => {
+  it('TINY-14495: restores window.fetch after callback throws', async () => {
     const originalFetch = window.fetch;
     let thrown: unknown;
 

--- a/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
+++ b/modules/agar/src/test/ts/browser/http/FetchSpyTest.ts
@@ -141,6 +141,25 @@ describe('browser.agar.http.FetchSpyTest', () => {
     });
   });
 
+  it('TINY-14124: onAbort fires for a pre-aborted signal', async () => {
+    const controller = new window.AbortController();
+    controller.abort();
+
+    await FetchSpy.pWithFetchSpy({
+      filter: Fun.always,
+      onFetch: (req) => store.add(`fetched ${req.method}`),
+      onAbort: (req) => store.add(`aborted ${req.method}`)
+    }, async () => {
+      try {
+        await window.fetch('/custom/test', { signal: controller.signal });
+      } catch (_) { /* AbortError expected */ }
+    });
+
+    store.assertEq('Pre-aborted signal should trigger both onFetch and onAbort', [
+      'fetched GET', 'aborted GET'
+    ]);
+  });
+
   it('TINY-14123: restores window.fetch after callback resolves', async () => {
     const originalFetch = window.fetch;
 

--- a/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
@@ -8,32 +8,24 @@ describe('browser.agar.http.RequestFilterTest', () => {
   const makeRequest = (method: HttpMethod, url: string): Request => new window.Request(url, { method });
 
   describe('makeRequestFilter', () => {
-    it('TINY-14495: matches regardless of the case used for the filter method', () => {
-      const request = makeRequest('GET', '/users');
-      const upperFilter = RequestFilter.makeRequestFilter('GET', '/users');
-      const lowerFilter = RequestFilter.makeRequestFilter('get', '/users');
-      Assert.eq('An uppercase filter should match a GET request', true, upperFilter(request));
-      Assert.eq('A lowercase filter should match a GET request', true, lowerFilter(request));
-    });
-
     it('TINY-14495: returns false when the method does not match (path would otherwise match)', () => {
-      const filter = RequestFilter.makeRequestFilter('GET', '/users');
+      const filter = RequestFilter.makeRequestFilter('get', '/users');
       Assert.eq('A POST request should not match a GET filter', false, filter(makeRequest('POST', '/users')));
     });
 
     it('TINY-14495: returns false when the method matches but the path does not', () => {
-      const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
+      const filter = RequestFilter.makeRequestFilter('get', '/users/:id');
       Assert.eq('Path mismatch should cause false even on a method match', false, filter(makeRequest('GET', '/posts/42')));
     });
 
     it('TINY-14495: matches against url.pathname, ignores query params', () => {
-      const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
+      const filter = RequestFilter.makeRequestFilter('get', '/users/:id');
       const request = makeRequest('GET', '/users/42?foo=bar#frag');
       Assert.eq('Path with query params should match', true, filter(request));
     });
 
     it('TINY-14495: matches against url.pathname, ignores domain', () => {
-      const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
+      const filter = RequestFilter.makeRequestFilter('get', '/users/:id');
 
       const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/55');
       Assert.eq('Path with tiny.cloud domain should match', true, filter(tinyCloudRequest));
@@ -43,7 +35,7 @@ describe('browser.agar.http.RequestFilterTest', () => {
     });
 
     it('TINY-14495: pattern should only include path, not full url', () => {
-      const filter = RequestFilter.makeRequestFilter('GET', 'https://tiny.cloud/users/:id');
+      const filter = RequestFilter.makeRequestFilter('get', 'https://tiny.cloud/users/:id');
       const request = makeRequest('GET', 'https://tiny.cloud/users/55');
 
       Assert.eq('Pattern defined with full url should always fail', false, filter(request));

--- a/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
@@ -8,7 +8,7 @@ describe('browser.agar.http.RequestFilterTest', () => {
   const makeRequest = (method: HttpMethod, url: string): Request => new window.Request(url, { method });
 
   describe('makeRequestFilter', () => {
-    it('TINY-14123: matches regardless of the case used for the filter method', () => {
+    it('TINY-14495: matches regardless of the case used for the filter method', () => {
       const request = makeRequest('GET', '/users');
       const upperFilter = RequestFilter.makeRequestFilter('GET', '/users');
       const lowerFilter = RequestFilter.makeRequestFilter('get', '/users');
@@ -16,23 +16,23 @@ describe('browser.agar.http.RequestFilterTest', () => {
       Assert.eq('A lowercase filter should match a GET request', true, lowerFilter(request));
     });
 
-    it('TINY-14123: returns false when the method does not match (path would otherwise match)', () => {
+    it('TINY-14495: returns false when the method does not match (path would otherwise match)', () => {
       const filter = RequestFilter.makeRequestFilter('GET', '/users');
       Assert.eq('A POST request should not match a GET filter', false, filter(makeRequest('POST', '/users')));
     });
 
-    it('TINY-14123: returns false when the method matches but the path does not', () => {
+    it('TINY-14495: returns false when the method matches but the path does not', () => {
       const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
       Assert.eq('Path mismatch should cause false even on a method match', false, filter(makeRequest('GET', '/posts/42')));
     });
 
-    it('TINY-14123: matches against url.pathname, ignores query params', () => {
+    it('TINY-14495: matches against url.pathname, ignores query params', () => {
       const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
       const request = makeRequest('GET', '/users/42?foo=bar#frag');
       Assert.eq('Path with query params should match', true, filter(request));
     });
 
-    it('TINY-14123: matches against url.pathname, ignores domain', () => {
+    it('TINY-14495: matches against url.pathname, ignores domain', () => {
       const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
 
       const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/55');
@@ -42,7 +42,7 @@ describe('browser.agar.http.RequestFilterTest', () => {
       Assert.eq('Path with tiny.dev domain should match', true, filter(tinyDevRequest));
     });
 
-    it('TINY-14123: pattern should only include path, not full url', () => {
+    it('TINY-14495: pattern should only include path, not full url', () => {
       const filter = RequestFilter.makeRequestFilter('GET', 'https://tiny.cloud/users/:id');
       const request = makeRequest('GET', 'https://tiny.cloud/users/55');
 
@@ -69,23 +69,23 @@ describe('browser.agar.http.RequestFilterTest', () => {
       }
     };
 
-    it('TINY-14123: get matches GET requests and rejects every other method', () => {
+    it('TINY-14495: get matches GET requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestFilter.get, 'GET');
     });
 
-    it('TINY-14123: post matches POST requests and rejects every other method', () => {
+    it('TINY-14495: post matches POST requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestFilter.post, 'POST');
     });
 
-    it('TINY-14123: put matches PUT requests and rejects every other method', () => {
+    it('TINY-14495: put matches PUT requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestFilter.put, 'PUT');
     });
 
-    it('TINY-14123: del matches DELETE requests and rejects every other method', () => {
+    it('TINY-14495: del matches DELETE requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestFilter.del, 'DELETE');
     });
 
-    it('TINY-14123: patch matches PATCH requests and rejects every other method', () => {
+    it('TINY-14495: patch matches PATCH requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestFilter.patch, 'PATCH');
     });
   });

--- a/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
@@ -1,0 +1,75 @@
+import { Assert, describe, it } from '@ephox/bedrock-client';
+
+import * as RequestFilter from 'ephox/agar/http/RequestFilter';
+
+describe('browser.agar.http.RequestFilterTest', () => {
+  const methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' ] as const;
+  type HttpMethod = typeof methods[number];
+  const makeRequest = (method: HttpMethod, url: string): Request => new window.Request(url, { method });
+
+  describe('makeRequestFilter', () => {
+    it('TINY-14123: matches regardless of the case used for the filter method', () => {
+      const request = makeRequest('GET', '/users');
+      const upperFilter = RequestFilter.makeRequestFilter('GET', '/users');
+      const lowerFilter = RequestFilter.makeRequestFilter('get', '/users');
+      Assert.eq('An uppercase filter should match a GET request', true, upperFilter(request));
+      Assert.eq('A lowercase filter should match a GET request', true, lowerFilter(request));
+    });
+
+    it('TINY-14123: returns false when the method does not match (path would otherwise match)', () => {
+      const filter = RequestFilter.makeRequestFilter('GET', '/users');
+      Assert.eq('A POST request should not match a GET filter', false, filter(makeRequest('POST', '/users')));
+    });
+
+    it('TINY-14123: returns false when the method matches but the path does not', () => {
+      const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
+      Assert.eq('Path mismatch should cause false even on a method match', false, filter(makeRequest('GET', '/posts/42')));
+    });
+
+    it('TINY-14123: matches against url.pathname', () => {
+      const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
+      const request = makeRequest('GET', '/users/42?foo=bar#frag');
+      Assert.eq('Path with query params should match', true, filter(request));
+    });
+  });
+
+  describe('curried per-method helpers', () => {
+    const assertHelperMatchesOnly = (
+      helper: (pattern: string) => (request: Request) => boolean,
+      expectedMethod: HttpMethod
+    ): void => {
+      const filter = helper('/path');
+
+      for (const method of methods) {
+        const request = makeRequest(method, '/path');
+        const result = filter(request);
+
+        if (method === expectedMethod) {
+          Assert.eq(`${expectedMethod} helper should match a ${method} request`, true, result);
+        } else {
+          Assert.eq(`${expectedMethod} helper should not match a ${method} request`, false, result);
+        }
+      }
+    };
+
+    it('TINY-14123: get matches GET requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestFilter.get, 'GET');
+    });
+
+    it('TINY-14123: post matches POST requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestFilter.post, 'POST');
+    });
+
+    it('TINY-14123: put matches PUT requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestFilter.put, 'PUT');
+    });
+
+    it('TINY-14123: del matches DELETE requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestFilter.del, 'DELETE');
+    });
+
+    it('TINY-14123: patch matches PATCH requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestFilter.patch, 'PATCH');
+    });
+  });
+});

--- a/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
@@ -26,10 +26,20 @@ describe('browser.agar.http.RequestFilterTest', () => {
       Assert.eq('Path mismatch should cause false even on a method match', false, filter(makeRequest('GET', '/posts/42')));
     });
 
-    it('TINY-14123: matches against url.pathname', () => {
+    it('TINY-14123: matches against url.pathname, ignores query params', () => {
       const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
       const request = makeRequest('GET', '/users/42?foo=bar#frag');
       Assert.eq('Path with query params should match', true, filter(request));
+    });
+
+    it('TINY-14123: matches against url.pathname, ignores domain', () => {
+      const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
+
+      const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/:id');
+      Assert.eq('Path with tiny.cloud domain should match', true, filter(tinyCloudRequest));
+
+      const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/:id');
+      Assert.eq('Path with tiny.dev domain should match', true, filter(tinyDevRequest));
     });
   });
 

--- a/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
@@ -35,16 +35,16 @@ describe('browser.agar.http.RequestFilterTest', () => {
     it('TINY-14123: matches against url.pathname, ignores domain', () => {
       const filter = RequestFilter.makeRequestFilter('GET', '/users/:id');
 
-      const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/:id');
+      const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/55');
       Assert.eq('Path with tiny.cloud domain should match', true, filter(tinyCloudRequest));
 
-      const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/:id');
+      const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/55');
       Assert.eq('Path with tiny.dev domain should match', true, filter(tinyDevRequest));
     });
 
     it('TINY-14123: pattern should only include path, not full url', () => {
       const filter = RequestFilter.makeRequestFilter('GET', 'https://tiny.cloud/users/:id');
-      const request = makeRequest('GET', 'https://tiny.cloud/users/:id');
+      const request = makeRequest('GET', 'https://tiny.cloud/users/55');
 
       Assert.eq('Pattern defined with full url should always fail', false, filter(request));
     });

--- a/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestFilterTest.ts
@@ -41,6 +41,13 @@ describe('browser.agar.http.RequestFilterTest', () => {
       const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/:id');
       Assert.eq('Path with tiny.dev domain should match', true, filter(tinyDevRequest));
     });
+
+    it('TINY-14123: pattern should only include path, not full url', () => {
+      const filter = RequestFilter.makeRequestFilter('GET', 'https://tiny.cloud/users/:id');
+      const request = makeRequest('GET', 'https://tiny.cloud/users/:id');
+
+      Assert.eq('Pattern defined with full url should always fail', false, filter(request));
+    });
   });
 
   describe('curried per-method helpers', () => {

--- a/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
@@ -52,6 +52,13 @@ describe('browser.agar.http.RequestMatcherTest', () => {
       Assert.eq('Path should match', true, result.isSome());
       Assert.eq('Path parameters should be returned properly', { userId: '33', conversationId: '123' }, result.getOrDie());
     });
+
+    it('TINY-14123: pattern should only include path, not full url', () => {
+      const matcher = RequestMatcher.makeRequestMatcher('GET', 'https://tiny.cloud/users/:id');
+      const request = makeRequest('GET', 'https://tiny.cloud/users/:id');
+
+      Assert.eq('Pattern defined with full url should always fail', false, matcher(request).isSome());
+    });
   });
 
   describe('per-method helpers', () => {

--- a/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
@@ -27,11 +27,21 @@ describe('browser.agar.http.RequestMatcherTest', () => {
       Assert.eq('Path mismatch should cause none even on a method match', true, matcher(makeRequest('GET', '/posts/42')).isNone());
     });
 
-    it('TINY-14123: matches against url.pathname', () => {
+    it('TINY-14123: matches against url.pathname, ignores query params', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
       const request = makeRequest('GET', '/users/42?foo=bar#frag');
       const result = matcher(request);
       Assert.eq('Path with query params should match', true, result.isSome());
+    });
+
+    it('TINY-14123: matches against url.pathname, ignores domain', () => {
+      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
+
+      const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/:id');
+      Assert.eq('Path with tiny.cloud domain should match', true, matcher(tinyCloudRequest).isSome());
+
+      const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/:id');
+      Assert.eq('Path with tiny.dev domain should match', true, matcher(tinyDevRequest).isSome());
     });
 
     it('TINY-14123: returns matched params', () => {

--- a/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
@@ -9,7 +9,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
   const makeRequest = (method: HttpMethod, url: string): Request => new window.Request(url, { method });
 
   describe('makeRequestMatcher', () => {
-    it('TINY-14123: matches regardless of the case used for the matcher method', () => {
+    it('TINY-14495: matches regardless of the case used for the matcher method', () => {
       const request = makeRequest('GET', '/users');
       const upperMatcher = RequestMatcher.makeRequestMatcher('GET', '/users');
       const lowerMatcher = RequestMatcher.makeRequestMatcher('get', '/users');
@@ -17,24 +17,24 @@ describe('browser.agar.http.RequestMatcherTest', () => {
       Assert.eq('A lowercase matcher should match a GET request', true, lowerMatcher(request).isSome());
     });
 
-    it('TINY-14123: returns none when the method does not match (path would otherwise match)', () => {
+    it('TINY-14495: returns none when the method does not match (path would otherwise match)', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users');
       Assert.eq('A POST request should not match a GET matcher', true, matcher(makeRequest('POST', '/users')).isNone());
     });
 
-    it('TINY-14123: returns none when the method matches but the path does not', () => {
+    it('TINY-14495: returns none when the method matches but the path does not', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
       Assert.eq('Path mismatch should cause none even on a method match', true, matcher(makeRequest('GET', '/posts/42')).isNone());
     });
 
-    it('TINY-14123: matches against url.pathname, ignores query params', () => {
+    it('TINY-14495: matches against url.pathname, ignores query params', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
       const request = makeRequest('GET', '/users/42?foo=bar#frag');
       const result = matcher(request);
       Assert.eq('Path with query params should match', true, result.isSome());
     });
 
-    it('TINY-14123: matches against url.pathname, ignores domain', () => {
+    it('TINY-14495: matches against url.pathname, ignores domain', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
 
       const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/55');
@@ -44,7 +44,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
       Assert.eq('Path with tiny.dev domain should match', true, matcher(tinyDevRequest).isSome());
     });
 
-    it('TINY-14123: returns matched params', () => {
+    it('TINY-14495: returns matched params', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:userId/conversations/:conversationId');
       const request = makeRequest('GET', '/users/33/conversations/123');
       const result = matcher(request);
@@ -53,7 +53,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
       Assert.eq('Path parameters should be returned properly', { userId: '33', conversationId: '123' }, result.getOrDie());
     });
 
-    it('TINY-14123: pattern should only include path, not full url', () => {
+    it('TINY-14495: pattern should only include path, not full url', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', 'https://tiny.cloud/users/:id');
       const request = makeRequest('GET', 'https://tiny.cloud/users/55');
 
@@ -80,23 +80,23 @@ describe('browser.agar.http.RequestMatcherTest', () => {
       }
     };
 
-    it('TINY-14123: get matches GET requests and rejects every other method', () => {
+    it('TINY-14495: get matches GET requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestMatcher.get, 'GET');
     });
 
-    it('TINY-14123: post matches POST requests and rejects every other method', () => {
+    it('TINY-14495: post matches POST requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestMatcher.post, 'POST');
     });
 
-    it('TINY-14123: put matches PUT requests and rejects every other method', () => {
+    it('TINY-14495: put matches PUT requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestMatcher.put, 'PUT');
     });
 
-    it('TINY-14123: del matches DELETE requests and rejects every other method', () => {
+    it('TINY-14495: del matches DELETE requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestMatcher.del, 'DELETE');
     });
 
-    it('TINY-14123: patch matches PATCH requests and rejects every other method', () => {
+    it('TINY-14495: patch matches PATCH requests and rejects every other method', () => {
       assertHelperMatchesOnly(RequestMatcher.patch, 'PATCH');
     });
   });

--- a/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
@@ -1,0 +1,86 @@
+import { Assert, describe, it } from '@ephox/bedrock-client';
+import type { Optional } from '@ephox/katamari';
+
+import * as RequestMatcher from 'ephox/agar/http/RequestMatcher';
+
+describe('browser.agar.http.RequestMatcherTest', () => {
+  const methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' ] as const;
+  type HttpMethod = typeof methods[number];
+  const makeRequest = (method: HttpMethod, url: string): Request => new window.Request(url, { method });
+
+  describe('makeRequestMatcher', () => {
+    it('TINY-14123: matches regardless of the case used for the matcher method', () => {
+      const request = makeRequest('GET', '/users');
+      const upperMatcher = RequestMatcher.makeRequestMatcher('GET', '/users');
+      const lowerMatcher = RequestMatcher.makeRequestMatcher('GET', '/users');
+      Assert.eq('An uppercase matcher should match a GET request', true, upperMatcher(request).isSome());
+      Assert.eq('A lowercase matcher should match a GET request', true, lowerMatcher(request).isSome());
+    });
+
+    it('TINY-14123: returns none when the method does not match (path would otherwise match)', () => {
+      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users');
+      Assert.eq('A POST request should not match a GET matcher', true, matcher(makeRequest('POST', '/users')).isNone());
+    });
+
+    it('TINY-14123: returns none when the method matches but the path does not', () => {
+      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
+      Assert.eq('Path mismatch should cause none even on a method match', true, matcher(makeRequest('GET', '/posts/42')).isNone());
+    });
+
+    it('TINY-14123: matches against url.pathname', () => {
+      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
+      const request = makeRequest('GET', '/users/42?foo=bar#frag');
+      const result = matcher(request);
+      Assert.eq('Path with query params should match', true, result.isSome());
+    });
+
+    it('TINY-14123: returns matched params', () => {
+      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:userId/conversations/:conversationId');
+      const request = makeRequest('GET', '/users/33/conversations/123');
+      const result = matcher(request);
+
+      Assert.eq('Path should match', true, result.isSome());
+      Assert.eq('Path parameters should be returned properly', { userId: '33', conversationId: '123' }, result.getOrDie());
+    });
+  });
+
+  describe('per-method helpers', () => {
+    const assertHelperMatchesOnly = (
+      helper: (pattern: string) => (request: Request) => Optional<Record<string, string>>,
+      expectedMethod: HttpMethod
+    ): void => {
+      const matcher = helper('/path');
+
+      for (const method of methods) {
+        const request = makeRequest(method, '/path');
+        const result = matcher(request);
+
+        if (method === expectedMethod) {
+          Assert.eq(`${expectedMethod} helper should match a ${method} request`, true, result.isSome());
+        } else {
+          Assert.eq(`${expectedMethod} helper should not match a ${method} request`, false, result.isSome());
+        }
+      }
+    };
+
+    it('TINY-14123: get matches GET requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestMatcher.get, 'GET');
+    });
+
+    it('TINY-14123: post matches POST requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestMatcher.post, 'POST');
+    });
+
+    it('TINY-14123: put matches PUT requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestMatcher.put, 'PUT');
+    });
+
+    it('TINY-14123: del matches DELETE requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestMatcher.del, 'DELETE');
+    });
+
+    it('TINY-14123: patch matches PATCH requests and rejects every other method', () => {
+      assertHelperMatchesOnly(RequestMatcher.patch, 'PATCH');
+    });
+  });
+});

--- a/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
@@ -9,33 +9,25 @@ describe('browser.agar.http.RequestMatcherTest', () => {
   const makeRequest = (method: HttpMethod, url: string): Request => new window.Request(url, { method });
 
   describe('makeRequestMatcher', () => {
-    it('TINY-14495: matches regardless of the case used for the matcher method', () => {
-      const request = makeRequest('GET', '/users');
-      const upperMatcher = RequestMatcher.makeRequestMatcher('GET', '/users');
-      const lowerMatcher = RequestMatcher.makeRequestMatcher('get', '/users');
-      Assert.eq('An uppercase matcher should match a GET request', true, upperMatcher(request).isSome());
-      Assert.eq('A lowercase matcher should match a GET request', true, lowerMatcher(request).isSome());
-    });
-
     it('TINY-14495: returns none when the method does not match (path would otherwise match)', () => {
-      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users');
+      const matcher = RequestMatcher.makeRequestMatcher('get', '/users');
       Assert.eq('A POST request should not match a GET matcher', true, matcher(makeRequest('POST', '/users')).isNone());
     });
 
     it('TINY-14495: returns none when the method matches but the path does not', () => {
-      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
+      const matcher = RequestMatcher.makeRequestMatcher('get', '/users/:id');
       Assert.eq('Path mismatch should cause none even on a method match', true, matcher(makeRequest('GET', '/posts/42')).isNone());
     });
 
     it('TINY-14495: matches against url.pathname, ignores query params', () => {
-      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
+      const matcher = RequestMatcher.makeRequestMatcher('get', '/users/:id');
       const request = makeRequest('GET', '/users/42?foo=bar#frag');
       const result = matcher(request);
       Assert.eq('Path with query params should match', true, result.isSome());
     });
 
     it('TINY-14495: matches against url.pathname, ignores domain', () => {
-      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
+      const matcher = RequestMatcher.makeRequestMatcher('get', '/users/:id');
 
       const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/55');
       Assert.eq('Path with tiny.cloud domain should match', true, matcher(tinyCloudRequest).isSome());
@@ -45,7 +37,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
     });
 
     it('TINY-14495: returns matched params', () => {
-      const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:userId/conversations/:conversationId');
+      const matcher = RequestMatcher.makeRequestMatcher('get', '/users/:userId/conversations/:conversationId');
       const request = makeRequest('GET', '/users/33/conversations/123');
       const result = matcher(request);
 
@@ -54,7 +46,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
     });
 
     it('TINY-14495: pattern should only include path, not full url', () => {
-      const matcher = RequestMatcher.makeRequestMatcher('GET', 'https://tiny.cloud/users/:id');
+      const matcher = RequestMatcher.makeRequestMatcher('get', 'https://tiny.cloud/users/:id');
       const request = makeRequest('GET', 'https://tiny.cloud/users/55');
 
       Assert.eq('Pattern defined with full url should always fail', false, matcher(request).isSome());

--- a/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
+++ b/modules/agar/src/test/ts/browser/http/RequestMatcherTest.ts
@@ -12,7 +12,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
     it('TINY-14123: matches regardless of the case used for the matcher method', () => {
       const request = makeRequest('GET', '/users');
       const upperMatcher = RequestMatcher.makeRequestMatcher('GET', '/users');
-      const lowerMatcher = RequestMatcher.makeRequestMatcher('GET', '/users');
+      const lowerMatcher = RequestMatcher.makeRequestMatcher('get', '/users');
       Assert.eq('An uppercase matcher should match a GET request', true, upperMatcher(request).isSome());
       Assert.eq('A lowercase matcher should match a GET request', true, lowerMatcher(request).isSome());
     });
@@ -37,10 +37,10 @@ describe('browser.agar.http.RequestMatcherTest', () => {
     it('TINY-14123: matches against url.pathname, ignores domain', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', '/users/:id');
 
-      const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/:id');
+      const tinyCloudRequest = makeRequest('GET', 'https://tiny.cloud/users/55');
       Assert.eq('Path with tiny.cloud domain should match', true, matcher(tinyCloudRequest).isSome());
 
-      const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/:id');
+      const tinyDevRequest = makeRequest('GET', 'https://tiny.dev/users/55');
       Assert.eq('Path with tiny.dev domain should match', true, matcher(tinyDevRequest).isSome());
     });
 
@@ -55,7 +55,7 @@ describe('browser.agar.http.RequestMatcherTest', () => {
 
     it('TINY-14123: pattern should only include path, not full url', () => {
       const matcher = RequestMatcher.makeRequestMatcher('GET', 'https://tiny.cloud/users/:id');
-      const request = makeRequest('GET', 'https://tiny.cloud/users/:id');
+      const request = makeRequest('GET', 'https://tiny.cloud/users/55');
 
       Assert.eq('Pattern defined with full url should always fail', false, matcher(request).isSome());
     });


### PR DESCRIPTION
Related Ticket: TINY-14495

Description of Changes:
* Added `RequestMatcher` utility that builds a matcher testing a `Request` against an HTTP method and URL path pattern, returning `Optional.some(params)` on match or `Optional.none()` otherwise. Supports parameterised path segments (e.g. `/users/:id`) and is case-insensitive for the method argument.
* Added `RequestFilter` utility that wraps `RequestMatcher` and returns a simple `boolean` predicate, useful for filtering requests without needing the matched params.
* Added `FetchSpy` utility (`pWithFetchSpy`) that temporarily replaces `window.fetch` within a callback, invoking `onFetch` when a matching request is initiated and `onAbort` when its signal is aborted (including pre-aborted signals). `window.fetch` is always restored after the callback resolves or throws.
* Extracted `HttpMethod` type to a shared module and refactored `HttpHandler` to delegate method/path matching to `RequestMatcher`, removing the duplicated inline logic.
* Exported all three new utilities (`FetchSpy`, `RequestMatcher`, `RequestFilter`) from the `agar` public API.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
~~* [ ] Docs ticket created (if applicable)~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FetchSpy, RequestMatcher, and RequestFilter utilities, exposed in the public API with HTTP method helpers (GET, POST, PUT, DELETE, PATCH).
  * FetchSpy observes requests, handles aborts, and restores the original fetch after use.
  * Matchers/filters perform case-insensitive method matching and path-based URL matching.

* **Tests**
  * Added browser tests covering FetchSpy behavior, request matching/filtering, HTTP method helpers, abort handling, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->