### PR TITLE
TINY-14494: remove unwanted code pattern from tests

### DIFF
--- a/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
+++ b/modules/tinymce/src/plugins/charmap/test/ts/browser/CharmapDialogHeightTest.ts
@@ -38,8 +38,12 @@ describe('browser.tinymce.plugins.charmap.DialogHeightTest', () => {
         UiControls.setValue(input, Value.get(input) + text, 'input');
       };
 
-      // Edge is being strange and focusing the body in this test but not when executed in isolation see #TINY-10579 for details
-      (isChromeEdge() ? it.skip : it)('TBA: Search for items, dialog height should not change when fewer items returned', async () => {
+      it('TBA: Search for items, dialog height should not change when fewer items returned', async function () {
+        // Edge is being strange and focusing the body in this test but not when executed in isolation see #TINY-10579 for details
+        if (isChromeEdge()) {
+          this.skip();
+          return;
+        }
         const editor = hook.editor();
         const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
         const body = SugarShadowDom.getContentContainer(root);

--- a/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
+++ b/modules/tinymce/src/plugins/codesample/test/ts/webdriver/CodeSampleCopyAndPasteTest.ts
@@ -48,7 +48,11 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     hook.editor().setContent('');
   });
 
-  (browser.isSafari() ? it.skip : it)('TINY-8861: press enter after pasting a code sample should not add a newline inside the code', async () => {
+  it('TINY-8861: press enter after pasting a code sample should not add a newline inside the code', async function () {
+    if (browser.isSafari()) {
+      this.skip();
+      return;
+    }
     const editor = hook.editor();
     editor.setContent('<p><br /></p><p><br /></p>');
     await TestUtils.pOpenDialogAndAssertInitial(hook.editor(), 'markup', '');
@@ -84,8 +88,12 @@ describe('webdriver.tinymce.plugins.codesample.CodeSampleCopyAndPasteTest', () =
     }));
   });
 
-  // Safari cannot select the CEF in this scenario, so we can't run the test (and there is no bug)
-  (browser.isSafari() ? it.skip : it)('TINY-8861: copying and pasting a piece of code and a text should leave the cursor on the text after paste', async () => {
+  it('TINY-8861: copying and pasting a piece of code and a text should leave the cursor on the text after paste', async function () {
+    // Safari cannot select the CEF in this scenario, so we can't run the test (and there is no bug)
+    if (browser.isSafari()) {
+      this.skip();
+      return;
+    }
     const editor = hook.editor();
     editor.setContent(
       '<pre class="language-markup" contenteditable="false" data-mce-highlighted="true">test content</pre>' +

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/ToolbarButtonContextTest.ts
@@ -1,5 +1,5 @@
 import { Keys, UiFinder, Waiter } from '@ephox/agar';
-import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { afterEach, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Type } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -565,8 +565,7 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
         });
       });
 
-      // Missing enabled property in menu/split toolbar button spec
-      (scenario.label === 'Menu toolbar button' || scenario.label === 'Split toolbar button' ? context.skip : context)('Toolbar button spec enabled: false', () => {
+      context('Toolbar button spec enabled: false', () => {
         const hook = TinyHooks.bddSetup<Editor>({
           base_url: '/project/tinymce/js/tinymce',
           toolbar: 't12',
@@ -575,6 +574,13 @@ describe('browser.tinymce.themes.silver.editor.toolbar.ToolbarButtonContextTest'
             scenario.buttonSetupAnyEnabledFalse(ed);
           }
         }, [], true);
+
+        before(function () {
+          // Missing enabled property in menu/split toolbar button spec
+          if (scenario.label === 'Menu toolbar button' || scenario.label === 'Split toolbar button') {
+            this.skip();
+          }
+        });
 
         it(`TINY-11211: Toolbar ${scenario.label} should be stay disabled when enabled: false`, async () => {
           const editor = hook.editor();


### PR DESCRIPTION
Related Ticket: TINY-14494

Description of Changes:

- Refactored tests skip logic to use `this.skip()` inside the test body instead of conditionally skipping the test with `(condition ? it.skip : it)()`

Pre-checks:

~~- [] Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test structure for browser-specific skip conditions across charmap, codesample, and toolbar button tests.

* **Refactor**
  * Improved test reliability by consolidating conditional skip logic within test bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->