### PR TITLE
TINY-14518: Expose dialog inset variables through skin

### DIFF
--- a/modules/oxide/src/less/theme/components/dialog/dialog.less
+++ b/modules/oxide/src/less/theme/components/dialog/dialog.less
@@ -2,6 +2,11 @@
 // Dialog
 //
 
+@dialog-wrap-inset-top: 0;
+@dialog-wrap-inset-right: 0;
+@dialog-wrap-inset-bottom: 0;
+@dialog-wrap-inset-left: 0;
+
 @dialog-backdrop-background-color: fade(@background-color, 75);
 @dialog-backdrop-background-color-opaque: @background-color;
 
@@ -79,13 +84,13 @@
 .tox {
   .tox-dialog-wrap {
     align-items: center;
-    bottom: 0;
     display: flex;
     justify-content: center;
-    left: 0;
     position: fixed;
-    right: 0;
-    top: 0;
+    top: @dialog-wrap-inset-top;
+    right: @dialog-wrap-inset-right;
+    bottom: @dialog-wrap-inset-bottom;
+    left: @dialog-wrap-inset-left;
     z-index: @z-index-dialogs;
   }
 


### PR DESCRIPTION
Related Ticket: TINY-14518

Description of Changes:
* Expose dialog inset variables through skin

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dialog positioning flexibility by introducing configurable inset values for dialog wrapper placement, while preserving existing visual appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->