### PR TITLE
TINY-14458: Add justify format rules for tiny-pageembed element

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/DefaultFormats.ts
@@ -66,7 +66,7 @@ const get = (editor: Editor): Formats => {
         preview: 'font-family font-size'
       },
       {
-        selector: '.mce-preview-object,[data-ephox-embed-iri]',
+        selector: '.mce-preview-object,[data-ephox-embed-iri],.tiny-pageembed',
         ceFalseOverride: true,
         styles: {
           float: 'left'
@@ -119,7 +119,7 @@ const get = (editor: Editor): Formats => {
         preview: 'font-family font-size'
       },
       {
-        selector: '.mce-preview-object',
+        selector: '.mce-preview-object,.tiny-pageembed',
         ceFalseOverride: true,
         styles: {
           display: 'table', // Needs to be `table` to properly render while editing
@@ -184,7 +184,7 @@ const get = (editor: Editor): Formats => {
         preview: 'font-family font-size'
       },
       {
-        selector: '.mce-preview-object,[data-ephox-embed-iri]',
+        selector: '.mce-preview-object,[data-ephox-embed-iri],.tiny-pageembed',
         ceFalseOverride: true,
         styles: {
           float: 'right'


### PR DESCRIPTION
Related Ticket: TINY-14458

Description of Changes:

- Added `.tiny-pageembed` to the float left, float right, and display format selectors so that page embed elements are included when applying alignment

Pre-checks:

~~- [ ] Changelog entry added~~ In the plugin PR
~~- [ ] Tests have been added (if applicable)~~ In the plugin PR
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Enhanced preview rendering for left/center/right alignment formatting when working with embedded page content, ensuring the alignment-specific preview selector also covers `.tiny-pageembed`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->