### PR TITLE
TINY-14384: Fix tooltip being clipped when hosted in a ShadowDOM

### DIFF
--- a/.changes/unreleased/tinymce-TINY-14384-2026-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-14384-2026-06-11.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Tooltip being clipped when the editor is hosted in ShadowDOM.
+body: Tooltips were clipped when the editor was hosted in a shadow DOM and its parent element had `overflow:scroll`.
 time: 2026-06-11T11:17:55.185451+09:30
 custom:
     Issue: TINY-14384

--- a/.changes/unreleased/tinymce-TINY-14384-2026-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-14384-2026-06-11.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Tooltip being clipped when the editor is hosted in a webcomponent.
+time: 2026-06-11T11:17:55.185451+09:30
+custom:
+    Issue: TINY-14384

--- a/.changes/unreleased/tinymce-TINY-14384-2026-06-11.yaml
+++ b/.changes/unreleased/tinymce-TINY-14384-2026-06-11.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Fixed
-body: Tooltip being clipped when the editor is hosted in a webcomponent.
+body: Tooltip being clipped when the editor is hosted in ShadowDOM.
 time: 2026-06-11T11:17:55.185451+09:30
 custom:
     Issue: TINY-14384

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -1,9 +1,9 @@
 import {
-  type AlloyComponent, AlloyEvents, type AlloyParts, type AlloySpec, Behaviour, type Boxes, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, type SimpleSpec, SystemEvents, VerticalDir
+  type AlloyComponent, AlloyEvents, type AlloyParts, type AlloySpec, Behaviour, Boxes, Disabling, Gui, GuiFactory, Keying, Memento, Positioning, type SimpleSpec, SystemEvents, VerticalDir
 } from '@ephox/alloy';
 import { Arr, Merger, Obj, Optional, Result, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Compare, Css, SugarBody, type SugarElement } from '@ephox/sugar';
+import { Compare, Css, SugarBody, SugarShadowDom, type SugarElement } from '@ephox/sugar';
 
 import type Editor from 'tinymce/core/api/Editor';
 import type { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
@@ -285,6 +285,16 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     };
   };
 
+  // TINY-14384:we want to restrict the bounds to the host element, rather than the entire window when the sink is attached in a webcomponent. Assume that the editor is also attached in the same webcomponent
+  const getSinkBounds = (sinkOpt: Optional<SinkAndMothership>) => sinkOpt.bind(
+    ({ sink }) => {
+      const rootNode = SugarShadowDom.getRootNode(sink.element);
+      if (SugarShadowDom.isShadowRoot(rootNode)) {
+        return Optional.some( Boxes.box(SugarShadowDom.getShadowHost(rootNode) as SugarElement<HTMLElement>));
+      }
+      return Optional.none();
+    }).getOr(Boxes.win());
+
   const renderDialogUi = () => {
     const uiContainer = Options.getUiContainer(editor);
 
@@ -301,8 +311,9 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       },
       behaviours: Behaviour.derive([
         Positioning.config({
-          useFixed: () => header.isDocked(lazyHeader)
-        })
+          useFixed: () => header.isDocked(lazyHeader),
+          getBounds: () => getSinkBounds(lazyUiRefs.dialogUi.get())
+        }),
       ])
     };
 

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -285,7 +285,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     };
   };
 
-  // TINY-14384:we want to restrict the bounds to the host element, rather than the entire window when the sink is attached in a webcomponent. Assume that the editor is also attached in the same webcomponent
+  // TINY-14384: we want to restrict the bounds to the host element, rather than the entire window when the sink is attached in a ShadowDOM (ie: webcomponent)
   const getSinkBounds = (sinkOpt: Optional<SinkAndMothership>) => sinkOpt.bind(
     ({ sink }) => {
       const rootNode = SugarShadowDom.getRootNode(sink.element);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipInShadowRoot.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipInShadowRoot.ts
@@ -2,7 +2,7 @@ import { Assertions, Waiter } from '@ephox/agar';
 import { Boxes } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Fun, Optional } from '@ephox/katamari';
-import { Css, Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
@@ -43,7 +43,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipInShadowDom', () => {
     }
   ], ({ label, settings }) => {
     context(`UI mode: ${label}`, () => {
-      let rootOpt = Optional.none<SugarElement<HTMLElement>>();
+      let rootOpt = Optional.none<SugarElement<Node & ChildNode>>();
 
       const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
         base_url: '/project/tinymce/js/tinymce',
@@ -67,13 +67,13 @@ describe('browser.tinymce.themes.silver.editor.TooltipInShadowDom', () => {
 
       before(async () => {
         const shadowRoot = hook.shadowRoot();
-        const container = SugarElement.fromTag('div', document);
-        rootOpt = Optional.from(container);
-        Css.setAll(container, { display: 'flex', width: '400px', height: '400px', overflow: 'scroll' });
-        const hostContainer = SugarElement.fromTag('div', document);
-        Css.setAll(hostContainer, { 'padding-left': '50px', 'overflow': 'auto' });
-
+        const container = SugarElement.fromHtml('<div style="display: flex; width: 400px; height: 400px;"></div>');
+        const sidePanel = SugarElement.fromHtml('<div style="width: 200px; background-color: red;">Side Panel</div>');
+        const hostContainer = SugarElement.fromHtml('<div style="padding: left; overflow: scroll;"></div>');
         const hostElement = SugarShadowDom.getShadowHost(shadowRoot);
+        rootOpt = Optional.from(container);
+
+        Insert.append(container, sidePanel);
         Insert.append(container, hostContainer);
         Insert.append(SugarBody.body(), container);
         Insert.append(hostContainer, hostElement);

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipInShadowRoot.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipInShadowRoot.ts
@@ -1,0 +1,93 @@
+import { Assertions, Waiter } from '@ephox/agar';
+import { Boxes } from '@ephox/alloy';
+import { after, before, context, describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { Css, Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
+import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+import * as TooltipUtils from '../../module/TooltipUtils';
+
+describe('browser.tinymce.themes.silver.editor.TooltipInShadowDom', () => {
+  const withinBounds = (innerBound: Boxes.Bounds, outerBound: Boxes.Bounds) =>
+    innerBound.x >= outerBound.x
+    && innerBound.y >= outerBound.y
+    && innerBound.bottom <= outerBound.bottom
+    && innerBound.right <= outerBound.right;
+
+  const pAssertTooltipWithinEditorHostBound = async (editor: Editor) => {
+    const tooltipSelector = '.tox-silver-sink .tox-tooltip__body';
+    const buttonSelector = 'button[data-mce-name="first-button"]';
+    await TooltipUtils.pTriggerTooltipWithMouse(editor, buttonSelector);
+    const tooltip = await TinyUiActions.pWaitForUi(editor, tooltipSelector) as SugarElement<HTMLElement>;
+    const tooltipBound = Boxes.box(tooltip);
+    const rootNode = SugarShadowDom.getShadowRoot(TinyDom.container(editor));
+    const rootBound = Boxes.box(SugarShadowDom.getShadowHost(rootNode.getOrDie()) as SugarElement<HTMLElement>);
+    Assertions.assertEq('Tooltip should be positioned within the editor\'s host bound', true, withinBounds(tooltipBound, rootBound));
+    await TooltipUtils.pCloseTooltip(editor, buttonSelector);
+  };
+
+  Arr.each([
+    {
+      label: 'split',
+      settings: {
+        ui_mode: 'split'
+      }
+    },
+    {
+      label: 'combined',
+      settings: {
+        ui_mode: 'combined'
+      }
+    }
+  ], ({ label, settings }) => {
+    context(`UI mode: ${label}`, () => {
+      let containerRef: SugarElement<HTMLElement> | undefined;
+
+      const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'first-button second-button',
+        width: 400,
+        ...settings,
+        setup: (ed: Editor) => {
+          ed.ui.registry.addButton('first-button', {
+            text: 'First button',
+            tooltip: 'A very very long tooltip',
+            onAction: Fun.noop
+          });
+
+          ed.ui.registry.addButton('second-button', {
+            text: 'Second Button',
+            tooltip: 'Second Button',
+            onAction: Fun.noop
+          });
+        },
+      }, []);
+
+      before(async () => {
+        const shadowRoot = hook.shadowRoot();
+        const container = SugarElement.fromTag('div', document);
+        containerRef = container;
+        Css.setAll(container, { display: 'flex', width: '400px', height: '400px', overflow: 'scroll' });
+        const hostContainer = SugarElement.fromTag('div', document);
+        Css.setAll(hostContainer, { 'padding-left': '50px', 'overflow': 'auto' });
+
+        const hostElement = SugarShadowDom.getShadowHost(shadowRoot);
+        Insert.append(container, hostContainer);
+        Insert.append(SugarBody.body(), container);
+        Insert.append(hostContainer, hostElement);
+        // wait for the UI to be updated
+        await Waiter.pWait(100);
+      });
+
+      after(() => {
+        Remove.remove(containerRef as any);
+      });
+
+      it('TINY-14384: Tooltip should be rendered within the boundary of the shadow dom host', async () => {
+        await pAssertTooltipWithinEditorHostBound(hook.editor());
+      });
+    });
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipInShadowRoot.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/TooltipInShadowRoot.ts
@@ -1,7 +1,7 @@
 import { Assertions, Waiter } from '@ephox/agar';
 import { Boxes } from '@ephox/alloy';
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Optional } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarBody, SugarElement, SugarShadowDom } from '@ephox/sugar';
 import { TinyDom, TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -43,7 +43,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipInShadowDom', () => {
     }
   ], ({ label, settings }) => {
     context(`UI mode: ${label}`, () => {
-      let containerRef: SugarElement<HTMLElement> | undefined;
+      let rootOpt = Optional.none<SugarElement<HTMLElement>>();
 
       const hook = TinyHooks.bddSetupInShadowRoot<Editor>({
         base_url: '/project/tinymce/js/tinymce',
@@ -68,7 +68,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipInShadowDom', () => {
       before(async () => {
         const shadowRoot = hook.shadowRoot();
         const container = SugarElement.fromTag('div', document);
-        containerRef = container;
+        rootOpt = Optional.from(container);
         Css.setAll(container, { display: 'flex', width: '400px', height: '400px', overflow: 'scroll' });
         const hostContainer = SugarElement.fromTag('div', document);
         Css.setAll(hostContainer, { 'padding-left': '50px', 'overflow': 'auto' });
@@ -82,7 +82,7 @@ describe('browser.tinymce.themes.silver.editor.TooltipInShadowDom', () => {
       });
 
       after(() => {
-        Remove.remove(containerRef as any);
+        rootOpt.each(Remove.remove);
       });
 
       it('TINY-14384: Tooltip should be rendered within the boundary of the shadow dom host', async () => {


### PR DESCRIPTION
Related Ticket: TINY-14384

Description of Changes:
* When the editor is hosted inside a ShadowDOM, set the bounds of the dialog sink to the host element so the tooltip will not be positioned/grown outside
* Added a test file for this specific case

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where editor tooltips could be clipped or positioned incorrectly when the editor is hosted in Shadow DOM with scrollable parent elements, by keeping tooltip placement within the shadow-root host bounds.

* **Tests**
  * Added a new browser test to confirm tooltips stay within the shadow-root host for both supported UI modes, including Shadow DOM setup and bounds validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->