### PR TITLE
TINY-12791: Added delay for first aria message

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
+++ b/modules/tinymce/src/core/main/ts/api/dom/AriaAnnouncer.ts
@@ -1,3 +1,5 @@
+import { Fun } from '@ephox/katamari';
+
 import * as Announcer from '../../aria/Announcer';
 
 /**
@@ -36,9 +38,9 @@ const announcer = Announcer.createAnnouncer();
  */
 const announce = (message: string, options?: { assertive?: boolean }): void => {
   if (options?.assertive === true) {
-    announcer.assertive(message);
+    announcer.assertive(message).catch(Fun.noop);
   } else {
-    announcer.polite(message);
+    announcer.polite(message).catch(Fun.noop);
   }
 };
 

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -81,7 +81,15 @@ export const createAnnouncer = (): Announcer => {
       createNewPendingState,
       async (existingPromise) => {
         const { container } = await existingPromise;
-        return isConnected(container) ? existingPromise : createNewPendingState();
+
+        if (isConnected(container)) {
+          return existingPromise;
+        } else {
+          // A concurrent caller may have already replaced the stale state while we awaited.
+          // The block after the await runs atomically, so reuse that state if present and
+          // only create a fresh one when the state is still the stale promise we observed.
+          return state.get().filter((current) => current !== existingPromise).getOrThunk(createNewPendingState);
+        }
       }
     );
   };

--- a/modules/tinymce/src/core/main/ts/aria/Announcer.ts
+++ b/modules/tinymce/src/core/main/ts/aria/Announcer.ts
@@ -4,11 +4,12 @@ import { Attribute, Css, Insert, Remove, SelectorFilter, SugarBody, SugarElement
 export const announcerContainerId = Id.generate('tiny-aria-announcer');
 
 const POLITE_MESSAGE_TTL_MS = 600000; // 10 minutes
+const CREATE_DELAY_MS = 100; // Delay before creating announcer regions to avoid interfering with screen readers initial announcements.
 const politeTimestampAttr = 'data-mce-announced-at';
 
 export interface Announcer {
-  readonly polite: (message: string) => void;
-  readonly assertive: (message: string) => void;
+  readonly polite: (message: string) => Promise<void>;
+  readonly assertive: (message: string) => Promise<void>;
 }
 
 interface AnnouncerState {
@@ -62,14 +63,27 @@ const cleanupExpiredMessages = (polite: SugarElement<HTMLDivElement>, now: numbe
 };
 
 export const createAnnouncer = (): Announcer => {
-  const state = Singleton.value<AnnouncerState>();
+  const state = Singleton.value<Promise<AnnouncerState>>();
 
-  const mountRegions = () => {
-    return state.get().filter(({ container }) => isConnected(container)).getOrThunk(() => {
-      const newState = createNewState();
-      state.set(newState);
-      return newState;
-    });
+  const mountRegions = async () => {
+    const createNewPendingState = async () => {
+      const promise = new Promise<AnnouncerState>((resolve) => {
+        const newState = createNewState();
+        setTimeout(() => resolve(newState), CREATE_DELAY_MS);
+      });
+
+      state.set(promise);
+
+      return promise;
+    };
+
+    return state.get().fold(
+      createNewPendingState,
+      async (existingPromise) => {
+        const { container } = await existingPromise;
+        return isConnected(container) ? existingPromise : createNewPendingState();
+      }
+    );
   };
 
   const addMessage = (region: SugarElement<HTMLDivElement>, message: string): void => {
@@ -83,12 +97,14 @@ export const createAnnouncer = (): Announcer => {
     Insert.append(region, messageDiv);
   };
 
-  const polite = (message: string): void => {
-    addMessage(mountRegions().politeRegion, message);
+  const polite = async (message: string): Promise<void> => {
+    const { politeRegion } = await mountRegions();
+    addMessage(politeRegion, message);
   };
 
-  const assertive = (message: string): void => {
-    addMessage(mountRegions().assertiveRegion, message);
+  const assertive = async (message: string): Promise<void> => {
+    const { assertiveRegion } = await mountRegions();
+    addMessage(assertiveRegion, message);
   };
 
   return { polite, assertive };

--- a/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/AriaAnnouncerTest.ts
@@ -1,7 +1,7 @@
 import { UiFinder, Waiter } from '@ephox/agar';
 import { afterEach, describe, it } from '@ephox/bedrock-client';
 import { Arr, Type } from '@ephox/katamari';
-import { Attribute, Css, Insert, Remove, SelectorFind, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
+import { Attribute, Css, Insert, Remove, SelectorFilter, SelectorFind, SugarBody, SugarElement, TextContent } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import AriaAnnouncer from 'tinymce/core/api/dom/AriaAnnouncer';
@@ -70,6 +70,34 @@ describe('browser.tinymce.core.AriaAnnouncerTest', () => {
     await pMessage(container, 'assertive', 'Urgent');
 
     await pMessage(container, 'polite', 'Polite message');
+  });
+
+  describe('Concurrent recreation after disconnect', () => {
+    const countContainers = (): number =>
+      SelectorFilter.descendants(SugarBody.body(), containerSelector).length;
+
+    it('TINY-12791: Concurrent announces after the container is disconnected recreate exactly one container', async () => {
+      const announcer = Announcer.createAnnouncer();
+
+      // Disconnect the container to leave the singleton holding stale state.
+      await announcer.polite('Initial');
+      const container = await pGetContainer();
+      Remove.remove(container);
+      assert.equal(countContainers(), 0, 'stale container should have been removed');
+
+      // Both callers observe the stale state and race to recreate it.
+      await Promise.all([
+        announcer.polite('Concurrent A'),
+        announcer.assertive('Concurrent B')
+      ]);
+
+      assert.equal(countContainers(), 1, 'concurrent recreation should produce exactly one container');
+
+      // The recreated container should be usable for both regions.
+      const recreated = await pGetContainer();
+      await pMessage(recreated, 'polite', 'Concurrent A');
+      await pMessage(recreated, 'assertive', 'Concurrent B');
+    });
   });
 
   describe('Polite region', () => {


### PR DESCRIPTION
Related Ticket: TINY-12791

Description of Changes:
* Changes so that the initial message has a short delay adding the region and the message at the same time prevents screen readers from picking it up.

Pre-checks:
* [x] ~~Changelog entry added~~
* [x] ~~Tests have been added (if applicable)~~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardened accessibility announcements by suppressing rejected announcement promises.
  * Improved announcer region creation and lifecycle handling, including consistent remounting and reuse after disconnects (with delayed region setup).

* **New Features**
  * Updated the announcer API so `polite` and `assertive` are asynchronous (`Promise<void>`), ensuring announcements are queued after the region is ready.

* **Tests**
  * Added coverage for concurrent `polite`/`assertive` calls after an announcer disconnect, verifying a single region recreation and both messages are rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->