### PR TITLE
TINYMCE-14489: Avoid resubscribing keyboard events when callbacks change

### DIFF
--- a/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
+++ b/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
@@ -1,4 +1,4 @@
-import { Fun } from '@ephox/katamari';
+import { Fun, Optional } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 
@@ -34,19 +34,30 @@ export interface TabKeyNavigationApi {
 
 export const useTabKeyNavigation = (props: TabKeyingProps): TabKeyNavigationApi => {
   const goBackwardsRef = useRef<() => void>(Fun.noop);
+  const propsRef = useRef(props);
+  propsRef.current = props;
+  const { containerRef } = props;
 
   useEffect(() => {
-    const { containerRef } = props;
-
     if (containerRef.current) {
-      const handlers = TabbingType.create(SugarElement.fromDom(containerRef.current), props);
+      const wrappedProps: TabbingType.TabbingConfig = {
+        selector: propsRef.current.selector,
+        ...(propsRef.current.execute && { execute: (focused) => propsRef.current.execute?.(focused) ?? Optional.none() }),
+        ...(propsRef.current.escape && { escape: (focused) => propsRef.current.escape?.(focused) ?? Optional.none() }),
+        ...(propsRef.current.firstTabstop !== undefined && { firstTabstop: propsRef.current.firstTabstop }),
+        ...(propsRef.current.useTabstopAt && { useTabstopAt: (elem) => propsRef.current.useTabstopAt?.(elem) ?? true }),
+        ...(propsRef.current.cyclic !== undefined && { cyclic: propsRef.current.cyclic }),
+        ...(propsRef.current.focusIn !== undefined && { focusIn: propsRef.current.focusIn }),
+        ...(propsRef.current.closest !== undefined && { closest: propsRef.current.closest }),
+      };
+      const handlers = TabbingType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       goBackwardsRef.current = handlers.goBackwards;
       return bindEvents(containerRef.current, handlers);
     } else {
       goBackwardsRef.current = Fun.noop;
       return Fun.noop;
     }
-  }, [ props ]);
+  }, [ containerRef ]);
 
   const goBackwardsCallback = useCallback(() => goBackwardsRef.current(), []);
   return { goBackwards: goBackwardsCallback };
@@ -55,31 +66,57 @@ export const useTabKeyNavigation = (props: TabKeyingProps): TabKeyNavigationApi 
 export interface FlowKeyingProps extends BaseProps, FlowType.FlowConfig { }
 
 export const useFlowKeyNavigation = (props: FlowKeyingProps): void => {
-  useEffect(() => {
-    const { containerRef } = props;
+  const propsRef = useRef(props);
+  propsRef.current = props;
+  const { containerRef } = props;
 
+  useEffect(() => {
     if (containerRef.current) {
-      const handlers = FlowType.create(SugarElement.fromDom(containerRef.current), props);
+      const wrappedProps: FlowType.FlowConfig = {
+        selector: propsRef.current.selector,
+        ...(propsRef.current.execute && { execute: (focused) => propsRef.current.execute?.(focused) ?? Optional.none() }),
+        ...(propsRef.current.escape && { escape: (focused) => propsRef.current.escape?.(focused) ?? Optional.none() }),
+        ...(propsRef.current.allowVertical !== undefined && { allowVertical: propsRef.current.allowVertical }),
+        ...(propsRef.current.allowHorizontal !== undefined && { allowHorizontal: propsRef.current.allowHorizontal }),
+        ...(propsRef.current.cycles !== undefined && { cycles: propsRef.current.cycles }),
+        ...(propsRef.current.focusIn !== undefined && { focusIn: propsRef.current.focusIn }),
+        ...(propsRef.current.closest !== undefined && { closest: propsRef.current.closest }),
+      };
+      const handlers = FlowType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       return bindEvents(containerRef.current, handlers);
     } else {
       return Fun.noop;
     }
-  }, [ props ]);
+  }, [ containerRef ]);
 };
 
 export interface SpecialKeyingProps extends BaseProps, SpecialType.SpecialConfig { }
 
 export const useSpecialKeyNavigation = (props: SpecialKeyingProps): void => {
-  useEffect(() => {
-    const { containerRef } = props;
+  const propsRef = useRef(props);
+  propsRef.current = props;
+  const { containerRef } = props;
 
+  useEffect(() => {
     if (containerRef.current) {
-      const handlers = SpecialType.create(SugarElement.fromDom(containerRef.current), props);
+      const wrappedProps: SpecialType.SpecialConfig = {
+        ...(propsRef.current.onSpace && { onSpace: () => propsRef.current.onSpace?.() }),
+        ...(propsRef.current.onEnter && { onEnter: () => propsRef.current.onEnter?.() }),
+        ...(propsRef.current.onTab && { onTab: () => propsRef.current.onTab?.() }),
+        ...(propsRef.current.onShiftTab && { onShiftTab: () => propsRef.current.onShiftTab?.() }),
+        ...(propsRef.current.onShiftEnter && { onShiftEnter: () => propsRef.current.onShiftEnter?.() }),
+        ...(propsRef.current.onLeft && { onLeft: () => propsRef.current.onLeft?.() }),
+        ...(propsRef.current.onRight && { onRight: () => propsRef.current.onRight?.() }),
+        ...(propsRef.current.onUp && { onUp: () => propsRef.current.onUp?.() }),
+        ...(propsRef.current.onDown && { onDown: () => propsRef.current.onDown?.() }),
+        ...(propsRef.current.onEscape && { onEscape: () => propsRef.current.onEscape?.() }),
+      };
+      const handlers = SpecialType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       return bindEvents(containerRef.current, handlers);
     } else {
       return Fun.noop;
     }
-  }, [ props ]);
+  }, [ containerRef ]);
 };
 
 export interface ExecutingConfig extends BaseProps, ExecutingType.ExecutingConfig { }
@@ -101,14 +138,19 @@ export const useExecutionType = (props: ExecutingConfig): void => {
 export interface EscapeKeyProps extends BaseProps, EscapingType.EscapingConfig { }
 
 export const useEscapeKeyNavigation = (props: EscapeKeyProps): void => {
-  useEffect(() => {
-    const { containerRef } = props;
+  const propsRef = useRef(props);
+  propsRef.current = props;
+  const { containerRef } = props;
 
+  useEffect(() => {
     if (containerRef.current) {
-      const handlers = EscapingType.create(SugarElement.fromDom(containerRef.current), props);
+      const wrappedProps: EscapingType.EscapingConfig = {
+        onEscape: (comp, event) => propsRef.current.onEscape(comp, event),
+      };
+      const handlers = EscapingType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       return bindEvents(containerRef.current, handlers);
     } else {
       return Fun.noop;
     }
-  }, [ props ]);
+  }, [ containerRef ]);
 };

--- a/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
+++ b/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
@@ -41,14 +41,10 @@ export const useTabKeyNavigation = (props: TabKeyingProps): TabKeyNavigationApi 
   useEffect(() => {
     if (containerRef.current) {
       const wrappedProps: TabbingType.TabbingConfig = {
-        selector: propsRef.current.selector,
-        ...(propsRef.current.execute && { execute: (focused) => propsRef.current.execute?.(focused) ?? Optional.none() }),
-        ...(propsRef.current.escape && { escape: (focused) => propsRef.current.escape?.(focused) ?? Optional.none() }),
-        ...(propsRef.current.firstTabstop !== undefined && { firstTabstop: propsRef.current.firstTabstop }),
-        ...(propsRef.current.useTabstopAt && { useTabstopAt: (elem) => propsRef.current.useTabstopAt?.(elem) ?? true }),
-        ...(propsRef.current.cyclic !== undefined && { cyclic: propsRef.current.cyclic }),
-        ...(propsRef.current.focusIn !== undefined && { focusIn: propsRef.current.focusIn }),
-        ...(propsRef.current.closest !== undefined && { closest: propsRef.current.closest }),
+        ...propsRef.current,
+        execute: (focused) => Optional.from(propsRef.current.execute).map((f) => f(focused)).getOr(Optional.none()),
+        escape: (focused) => Optional.from(propsRef.current.escape).map((f) => f(focused)).getOr(Optional.none()),
+        useTabstopAt: (elem) => Optional.from(propsRef.current.useTabstopAt).map((f) => f(elem)).getOr(true),
       };
       const handlers = TabbingType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       goBackwardsRef.current = handlers.goBackwards;
@@ -73,14 +69,9 @@ export const useFlowKeyNavigation = (props: FlowKeyingProps): void => {
   useEffect(() => {
     if (containerRef.current) {
       const wrappedProps: FlowType.FlowConfig = {
-        selector: propsRef.current.selector,
-        ...(propsRef.current.execute && { execute: (focused) => propsRef.current.execute?.(focused) ?? Optional.none() }),
-        ...(propsRef.current.escape && { escape: (focused) => propsRef.current.escape?.(focused) ?? Optional.none() }),
-        ...(propsRef.current.allowVertical !== undefined && { allowVertical: propsRef.current.allowVertical }),
-        ...(propsRef.current.allowHorizontal !== undefined && { allowHorizontal: propsRef.current.allowHorizontal }),
-        ...(propsRef.current.cycles !== undefined && { cycles: propsRef.current.cycles }),
-        ...(propsRef.current.focusIn !== undefined && { focusIn: propsRef.current.focusIn }),
-        ...(propsRef.current.closest !== undefined && { closest: propsRef.current.closest }),
+        ...propsRef.current,
+        execute: (focused) => Optional.from(propsRef.current.execute).map((f) => f(focused)).getOr(Optional.none()),
+        escape: (focused) => Optional.from(propsRef.current.escape).map((f) => f(focused)).getOr(Optional.none()),
       };
       const handlers = FlowType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       return bindEvents(containerRef.current, handlers);

--- a/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
+++ b/modules/oxide-components/src/main/ts/keynav/KeyboardNavigationHooks.ts
@@ -70,8 +70,8 @@ export const useFlowKeyNavigation = (props: FlowKeyingProps): void => {
     if (containerRef.current) {
       const wrappedProps: FlowType.FlowConfig = {
         ...propsRef.current,
-        execute: (focused) => Optional.from(propsRef.current.execute).map((f) => f(focused)).getOr(Optional.none()),
-        escape: (focused) => Optional.from(propsRef.current.escape).map((f) => f(focused)).getOr(Optional.none()),
+        ...(propsRef.current.execute && { execute: (focused) => Optional.from(propsRef.current.execute).map((f) => f(focused)).getOr(Optional.none()) }),
+        ...(propsRef.current.escape && { escape: (focused) => Optional.from(propsRef.current.escape).map((f) => f(focused)).getOr(Optional.none()) }),
       };
       const handlers = FlowType.create(SugarElement.fromDom(containerRef.current), wrappedProps);
       return bindEvents(containerRef.current, handlers);

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/TabbingType.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/TabbingType.ts
@@ -126,14 +126,14 @@ export interface TabbingHandlers extends KeyingType.Handlers {
 
 const create = (source: SugarElement<HTMLElement>, config: TabbingConfig): TabbingHandlers => {
   const partialConfig: Required<TabbingConfig> = {
-    execute: Fun.constant(Optional.none()),
-    escape: Fun.constant(Optional.none()),
-    firstTabstop: 0,
-    useTabstopAt: Fun.always,
-    cyclic: true,
-    focusIn: false,
-    closest: true,
-    ...config
+    selector: config.selector,
+    execute: config.execute ?? Fun.constant(Optional.none()),
+    escape: config.escape ?? Fun.constant(Optional.none()),
+    firstTabstop: config.firstTabstop ?? 0,
+    useTabstopAt: config.useTabstopAt ?? Fun.always,
+    cyclic: config.cyclic ?? true,
+    focusIn: config.focusIn ?? false,
+    closest: config.closest ?? true
   };
 
   const fullConfig: FullTabbingConfig = {

--- a/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.ts
+++ b/modules/oxide-components/src/main/ts/keynav/keyboard/flowtype/FlowType.ts
@@ -87,16 +87,15 @@ export const create = (source: SugarElement<HTMLElement>, config: FlowConfig): K
 
   const getKeyupRules: () => Array<KeyRules.KeyRule<FlowConfig>> = Fun.constant([]);
 
-  // Default to whatever needed for this task
   const partialConfig: Required<FlowConfig> = {
-    execute: defaultExecute,
-    escape: Fun.constant(Optional.none()),
-    allowVertical: true,
-    allowHorizontal: true,
-    cycles: true,
-    focusIn: false,
-    closest: true,
-    ...config
+    selector: config.selector,
+    execute: config.execute ?? defaultExecute,
+    escape: config.escape ?? Fun.constant(Optional.none()),
+    allowVertical: config.allowVertical ?? true,
+    allowHorizontal: config.allowHorizontal ?? true,
+    cycles: config.cycles ?? true,
+    focusIn: config.focusIn ?? false,
+    closest: config.closest ?? true
   };
 
   const keyingHandlers = KeyingType.typical<FullFlowConfig>(partialConfig, getKeydownRules, getKeyupRules, () => Optionals.someIf(partialConfig.focusIn, focusIn));

--- a/modules/oxide-components/src/test/ts/browser/keynav/SpecialType.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/keynav/SpecialType.spec.tsx
@@ -73,7 +73,7 @@ describe('KeynavSpecialTypeTest', () => {
 
   });
 
-  it('Should call updated callbacks without re-subscribing', async () => {
+  it('TINYMCE-14489: Should call updated callbacks without re-subscribing', async () => {
 
     const Container = () => {
       const ref = useRef<HTMLDivElement>(null);

--- a/modules/oxide-components/src/test/ts/browser/keynav/SpecialType.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/keynav/SpecialType.spec.tsx
@@ -1,6 +1,6 @@
 import { Optional } from '@ephox/katamari';
 import { useSpecialKeyNavigation } from 'oxide-components/keynav/KeyboardNavigationHooks';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
@@ -70,6 +70,63 @@ describe('KeynavSpecialTypeTest', () => {
     await press('down', '{ArrowDown}');
     await press('right', '{ArrowRight}');
     await press('escape', '{Escape}');
+
+  });
+
+  it('Should call updated callbacks without re-subscribing', async () => {
+
+    const Container = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      const [ count, setCount ] = useState(0);
+
+      useSpecialKeyNavigation({
+        containerRef: ref,
+        onEnter: () => {
+          store.push(`enter-${count}`);
+        },
+        onSpace: () => {
+          setCount((c) => c + 1);
+        }
+      });
+
+      return (
+        <div
+          ref={ref}
+          className="special-keying"
+          data-testid="container"
+          tabIndex={-1}
+          style={{
+            width: '100px',
+            height: '100px',
+            border: '1px solid black'
+          }}
+        >
+          Count: {count}
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(<Container />, {
+      wrapper: ({ children }) => <div className='tox'>{children}</div>
+    });
+
+    const container = getByTestId('container');
+    await userEvent.click(container);
+    await expect.element(container).toHaveFocus();
+
+    clearStore();
+    await userEvent.keyboard('{Enter}');
+    expect(store, 'Initial enter should log count 0').toEqual([ 'enter-0' ]);
+
+    clearStore();
+    await userEvent.keyboard(' ');
+    await userEvent.keyboard('{Enter}');
+    expect(store, 'After incrementing, enter should log count 1').toEqual([ 'enter-1' ]);
+
+    clearStore();
+    await userEvent.keyboard(' ');
+    await userEvent.keyboard('{Enter}');
+    expect(store, 'After incrementing again, enter should log count 2').toEqual([ 'enter-2' ]);
 
   });
 });


### PR DESCRIPTION
Related Ticket: [TINYMCE-14489](https://tiugotech.atlassian.net/browse/TINYMCE-14489)

Description of Changes:
* Refactored keyboard navigation hooks to use internal refs for callbacks so they don't re-subscribe to events when callbacks change. This means consumers can pass callbacks directly without needing useCallback or ref workarounds.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINYMCE-14489]: https://tiugotech.atlassian.net/browse/TINYMCE-14489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated keyboard navigation so Enter/Space/Tab/Escape and flow/special key handling always uses the latest callbacks from the currently focused component state.
  * Improved optional handler handling across Tab/Flow/Escape/special navigation to reliably fall back to safe defaults when callbacks are not provided.
* **Tests**
  * Added a browser test covering repeated Enter/Space interactions to verify state-driven callbacks are reflected correctly on subsequent key presses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->