### PR TITLE
TINYMCE-14490: fix  edge case of `TINY-13886`

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-14490-2026-06-30.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-14490-2026-06-30.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Worked around an edge case of a Chromium bug where clicking on the right of
+  an `li` could fail.
+time: 2026-06-30T11:28:04.75448296+02:00
+custom:
+  Issue: TINYMCE-14490

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -744,19 +744,27 @@ const Quirks = (editor: Editor): Quirks => {
     editor.on('mousedown', (e) => {
       const target = SugarElement.fromDom(e.target);
       if (isListItem(target)) {
-        firstBlockChildOrNewLine(target).each((firstBlock) => {
-          const prevSiblings = Traverse.prevSiblings(firstBlock);
+        firstBlockChildOrNewLine(target).fold(
+          () => {
+            CaretFinder.lastPositionIn(target.dom).each((pos) => {
+              e.preventDefault();
+              editor.focus();
+              editor.selection.setRng(pos.toRange());
+            });
+          },
+          (firstBlock) => {
+            const prevSiblings = Traverse.prevSiblings(firstBlock);
 
-          Arr.findLast(prevSiblings, isValidSibling).each((lastInlineBeforeBlock) => {
-            if (Arr.get(getClientRects([ lastInlineBeforeBlock.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
-              CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => {
-                e.preventDefault();
-                editor.focus();
-                editor.selection.setRng(pos.toRange());
-              });
-            }
+            Arr.findLast(prevSiblings, isValidSibling).each((lastInlineBeforeBlock) => {
+              if (Arr.get(getClientRects([ lastInlineBeforeBlock.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
+                CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => {
+                  e.preventDefault();
+                  editor.focus();
+                  editor.selection.setRng(pos.toRange());
+                });
+              }
+            });
           });
-        });
       }
     });
   };

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -759,9 +759,7 @@ const Quirks = (editor: Editor): Quirks => {
             });
           },
           (firstBlock) => {
-            const prevSiblings = Traverse.prevSiblings(firstBlock);
-
-            Arr.findLast(prevSiblings, isValidSibling).each((lastInlineBeforeBlock) => {
+            Arr.findLast(Traverse.prevSiblings(firstBlock), isValidSibling).each((lastInlineBeforeBlock) => {
               if (clickAfterEl(e.clientX, e.clientY, lastInlineBeforeBlock)) {
                 CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => selectPos(editor, e, pos));
               }

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -746,10 +746,14 @@ const Quirks = (editor: Editor): Quirks => {
       if (isListItem(target)) {
         firstBlockChildOrNewLine(target).fold(
           () => {
-            CaretFinder.lastPositionIn(target.dom).each((pos) => {
-              e.preventDefault();
-              editor.focus();
-              editor.selection.setRng(pos.toRange());
+            Traverse.lastChild(target).each((lastChild) => {
+              if (Arr.get(getClientRects([ lastChild.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
+                CaretFinder.lastPositionIn(target.dom).each((pos) => {
+                  e.preventDefault();
+                  editor.focus();
+                  editor.selection.setRng(pos.toRange());
+                });
+              }
             });
           },
           (firstBlock) => {

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -12,7 +12,7 @@ import * as CaretContainer from '../caret/CaretContainer';
 import * as CaretFinder from '../caret/CaretFinder';
 import { CaretPosition } from '../caret/CaretPosition';
 import * as SymulateDelete from '../delete/SymulateDelete';
-import { getClientRects, type NodeClientRect } from '../dom/Dimensions';
+import { getClientRects } from '../dom/Dimensions';
 import * as ElementType from '../dom/ElementType';
 import { isListItem } from '../dom/ElementType';
 import * as Empty from '../dom/Empty';
@@ -731,8 +731,14 @@ const Quirks = (editor: Editor): Quirks => {
   const firstBlockChildOrNewLine = (target: SugarElement<Node>) =>
     PredicateFind.child(target, (child) => ElementType.isBr(child) || SugarNode.isElement(child) && Css.get(child, 'display') === 'block');
 
-  const clickAfterEl = (clientX: number, clientY: number, rect: NodeClientRect): boolean =>
-    clientX >= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+  const clickAfterEl = (clientX: number, clientY: number, el: SugarElement<Node>): boolean =>
+    Arr.get(getClientRects([ el.dom ]), 0).exists((rect) => clientX >= rect.right && clientY >= rect.top && clientY <= rect.bottom);
+
+  const selectPos = (editor: Editor, e: EditorEvent<MouseEvent>, pos: CaretPosition): void => {
+    e.preventDefault();
+    editor.focus();
+    editor.selection.setRng(pos.toRange());
+  };
 
   /**
    * In Chrome in a `LI` that contains a block element and where the first child is an inline element
@@ -747,12 +753,8 @@ const Quirks = (editor: Editor): Quirks => {
         firstBlockChildOrNewLine(target).fold(
           () => {
             Traverse.lastChild(target).each((lastChild) => {
-              if (Arr.get(getClientRects([ lastChild.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
-                CaretFinder.lastPositionIn(target.dom).each((pos) => {
-                  e.preventDefault();
-                  editor.focus();
-                  editor.selection.setRng(pos.toRange());
-                });
+              if (clickAfterEl(e.clientX, e.clientY, lastChild)) {
+                CaretFinder.lastPositionIn(target.dom).each((pos) => selectPos(editor, e, pos));
               }
             });
           },
@@ -760,12 +762,8 @@ const Quirks = (editor: Editor): Quirks => {
             const prevSiblings = Traverse.prevSiblings(firstBlock);
 
             Arr.findLast(prevSiblings, isValidSibling).each((lastInlineBeforeBlock) => {
-              if (Arr.get(getClientRects([ lastInlineBeforeBlock.dom ]), 0).exists((rect) => clickAfterEl(e.clientX, e.clientY, rect))) {
-                CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => {
-                  e.preventDefault();
-                  editor.focus();
-                  editor.selection.setRng(pos.toRange());
-                });
+              if (clickAfterEl(e.clientX, e.clientY, lastInlineBeforeBlock)) {
+                CaretFinder.prevPosition(target.dom, CaretPosition(firstBlock.dom, 0)).each((pos) => selectPos(editor, e, pos));
               }
             });
           });

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
@@ -1,8 +1,9 @@
+import { Keys } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
 import Plugin from 'tinymce/plugins/accordion/Plugin';
@@ -35,8 +36,6 @@ describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
   });
 
   const testClickOnRightSideOfLI = async (editor: Editor, { content, path, offset }: { content: string; path: number[]; offset: number }) => {
-    editor.setContent(content);
-
     const li = editor.dom.select('li')[0];
     const firstChild = SugarElement.fromDom(li.firstChild as Node);
     const textNode = SugarNode.isText(firstChild) ? firstChild.dom : PredicateFind.descendant(firstChild, SugarNode.isText).getOrDie().dom;
@@ -101,7 +100,26 @@ describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
     )(`TINY-13886: clicking on the right of the first element (which must be an inline element) of li that also have a block element inside should place the caret at the end of the first element (${i}, ${content})`,
       async () => {
         const editor = hook.editor();
+        editor.setContent(content);
         await testClickOnRightSideOfLI(editor, { content, path, offset });
       });
+  });
+
+  it(`TINYMCE-14490: inserting a new li pressing enter in an li that also has a block element inside and clicking on the right of the first li the caret should be at the end of the element`, async () => {
+    const editor = hook.editor();
+    const content = [ '<ol>' +
+      '<li>abc' +
+        '<ol>' +
+          '<li>first</li>' +
+          '<li>second</li>' +
+        '</ol>' +
+      '</li>' +
+    '</ol>' ].join('');
+    editor.setContent(content);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
+    TinyContentActions.keystroke(editor, Keys.enter());
+    await TinyContentActions.pType(editor, 'def');
+
+    await testClickOnRightSideOfLI(editor, { content, path: [ 0, 0, 0 ], offset: 3 });
   });
 });

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
@@ -105,7 +105,10 @@ describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
       });
   });
 
-  it(`TINYMCE-14490: inserting a new li pressing enter in an li that also has a block element inside and clicking on the right of the first li the caret should be at the end of the element`, async () => {
+  ((browser.isFirefox() || browser.isSafari()) ?
+    it.skip :
+    it
+  )(`TINYMCE-14490: inserting a new li pressing enter in an li that also has a block element inside and clicking on the right of the first li the caret should be at the end of the element`, async () => {
     const editor = hook.editor();
     const content = [ '<ol>' +
       '<li>abc' +

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/QuirksTest.ts
@@ -1,5 +1,5 @@
 import { Keys } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 import { PredicateFind, SugarElement, SugarNode } from '@ephox/sugar';
@@ -35,94 +35,96 @@ describe('browser.tinymce.plugins.accordion.QuirksTest', () => {
     TinyAssertions.assertCursor(editor, [ 1, 0 ], 0);
   });
 
-  const testClickOnRightSideOfLI = async (editor: Editor, { content, path, offset }: { content: string; path: number[]; offset: number }) => {
-    const li = editor.dom.select('li')[0];
-    const firstChild = SugarElement.fromDom(li.firstChild as Node);
-    const textNode = SugarNode.isText(firstChild) ? firstChild.dom : PredicateFind.descendant(firstChild, SugarNode.isText).getOrDie().dom;
-    const rng = editor.getDoc().createRange();
-    rng.setStart(textNode, 0);
-    rng.setEnd(textNode, textNode.data.length);
-    const rect = rng.getClientRects()[0];
-
-    if (content.includes('<img')) {
-      const img = editor.dom.select('img')[0];
-      if (img && !img.complete) {
-        await new Promise((resolve) => {
-          img.onload = resolve;
-          img.onerror = resolve;
-        });
+  context('TINY-13886: nested list Chrome selection quirk', () => {
+    before(function () {
+      if (browser.isFirefox() || browser.isSafari()) {
+        this.skip();
       }
-    }
+    });
 
-    const mouseEvent = {
-      target: li as EventTarget,
-      clientX: rect.right + 100,
-      clientY: rect.top + rect.height / 2
-    } as MouseEvent;
-    editor.dispatch('mousedown', mouseEvent);
-    editor.dispatch('click', mouseEvent);
-    editor.dispatch('mouseup', mouseEvent);
+    const testClickOnRightSideOfLI = async (editor: Editor, { content, path, offset }: { content: string; path: number[]; offset: number }) => {
+      const li = editor.dom.select('li')[0];
+      const firstChild = SugarElement.fromDom(li.firstChild as Node);
+      const textNode = SugarNode.isText(firstChild) ? firstChild.dom : PredicateFind.descendant(firstChild, SugarNode.isText).getOrDie().dom;
+      const rng = editor.getDoc().createRange();
+      rng.setStart(textNode, 0);
+      rng.setEnd(textNode, textNode.data.length);
+      const rect = rng.getClientRects()[0];
 
-    TinyAssertions.assertCursor(editor, path, offset);
-  };
+      if (content.includes('<img')) {
+        const img = editor.dom.select('img')[0];
+        if (img && !img.complete) {
+          await new Promise((resolve) => {
+            img.onload = resolve;
+            img.onerror = resolve;
+          });
+        }
+      }
 
-  const cases = [
-    { content: '<ol><li>abc<div>def</div></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li>abc\n<div>def</div></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li>abc<br><div>def</div></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li>abc<div>def</div></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li>abc\n<div>def</div></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li>abc<ul><li>def</li></ul></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li>abc<ul><li>def</li></ul></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li><span style="border: 2px solid red;">abc</span><div>def</div></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li><span style="border: 2px solid red;">abc</span>\n<div>def</div></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li><span style="border: 2px solid red;">abc</span><div>def</div></li></ul>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li><span style="border: 2px solid red;">abc</span><ul><li>def</li></ul></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li><span style="border: 2px solid red;">abc</span><ul><li>def</li></ul></li></ul>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li>abc<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li>abc<span style="display: block;">def</span></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li><span style="border: 2px solid red;">abc</span><span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ul><li><span style="border: 2px solid red;">abc</span><span style="display: block;">def</span></li></ul>', path: [ 0, 0, 0, 0 ], offset: 3 },
-    { content: '<ol><li><span style="border: 2px solid red;">abc</span>\n<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 1 ], offset: 1 },
-    { content: '<ol><li>a<b>b</b>c<div>def</div></li></ol>', path: [ 0, 0, 2 ], offset: 1 },
-    { content: '<ol><li>&nbsp;<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0 ], offset: 1 },
-    { content: '<ol><li>&nbsp;\n<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0 ], offset: 2 },
-    { content: '<ol><li><span style="border: 2px solid red;">&nbsp;</span><span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0, 0 ], offset: 1 },
-    { content: '<ol><li><span style="border: 2px solid red;">&nbsp;</span>\n<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 1 ], offset: 1 },
-    { content: '<ol><li>abc<img src="some-fake-url"><div>def</div></li></ol>', path: [ 0, 0 ], offset: 2 },
-    { content: '<ol><li>abc<img src="some-fake-url">\n<div>def</div></li></ol>', path: [ 0, 0 ], offset: 2 },
-  ];
+      const mouseEvent = {
+        target: li as EventTarget,
+        clientX: rect.right + 100,
+        clientY: rect.top + rect.height / 2
+      } as MouseEvent;
+      editor.dispatch('mousedown', mouseEvent);
+      editor.dispatch('click', mouseEvent);
+      editor.dispatch('mouseup', mouseEvent);
 
-  Arr.each(cases, ({ content, path, offset }, i) => {
-    ((browser.isFirefox() || browser.isSafari()) ?
-      it.skip :
-      it
-    )(`TINY-13886: clicking on the right of the first element (which must be an inline element) of li that also have a block element inside should place the caret at the end of the first element (${i}, ${content})`,
-      async () => {
-        const editor = hook.editor();
-        editor.setContent(content);
-        await testClickOnRightSideOfLI(editor, { content, path, offset });
-      });
-  });
+      TinyAssertions.assertCursor(editor, path, offset);
+    };
 
-  ((browser.isFirefox() || browser.isSafari()) ?
-    it.skip :
-    it
-  )(`TINYMCE-14490: inserting a new li pressing enter in an li that also has a block element inside and clicking on the right of the first li the caret should be at the end of the element`, async () => {
-    const editor = hook.editor();
-    const content = [ '<ol>' +
-      '<li>abc' +
-        '<ol>' +
-          '<li>first</li>' +
-          '<li>second</li>' +
-        '</ol>' +
-      '</li>' +
-    '</ol>' ].join('');
-    editor.setContent(content);
-    TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
-    TinyContentActions.keystroke(editor, Keys.enter());
-    await TinyContentActions.pType(editor, 'def');
+    const cases = [
+      { content: '<ol><li>abc<div>def</div></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li>abc\n<div>def</div></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li>abc<br><div>def</div></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li>abc<div>def</div></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li>abc\n<div>def</div></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li>abc<ul><li>def</li></ul></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li>abc<ul><li>def</li></ul></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li><span style="border: 2px solid red;">abc</span><div>def</div></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li><span style="border: 2px solid red;">abc</span>\n<div>def</div></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li><span style="border: 2px solid red;">abc</span><div>def</div></li></ul>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li><span style="border: 2px solid red;">abc</span><ul><li>def</li></ul></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li><span style="border: 2px solid red;">abc</span><ul><li>def</li></ul></li></ul>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li>abc<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li>abc<span style="display: block;">def</span></li></ul>', path: [ 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li><span style="border: 2px solid red;">abc</span><span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ul><li><span style="border: 2px solid red;">abc</span><span style="display: block;">def</span></li></ul>', path: [ 0, 0, 0, 0 ], offset: 3 },
+      { content: '<ol><li><span style="border: 2px solid red;">abc</span>\n<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 1 ], offset: 1 },
+      { content: '<ol><li>a<b>b</b>c<div>def</div></li></ol>', path: [ 0, 0, 2 ], offset: 1 },
+      { content: '<ol><li>&nbsp;<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0 ], offset: 1 },
+      { content: '<ol><li>&nbsp;\n<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0 ], offset: 2 },
+      { content: '<ol><li><span style="border: 2px solid red;">&nbsp;</span><span style="display: block;">def</span></li></ol>', path: [ 0, 0, 0, 0 ], offset: 1 },
+      { content: '<ol><li><span style="border: 2px solid red;">&nbsp;</span>\n<span style="display: block;">def</span></li></ol>', path: [ 0, 0, 1 ], offset: 1 },
+      { content: '<ol><li>abc<img src="some-fake-url"><div>def</div></li></ol>', path: [ 0, 0 ], offset: 2 },
+      { content: '<ol><li>abc<img src="some-fake-url">\n<div>def</div></li></ol>', path: [ 0, 0 ], offset: 2 },
+    ];
 
-    await testClickOnRightSideOfLI(editor, { content, path: [ 0, 0, 0 ], offset: 3 });
+    Arr.each(cases, ({ content, path, offset }, i) => {
+      it(`TINY-13886: clicking on the right of the first element (which must be an inline element) of li that also have a block element inside should place the caret at the end of the first element (${i}, ${content})`,
+        async () => {
+          const editor = hook.editor();
+          editor.setContent(content);
+          await testClickOnRightSideOfLI(editor, { content, path, offset });
+        });
+    });
+
+    it(`TINYMCE-14490: inserting a new li pressing enter in an li that also has a block element inside and clicking on the right of the first li the caret should be at the end of the element`, async () => {
+      const editor = hook.editor();
+      const content = [ '<ol>' +
+        '<li>abc' +
+          '<ol>' +
+            '<li>first</li>' +
+            '<li>second</li>' +
+          '</ol>' +
+        '</li>' +
+      '</ol>' ].join('');
+      editor.setContent(content);
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 3);
+      TinyContentActions.keystroke(editor, Keys.enter());
+      await TinyContentActions.pType(editor, 'def');
+
+      await testClickOnRightSideOfLI(editor, { content, path: [ 0, 0, 0 ], offset: 3 });
+    });
   });
 });


### PR DESCRIPTION
Related Ticket: TINYMCE-14490

Description of Changes:
sadly this happen only starting from an already existing list and inserting a new `li` via `Enter`, having the same HTML but directly put it the editor doesn't replicate the bug.

So my solution have no particular check on the structure of the list because there is no way to distinguish between a working `li` and not working one.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Chromium edge case where clicking the right side of a list item could place the caret incorrectly or fail, impacting nested and partially filled lists.
  * Improved caret placement consistency when interacting with list items after clicks and selection changes.

* **Tests**
  * Added new browser test coverage for the affected caret positioning scenario, including nested ordered lists, Enter-driven list item creation, and follow-up typing.
  * Refreshed related nested-list click tests to better set up editor content per scenario and updated browser skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->