### PR TITLE
TINYMCE-14528: Add sidebar width config options

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-14527-2026-06-30.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-14527-2026-06-30.yaml
@@ -1,6 +1,6 @@
 project: tinymce
 kind: Improved
-body: Sidebars can now be resized by dragging their edge.
+body: Sidebars can now be resized by dragging their edge, and their width can be configured with the new `sidebar_width` option.
 time: 2026-06-30T20:16:56.784348336Z
 custom:
   Issue: TINYMCE-14527

--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -220,6 +220,9 @@ interface BaseEditorOptions {
   selector?: string;
   setup?: SetupCallback;
   sidebar_show?: string;
+  sidebar_width?: number;
+  sidebar_min_width?: number;
+  sidebar_max_width?: number;
   skin?: boolean | string;
   skin_url?: string;
   smart_paste?: boolean;
@@ -363,6 +366,9 @@ export interface EditorOptions extends NormalizedEditorOptions {
   removed_menuitems: string;
   sandbox_iframes: boolean;
   sandbox_iframes_exclusions: string[];
+  sidebar_width: number;
+  sidebar_min_width: number;
+  sidebar_max_width: number;
   toolbar: boolean | string | string[] | Array<ToolbarGroup>;
   toolbar_groups: Record<string, Toolbar.GroupToolbarButtonSpec>;
   toolbar_location: ToolbarLocation;

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -270,7 +270,8 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       dom: {
         tag: 'div',
         classes: [ 'tox-sidebar' ]
-      }
+      },
+      editor
     });
 
     return {

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -271,7 +271,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
         tag: 'div',
         classes: [ 'tox-sidebar' ]
       },
-      editor
+      configuredSidebarWidth: Options.getSidebarWidth(editor)
     });
 
     return {

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -286,6 +286,21 @@ const register = (editor: Editor): void => {
     processor: 'string'
   });
 
+  registerOption('sidebar_width', {
+    processor: 'number',
+    default: 440
+  });
+
+  registerOption('sidebar_min_width', {
+    processor: 'number',
+    default: 300
+  });
+
+  registerOption('sidebar_max_width', {
+    processor: 'number',
+    default: 800
+  });
+
   registerOption('view_show', {
     processor: 'string'
   });
@@ -338,6 +353,9 @@ const useBranding = option('branding');
 const getResize = option('resize');
 const getPasteAsText = option('paste_as_text');
 const getSidebarShow = option('sidebar_show');
+const getSidebarWidth = option('sidebar_width');
+const getSidebarMinWidth = option('sidebar_min_width');
+const getSidebarMaxWidth = option('sidebar_max_width');
 const getViewShow = option('view_show');
 const promotionEnabled = option('promotion');
 const useHelpAccessibility = option('help_accessibility');
@@ -468,6 +486,9 @@ export {
   getRemovedMenuItems,
   getResize,
   getSidebarShow,
+  getSidebarWidth,
+  getSidebarMinWidth,
+  getSidebarMaxWidth,
   getSkin,
   getSkinUrl,
   getSkinUrlOption,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -113,7 +113,11 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
     OuterContainer.setSidebar(
       outerContainer,
       rawUiConfig.sidebar,
-      editor
+      Options.getSidebarShow(editor),
+      {
+        minWidth: Options.getSidebarMinWidth(editor),
+        maxWidth: Options.getSidebarMaxWidth(editor)
+      }
     );
 
     OuterContainer.setViews(

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -113,7 +113,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
     OuterContainer.setSidebar(
       outerContainer,
       rawUiConfig.sidebar,
-      Options.getSidebarShow(editor)
+      editor
     );
 
     OuterContainer.setViews(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -5,8 +5,6 @@ import { FieldSchema } from '@ephox/boulder';
 import { Arr, Id, Obj, Optional, Optionals, Type, type Result } from '@ephox/katamari';
 import { Attribute, Css, SelectorFind, type SugarElement } from '@ephox/sugar';
 
-import type Editor from 'tinymce/core/api/Editor';
-
 import { ToolbarMode } from '../../api/Options';
 import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { type HeaderSpec, renderHeader } from '../header/CommonHeader';
@@ -59,7 +57,7 @@ interface ToolbarSketchSpec extends MoreDrawerData {
 interface OuterContainerApis {
   readonly getHeader: (comp: AlloyComponent) => Optional<AlloyComponent>;
   readonly getSocket: (comp: AlloyComponent) => Optional<AlloyComponent>;
-  readonly setSidebar: (comp: AlloyComponent, panelConfigs: Sidebar.SidebarConfig, editor: Editor) => void;
+  readonly setSidebar: (comp: AlloyComponent, panelConfigs: Sidebar.SidebarConfig, showSidebar: string | undefined, sizeConstraints: Sidebar.SidebarSizeConstraints) => void;
   readonly toggleSidebar: (comp: AlloyComponent, name: string) => void;
   readonly whichSidebar: (comp: AlloyComponent) => string | null;
   // Maybe just change to ToolbarAnchor.
@@ -108,9 +106,9 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
     getSocket: (comp) => {
       return Composite.parts.getPart(comp, detail, 'socket');
     },
-    setSidebar: (comp, panelConfigs, editor) => {
+    setSidebar: (comp, panelConfigs, showSidebar, sizeConstraints) => {
       Composite.parts.getPart(comp, detail, 'sidebar').each(
-        (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs, editor)
+        (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs, showSidebar, sizeConstraints)
       );
     },
     toggleSidebar: (comp, name) => {
@@ -423,8 +421,8 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
     getSocket: (apis, comp) => {
       return apis.getSocket(comp);
     },
-    setSidebar: (apis, comp, panelConfigs, showSidebar) => {
-      apis.setSidebar(comp, panelConfigs, showSidebar);
+    setSidebar: (apis, comp, panelConfigs, showSidebar, sizeConstraints) => {
+      apis.setSidebar(comp, panelConfigs, showSidebar, sizeConstraints);
     },
     toggleSidebar: (apis, comp, name) => {
       apis.toggleSidebar(comp, name);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -5,6 +5,8 @@ import { FieldSchema } from '@ephox/boulder';
 import { Arr, Id, Obj, Optional, Optionals, Type, type Result } from '@ephox/katamari';
 import { Attribute, Css, SelectorFind, type SugarElement } from '@ephox/sugar';
 
+import type Editor from 'tinymce/core/api/Editor';
+
 import { ToolbarMode } from '../../api/Options';
 import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { type HeaderSpec, renderHeader } from '../header/CommonHeader';
@@ -57,7 +59,7 @@ interface ToolbarSketchSpec extends MoreDrawerData {
 interface OuterContainerApis {
   readonly getHeader: (comp: AlloyComponent) => Optional<AlloyComponent>;
   readonly getSocket: (comp: AlloyComponent) => Optional<AlloyComponent>;
-  readonly setSidebar: (comp: AlloyComponent, panelConfigs: Sidebar.SidebarConfig, showSidebar?: string) => void;
+  readonly setSidebar: (comp: AlloyComponent, panelConfigs: Sidebar.SidebarConfig, editor: Editor) => void;
   readonly toggleSidebar: (comp: AlloyComponent, name: string) => void;
   readonly whichSidebar: (comp: AlloyComponent) => string | null;
   // Maybe just change to ToolbarAnchor.
@@ -106,9 +108,9 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
     getSocket: (comp) => {
       return Composite.parts.getPart(comp, detail, 'socket');
     },
-    setSidebar: (comp, panelConfigs, showSidebar) => {
+    setSidebar: (comp, panelConfigs, editor) => {
       Composite.parts.getPart(comp, detail, 'sidebar').each(
-        (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs, showSidebar)
+        (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs, editor)
       );
     },
     toggleSidebar: (comp, name) => {
@@ -352,7 +354,7 @@ const partSocket = Composite.partType.optional({
   ]
 });
 
-const partSidebar = Composite.partType.optional<OuterContainerSketchDetail, Sidebar.SidebarSpec>({
+const partSidebar = Composite.partType.optional({
   factory: {
     sketch: Sidebar.renderSidebar
   },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -358,7 +358,8 @@ const partSidebar = Composite.partType.optional({
   },
   name: 'sidebar',
   schema: [
-    FieldSchema.required('dom')
+    FieldSchema.required('dom'),
+    FieldSchema.required('configuredSidebarWidth')
   ]
 });
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -352,7 +352,7 @@ const partSocket = Composite.partType.optional({
   ]
 });
 
-const partSidebar = Composite.partType.optional({
+const partSidebar = Composite.partType.optional<OuterContainerSketchDetail, Sidebar.SidebarSpec>({
   factory: {
     sketch: Sidebar.renderSidebar
   },

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -12,6 +12,7 @@ import { Attribute, Css, type SugarElement, Width } from '@ephox/sugar';
 import type Editor from 'tinymce/core/api/Editor';
 import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
 
+import * as Options from '../../api/Options';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { SimpleBehaviours } from '../alien/SimpleBehaviours';
 import { numToPx } from '../sizing/Utils';
@@ -96,13 +97,13 @@ const makePanels = (parts: SlotContainerTypes.SlotContainerParts, panelConfigs: 
   });
 };
 
-const makeSidebar = (panelConfigs: SidebarConfig) => SlotContainer.sketch((parts) => ({
+const makeSidebar = (panelConfigs: SidebarConfig, editor: Editor) => SlotContainer.sketch((parts) => ({
   dom: {
     tag: 'div',
     classes: [ 'tox-sidebar__pane-container' ]
   },
   components: [
-    makeSidebarResizeHandle(),
+    makeSidebarResizeHandle(editor),
     ...makePanels(parts, panelConfigs)
   ],
   slotBehaviours: SimpleBehaviours.unnamedEvents([
@@ -110,11 +111,12 @@ const makeSidebar = (panelConfigs: SidebarConfig) => SlotContainer.sketch((parts
   ])
 }));
 
-const setSidebar = (sidebar: AlloyComponent, panelConfigs: SidebarConfig, showSidebar: string | undefined): void => {
+const setSidebar = (sidebar: AlloyComponent, panelConfigs: SidebarConfig, editor: Editor): void => {
+  const showSidebar = Options.getSidebarShow(editor);
   const optSlider = Composing.getCurrent(sidebar);
 
   optSlider.each((slider) => {
-    Replacing.set(slider, [ makeSidebar(panelConfigs) ]);
+    Replacing.set(slider, [ makeSidebar(panelConfigs, editor) ]);
 
     // Show the default sidebar
     const configKey = showSidebar?.toLowerCase();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -195,7 +195,7 @@ const renderSidebar = (spec: SidebarSpec): AlloySpec => ({
     tag: 'div',
     classes: [ 'tox-sidebar' ],
     styles: {
-      [SidebarResize.requestedWidthProperty]: numToPx(SidebarResize.initialWidth)
+      [SidebarResize.requestedWidthProperty]: numToPx(Options.getSidebarWidth(spec.editor))
     },
     attributes: {
       role: SidebarStateRoleAttr.Shrunk

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -190,7 +190,7 @@ const fixSize = Id.generate('FixSizeEvent');
 const autoSize = Id.generate('AutoSizeEvent');
 
 interface SidebarSpec extends SketchSpec {
-  readonly editor: Editor;
+  readonly configuredSidebarWidth: number;
 }
 
 const renderSidebar = (spec: SidebarSpec): AlloySpec => ({
@@ -199,7 +199,7 @@ const renderSidebar = (spec: SidebarSpec): AlloySpec => ({
     tag: 'div',
     classes: [ 'tox-sidebar' ],
     styles: {
-      [SidebarResize.requestedWidthProperty]: numToPx(Options.getSidebarWidth(spec.editor))
+      [SidebarResize.requestedWidthProperty]: numToPx(spec.configuredSidebarWidth)
     },
     attributes: {
       role: SidebarStateRoleAttr.Shrunk

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -22,6 +22,11 @@ import { makeSidebarResizeHandle } from './SidebarResizeHandle';
 
 export type SidebarConfig = Record<string, BridgeSidebar.SidebarSpec>;
 
+export interface SidebarSizeConstraints {
+  readonly minWidth: number;
+  readonly maxWidth: number;
+}
+
 const enum SidebarStateRoleAttr {
   Grown = 'region',
   Shrunk = 'presentation'
@@ -97,13 +102,13 @@ const makePanels = (parts: SlotContainerTypes.SlotContainerParts, panelConfigs: 
   });
 };
 
-const makeSidebar = (panelConfigs: SidebarConfig, editor: Editor) => SlotContainer.sketch((parts) => ({
+const makeSidebar = (panelConfigs: SidebarConfig, sizeConstraints: SidebarSizeConstraints) => SlotContainer.sketch((parts) => ({
   dom: {
     tag: 'div',
     classes: [ 'tox-sidebar__pane-container' ]
   },
   components: [
-    makeSidebarResizeHandle(editor),
+    makeSidebarResizeHandle(sizeConstraints),
     ...makePanels(parts, panelConfigs)
   ],
   slotBehaviours: SimpleBehaviours.unnamedEvents([
@@ -111,12 +116,11 @@ const makeSidebar = (panelConfigs: SidebarConfig, editor: Editor) => SlotContain
   ])
 }));
 
-const setSidebar = (sidebar: AlloyComponent, panelConfigs: SidebarConfig, editor: Editor): void => {
-  const showSidebar = Options.getSidebarShow(editor);
+const setSidebar = (sidebar: AlloyComponent, panelConfigs: SidebarConfig, showSidebar: string | undefined, sizeConstraints: SidebarSizeConstraints): void => {
   const optSlider = Composing.getCurrent(sidebar);
 
   optSlider.each((slider) => {
-    Replacing.set(slider, [ makeSidebar(panelConfigs, editor) ]);
+    Replacing.set(slider, [ makeSidebar(panelConfigs, sizeConstraints) ]);
 
     // Show the default sidebar
     const configKey = showSidebar?.toLowerCase();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -12,7 +12,6 @@ import { Attribute, Css, type SugarElement, Width } from '@ephox/sugar';
 import type Editor from 'tinymce/core/api/Editor';
 import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
 
-import * as Options from '../../api/Options';
 import { ComposingConfigs } from '../alien/ComposingConfigs';
 import { SimpleBehaviours } from '../alien/SimpleBehaviours';
 import { numToPx } from '../sizing/Utils';

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -183,7 +183,11 @@ interface FixSizeEvent extends CustomEvent {
 const fixSize = Id.generate('FixSizeEvent');
 const autoSize = Id.generate('AutoSizeEvent');
 
-const renderSidebar = (spec: SketchSpec): AlloySpec => ({
+interface SidebarSpec extends SketchSpec {
+  readonly editor: Editor;
+}
+
+const renderSidebar = (spec: SidebarSpec): AlloySpec => ({
   uid: spec.uid,
   dom: {
     tag: 'div',
@@ -256,6 +260,7 @@ const renderSidebar = (spec: SketchSpec): AlloySpec => ({
 });
 
 export {
+  type SidebarSpec,
   setSidebar,
   toggleSidebar,
   whichSidebar,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -265,7 +265,6 @@ const renderSidebar = (spec: SidebarSpec): AlloySpec => ({
 });
 
 export {
-  type SidebarSpec,
   setSidebar,
   toggleSidebar,
   whichSidebar,

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
@@ -5,11 +5,6 @@ import { numToPx } from '../sizing/Utils';
 export const requestedWidthProperty = '--tox-private-requested-sidebar-width';
 export const resolvedWidthProperty = '--tox-private-resolved-sidebar-width';
 
-export const minWidth = 300;
-export const maxWidth = 800;
-
-export const initialWidth = 440;
-
 export const applyWidth = (sidebar: SugarElement<HTMLElement>, width: number): void => {
   Css.set(sidebar, requestedWidthProperty, numToPx(width));
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
@@ -2,18 +2,14 @@ import { type AlloyComponent, type AlloySpec, Behaviour, Dragging, Resizing } fr
 import type { Optional } from '@ephox/katamari';
 import { Height, SelectorFind, type SugarElement, SugarPosition, Width } from '@ephox/sugar';
 
-import type Editor from 'tinymce/core/api/Editor';
-
-import * as Options from '../../api/Options';
-
+import type { SidebarSizeConstraints } from './Sidebar';
 import * as SidebarResize from './SidebarResize';
 
 const findSidebar = (handle: AlloyComponent): Optional<SugarElement<HTMLElement>> =>
   SelectorFind.ancestor<HTMLElement>(handle.element, '.tox-sidebar');
 
-export const makeSidebarResizeHandle = (editor: Editor): AlloySpec => {
-  const minWidth = Options.getSidebarMinWidth(editor);
-  const maxWidth = Options.getSidebarMaxWidth(editor);
+export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints): AlloySpec => {
+  const { minWidth, maxWidth } = sizeConstraints;
 
   return {
     dom: {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
@@ -2,6 +2,10 @@ import { type AlloyComponent, type AlloySpec, Behaviour, Dragging, Resizing } fr
 import type { Optional } from '@ephox/katamari';
 import { Height, SelectorFind, type SugarElement, SugarPosition, Width } from '@ephox/sugar';
 
+import type Editor from 'tinymce/core/api/Editor';
+
+import * as Options from '../../api/Options';
+
 import * as SidebarResize from './SidebarResize';
 
 const findSidebar = (handle: AlloyComponent): Optional<SugarElement<HTMLElement>> =>
@@ -12,30 +16,32 @@ const sizeConstraints = {
   maxWidth: SidebarResize.maxWidth
 };
 
-export const makeSidebarResizeHandle = (): AlloySpec => ({
-  dom: {
-    tag: 'div',
-    classes: [ 'tox-sidebar__resize-handle' ]
-  },
-  behaviours: Behaviour.derive([
-    Dragging.config({
-      mode: 'pointer',
-      repositionTarget: false,
-      onDragStart: (handle) => {
-        findSidebar(handle).each((sidebar) => {
-          Resizing.start(handle, Width.get(sidebar), Height.get(sidebar), sizeConstraints);
-        });
-      },
-      onDrag: (handle, _target, delta) => {
-        // The handle sits on the sidebar's left edge, so dragging left should grow it: invert the horizontal delta.
-        Resizing.moveBy(handle, SugarPosition(delta.left * -1, 0)).each(({ width }) => {
-          findSidebar(handle).each((sidebar) => SidebarResize.applyWidth(sidebar, width));
-        });
-      },
-      onDrop: (handle) => {
-        Resizing.stop(handle);
-      }
-    }),
-    Resizing.config({})
-  ])
-});
+export const makeSidebarResizeHandle = (editor: Editor): AlloySpec => {
+  return {
+    dom: {
+      tag: 'div',
+      classes: [ 'tox-sidebar__resize-handle' ]
+    },
+    behaviours: Behaviour.derive([
+      Dragging.config({
+        mode: 'pointer',
+        repositionTarget: false,
+        onDragStart: (handle) => {
+          findSidebar(handle).each((sidebar) => {
+            Resizing.start(handle, Width.get(sidebar), Height.get(sidebar), sizeConstraints);
+          });
+        },
+        onDrag: (handle, _target, delta) => {
+          // The handle sits on the sidebar's left edge, so dragging left should grow it: invert the horizontal delta.
+          Resizing.moveBy(handle, SugarPosition(delta.left * -1, 0)).each(({ width }) => {
+            findSidebar(handle).each((sidebar) => SidebarResize.applyWidth(sidebar, width));
+          });
+        },
+        onDrop: (handle) => {
+          Resizing.stop(handle);
+        }
+      }),
+      Resizing.config({})
+    ])
+  };
+};

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
@@ -11,12 +11,10 @@ import * as SidebarResize from './SidebarResize';
 const findSidebar = (handle: AlloyComponent): Optional<SugarElement<HTMLElement>> =>
   SelectorFind.ancestor<HTMLElement>(handle.element, '.tox-sidebar');
 
-const sizeConstraints = {
-  minWidth: SidebarResize.minWidth,
-  maxWidth: SidebarResize.maxWidth
-};
-
 export const makeSidebarResizeHandle = (editor: Editor): AlloySpec => {
+  const minWidth = Options.getSidebarMinWidth(editor);
+  const maxWidth = Options.getSidebarMaxWidth(editor);
+
   return {
     dom: {
       tag: 'div',
@@ -28,7 +26,7 @@ export const makeSidebarResizeHandle = (editor: Editor): AlloySpec => {
         repositionTarget: false,
         onDragStart: (handle) => {
           findSidebar(handle).each((sidebar) => {
-            Resizing.start(handle, Width.get(sidebar), Height.get(sidebar), sizeConstraints);
+            Resizing.start(handle, Width.get(sidebar), Height.get(sidebar), { minWidth, maxWidth });
           });
         },
         onDrag: (handle, _target, delta) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -11,7 +11,7 @@ import type Editor from 'tinymce/core/api/Editor';
 import * as SidebarUtils from '../../module/SidebarUtils';
 
 describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
-  const setupEditorHook = (configOverrides: { sidebar_show?: string } = {}) =>
+  const setupEditorHook = (configOverrides: { sidebar_show?: string; sidebar_min_width?: number; sidebar_max_width?: number; sidebar_width?: number } = {}) =>
     TinyHooks.bddSetupLight<Editor>({
       base_url: '/project/tinymce/js/tinymce',
       toolbar: 'sidebarone sidebartwo',
@@ -36,15 +36,15 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
     assert.equal(Width.get(sidebar), expectedWidth, message);
   };
 
-  const resetSidebarWidth = async () => {
-    const initialWidth = 440;
+  const resetSidebarWidth = async (initialWidth: number) => {
     const sidebar = SidebarUtils.getSidebar();
     await SidebarUtils.resizeSidebarBy([ Width.get(sidebar) - initialWidth, 0 ]);
   };
 
   context('TINYMCE-14527: Resizing the sidebar', () => {
-    setupEditorHook({ sidebar_show: 'sidebarone' });
-    afterEach(resetSidebarWidth);
+    const initialWidth = 440;
+    setupEditorHook({ sidebar_show: 'sidebarone', sidebar_width: initialWidth, sidebar_min_width: 300, sidebar_max_width: 800 });
+    afterEach(async () => resetSidebarWidth(initialWidth));
 
     it('TINYMCE-14527: should resize the sidebar by dragging the handle', async () => {
       const resizeHandle = SidebarUtils.getSidebarResizeHandle();
@@ -103,33 +103,50 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
   });
 
   context('TINYMCE-14527: Constraints', () => {
-    setupEditorHook({ sidebar_show: 'sidebarone' });
+    context('defaults', () => {
+      setupEditorHook({ sidebar_show: 'sidebarone' });
 
-    it('TINYMCE-14527: should respect initial and the min and max width constraints', async () => {
-      assertSidebarWidth(440, 'The sidebar should start at the initial width');
+      it('TINYMCE-14527: should respect initial and the min and max width constraints', async () => {
+        assertSidebarWidth(440, 'The sidebar should start at the initial width');
 
-      await SidebarUtils.resizeSidebarBy([ -1000, 0 ]);
-      assertSidebarWidth(800, 'The sidebar should be capped at the max width');
+        await SidebarUtils.resizeSidebarBy([ -1000, 0 ]);
+        assertSidebarWidth(800, 'The sidebar should be capped at the max width');
 
-      await SidebarUtils.resizeSidebarBy([ 1000, 0 ]);
-      assertSidebarWidth(300, 'The sidebar should be capped at the min width');
+        await SidebarUtils.resizeSidebarBy([ 1000, 0 ]);
+        assertSidebarWidth(300, 'The sidebar should be capped at the min width');
+      });
+    });
+
+    context('set options', () => {
+      setupEditorHook({ sidebar_show: 'sidebarone', sidebar_min_width: 100, sidebar_max_width: 600, sidebar_width: 200 });
+
+      it('TINYMCE-14527: should respect initial and the min and max width constraints', async () => {
+        assertSidebarWidth(200, 'The sidebar should start at the initial width');
+
+        await SidebarUtils.resizeSidebarBy([ -1000, 0 ]);
+        assertSidebarWidth(600, 'The sidebar should be capped at the max width');
+
+        await SidebarUtils.resizeSidebarBy([ 1000, 0 ]);
+        assertSidebarWidth(100, 'The sidebar should be capped at the min width');
+      });
     });
   });
 
   context('TINYMCE-14527: Persistence', () => {
-    const hook = setupEditorHook();
+    const initialWidth = 440;
+    const hook = setupEditorHook({ sidebar_width: 440, sidebar_min_width: 300, sidebar_max_width: 800 });
 
     afterEach(async () => {
       const editor = hook.editor();
       const currentSidebar = editor.queryCommandValue('ToggleSidebar');
       if (currentSidebar) {
-        await resetSidebarWidth();
+        await resetSidebarWidth(initialWidth);
         editor.execCommand('ToggleSidebar', false, editor.queryCommandValue('ToggleSidebar'));
         await SidebarUtils.pWaitForSidebarClosed();
       } else {
         editor.execCommand('ToggleSidebar', false, 'sidebarone');
         await SidebarUtils.pWaitForSidebarOpen();
-        await resetSidebarWidth();
+        await resetSidebarWidth(initialWidth);
         editor.execCommand('ToggleSidebar', false, 'sidebarone');
         await SidebarUtils.pWaitForSidebarClosed();
       }


### PR DESCRIPTION
Related Ticket: TINYMCE-14528

Description of Changes:

- Added three new editor options — `sidebar_width`, `sidebar_min_width`, and `sidebar_max_width` — allowing users to configure the initial width and resize constraints of the sidebar
- Default values are `440` for `sidebar_width`, `300` for `sidebar_min_width`, and `800` for `sidebar_max_width`
- Updated tests to cover both default and explicitly configured values for the new width options

Pre-checks:

~~- [ ] Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new editor options to configure sidebar width, including `sidebar_width` plus `sidebar_min_width` and `sidebar_max_width` (with sensible defaults).
  * Sidebar panels can be resized by dragging their edge, with sizing constrained by the configured limits.

* **Bug Fixes**
  * Improved sidebar rendering and resize behavior so width and constraints remain consistent during open, drag-resize, and restore actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->