### PR TITLE
TINYMCE-8784: Fix anchor links with special characters throwing querySelector errors

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-8784-2026-06-30.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-8784-2026-06-30.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Clicking anchor links with special characters like semicolons in readonly mode or using the link plugin was throwing a querySelectorAll syntax error.
+time: 2026-06-30T11:30:27.842199+10:00
+custom:
+  Issue: TINYMCE-8784

--- a/modules/tinymce/src/core/main/ts/mode/Disabled.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Disabled.ts
@@ -102,7 +102,8 @@ const processDisabledEvents = (editor: Editor, e: Event): void => {
       (href) => {
         e.preventDefault();
         if (/^#/.test(href)) {
-          const targetEl = editor.dom.select(`${href},[name="${Strings.removeLeading(href, '#')}"]`);
+          const escapedId = CSS.escape(Strings.removeLeading(href, '#'));
+          const targetEl = editor.dom.select(`#${escapedId},[name="${escapedId}"]`);
           if (targetEl.length) {
             editor.selection.scrollIntoView(targetEl[0], true);
           }

--- a/modules/tinymce/src/core/main/ts/mode/Disabled.ts
+++ b/modules/tinymce/src/core/main/ts/mode/Disabled.ts
@@ -102,8 +102,8 @@ const processDisabledEvents = (editor: Editor, e: Event): void => {
       (href) => {
         e.preventDefault();
         if (/^#/.test(href)) {
-          const escapedId = CSS.escape(Strings.removeLeading(href, '#'));
-          const targetEl = editor.dom.select(`#${escapedId},[name="${escapedId}"]`);
+          const id = Strings.removeLeading(href, '#');
+          const targetEl = editor.dom.select(`[id="${id}"],[name="${id}"]`);
           if (targetEl.length) {
             editor.selection.scrollIntoView(targetEl[0], true);
           }

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -292,7 +292,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
   });
 
   describe('TINYMCE-8784: Clicking anchor links with special characters should scroll to target with cmd/ctrl', () => {
-    it('with one semicolon', () => {
+    it('TINYMCE-8784: Should scroll to anchor with one semicolon when cmd/ctrl is pressed', () => {
       const editor = hook.editor();
       setMode(editor, 'design');
       editor.resetContent();
@@ -308,7 +308,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
       assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
     });
 
-    it('with multiple semicolons', () => {
+    it('TINYMCE-8784: Should scroll to anchor with multiple semicolons when cmd/ctrl is pressed', () => {
       const editor = hook.editor();
       setMode(editor, 'design');
       editor.resetContent();

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -291,8 +291,8 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
   });
 
-  describe('TINYMCE-8784: Clicking anchor links with special characters should scroll to target with cmd/ctrl', () => {
-    it('TINYMCE-8784: Should scroll to anchor with one semicolon when cmd/ctrl is pressed', () => {
+  describe('Clicking anchor links with special characters should scroll to target', () => {
+    it('TINYMCE-8784: Should scroll to anchor with one semicolon', () => {
       const editor = hook.editor();
       setMode(editor, 'design');
       editor.resetContent();
@@ -308,7 +308,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
       assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
     });
 
-    it('TINYMCE-8784: Should scroll to anchor with multiple semicolons when cmd/ctrl is pressed', () => {
+    it('TINYMCE-8784: Should scroll to anchor with multiple semicolons', () => {
       const editor = hook.editor();
       setMode(editor, 'design');
       editor.resetContent();
@@ -325,8 +325,8 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     });
   });
 
-  describe('TINYMCE-8784: getAnchorHrefOpt should return an Optional of the href of the closest anchor tag', () => {
-    it('without anchor', () => {
+  describe('getAnchorHrefOpt should return an Optional of the href of the closest anchor tag', () => {
+    it('TINYMCE-8784: Should return href for external links and none for links without href', () => {
       const editor = hook.editor();
       editor.setContent('<p><a href="https://tiny.cloud">external link</a></p>');
       assertHrefOpt(editor, 'a', Optional.some('https://tiny.cloud'));
@@ -337,19 +337,19 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     });
 
     describe('with anchor', () => {
-      it('without semicolon', () => {
+      it('TINYMCE-8784: Should return href for anchor without semicolon', () => {
         const editor = hook.editor();
         editor.setContent('<p><a href="#myanchor">external link</a></p>');
         assertHrefOpt(editor, 'a', Optional.some('#myanchor'));
       });
 
-      it('with one semicolon', () => {
+      it('TINYMCE-8784: Should return href for anchor with one semicolon', () => {
         const editor = hook.editor();
         editor.setContent('<p><a href="#myanchor;somekey=somevalue">external link anchor href with semicolon</a></p>');
         assertHrefOpt(editor, 'a', Optional.some('#myanchor;somekey=somevalue'));
       });
 
-      it('with multiple semicolons', () => {
+      it('TINYMCE-8784: Should return href for anchor with multiple semicolons', () => {
         const editor = hook.editor();
         editor.setContent('<p><a href="#myanchor;somekey=somevalue;somekey2=somevalue2">external link anchor href with semicolon</a></p>');
         assertHrefOpt(editor, 'a', Optional.some('#myanchor;somekey=somevalue;somekey2=somevalue2'));

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -291,7 +291,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
   });
 
-  describe('TINYMCE-8784: Clicking anchor links with special characters should scroll to target', () => {
+  describe('TINYMCE-8784: Clicking anchor links with special characters should scroll to target with cmd/ctrl', () => {
     it('with one semicolon', () => {
       const editor = hook.editor();
       setMode(editor, 'design');
@@ -303,7 +303,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
       const doc = TinyDom.document(editor);
       const yPos = Scroll.get(doc).top;
       const anchor = UiFinder.findIn(body, 'a[href="#someBookmark;somekey=somevalue"]').getOrDie();
-      Mouse.click(anchor);
+      Mouse.click(anchor, metaKey);
       const newPos = Scroll.get(doc).top;
       assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
     });
@@ -319,7 +319,7 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
       const doc = TinyDom.document(editor);
       const yPos = Scroll.get(doc).top;
       const anchor = UiFinder.findIn(body, 'a[href="#someBookmark;somekey=somevalue;somekey2=somevalue2"]').getOrDie();
-      Mouse.click(anchor);
+      Mouse.click(anchor, metaKey);
       const newPos = Scroll.get(doc).top;
       assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
     });

--- a/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/ReadOnlyModeTest.ts
@@ -1,14 +1,18 @@
 import { ApproxStructure, Mouse, UiFinder, Clipboard } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
+import { Assert, describe, it } from '@ephox/bedrock-client';
+import { Optional, OptionalInstances } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Attribute, Class, Css, Scroll, SelectorFind, SugarBody, Traverse } from '@ephox/sugar';
+import { Attribute, Class, Css, Scroll, SelectorFind, SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyAssertions, TinyContentActions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
 import type Editor from 'tinymce/core/api/Editor';
+import * as Disabled from 'tinymce/core/mode/Disabled';
 import AnchorPlugin from 'tinymce/plugins/anchor/Plugin';
 import LinkPlugin from 'tinymce/plugins/link/Plugin';
 import TablePlugin from 'tinymce/plugins/table/Plugin';
+
+const tOptional = OptionalInstances.tOptional;
 
 describe('browser.tinymce.core.ReadOnlyModeTest', () => {
   const hook = TinyHooks.bddSetup<Editor>({
@@ -88,6 +92,12 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     const elm = UiFinder.findIn(SugarBody.body(), '.tox-toolbar-overlord').getOrDie();
     assert.equal(Class.has(elm, 'tox-tbtn--disabled'), expectedState, 'Toolbar should have expected disabled state');
     assert.equal(Attribute.get(elm, 'aria-disabled'), expectedState.toString(), 'Toolbar should have expected disabled state');
+  };
+
+  const assertHrefOpt = (editor: Editor, selector: string, expectedHref: Optional<string>) => {
+    const elm = SugarElement.fromDom(editor.dom.select(selector)[0]);
+    const hrefOpt = Disabled.getAnchorHrefOpt(editor, elm);
+    Assert.eq('href options match', expectedHref, hrefOpt, tOptional());
   };
 
   const pSimulateIMEInput = async (editor: Editor, events: Array<{ type: string; data?: string; key?: string; code?: string; keyCode?: number }>) => {
@@ -279,6 +289,72 @@ describe('browser.tinymce.core.ReadOnlyModeTest', () => {
     Mouse.click(anchor, metaKey);
     const newPos = Scroll.get(doc).top;
     assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
+  });
+
+  describe('TINYMCE-8784: Clicking anchor links with special characters should scroll to target', () => {
+    it('with one semicolon', () => {
+      const editor = hook.editor();
+      setMode(editor, 'design');
+      editor.resetContent();
+      setMode(editor, 'readonly');
+      editor.setContent('<p><a href="#someBookmark;somekey=somevalue">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark;somekey=somevalue"></a></p>');
+
+      const body = TinyDom.body(editor);
+      const doc = TinyDom.document(editor);
+      const yPos = Scroll.get(doc).top;
+      const anchor = UiFinder.findIn(body, 'a[href="#someBookmark;somekey=somevalue"]').getOrDie();
+      Mouse.click(anchor);
+      const newPos = Scroll.get(doc).top;
+      assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
+    });
+
+    it('with multiple semicolons', () => {
+      const editor = hook.editor();
+      setMode(editor, 'design');
+      editor.resetContent();
+      setMode(editor, 'readonly');
+      editor.setContent('<p><a href="#someBookmark;somekey=somevalue;somekey2=somevalue2">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark;somekey=somevalue;somekey2=somevalue2"></a></p>');
+
+      const body = TinyDom.body(editor);
+      const doc = TinyDom.document(editor);
+      const yPos = Scroll.get(doc).top;
+      const anchor = UiFinder.findIn(body, 'a[href="#someBookmark;somekey=somevalue;somekey2=somevalue2"]').getOrDie();
+      Mouse.click(anchor);
+      const newPos = Scroll.get(doc).top;
+      assert.notEqual(newPos, yPos, 'assert yPos has changed i.e. has scrolled');
+    });
+  });
+
+  describe('TINYMCE-8784: getAnchorHrefOpt should return an Optional of the href of the closest anchor tag', () => {
+    it('without anchor', () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="https://tiny.cloud">external link</a></p>');
+      assertHrefOpt(editor, 'a', Optional.some('https://tiny.cloud'));
+      editor.setContent('<p><a>external link with no href</a></p>');
+      assertHrefOpt(editor, 'a', Optional.none());
+      editor.setContent('<p><a href="https://tiny.cloud"><img src="">nested image </img>inside anchor</a></p>');
+      assertHrefOpt(editor, 'img', Optional.some('https://tiny.cloud'));
+    });
+
+    describe('with anchor', () => {
+      it('without semicolon', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><a href="#myanchor">external link</a></p>');
+        assertHrefOpt(editor, 'a', Optional.some('#myanchor'));
+      });
+
+      it('with one semicolon', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><a href="#myanchor;somekey=somevalue">external link anchor href with semicolon</a></p>');
+        assertHrefOpt(editor, 'a', Optional.some('#myanchor;somekey=somevalue'));
+      });
+
+      it('with multiple semicolons', () => {
+        const editor = hook.editor();
+        editor.setContent('<p><a href="#myanchor;somekey=somevalue;somekey2=somevalue2">external link anchor href with semicolon</a></p>');
+        assertHrefOpt(editor, 'a', Optional.some('#myanchor;somekey=somevalue;somekey2=somevalue2'));
+      });
+    });
   });
 
   it('TINY-6248: processReadonlyEvents should scroll to bookmark with name', () => {

--- a/modules/tinymce/src/plugins/link/main/ts/core/OpenLink.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/OpenLink.ts
@@ -39,7 +39,8 @@ const gotoLink = (editor: Editor, a: HTMLAnchorElement | undefined): void => {
   if (a) {
     const href = Utils.getHref(a);
     if (/^#/.test(href)) {
-      const targetEl = editor.dom.select(`${href},[name="${Strings.removeLeading(href, '#')}"]`);
+      const escapedId = CSS.escape(Strings.removeLeading(href, '#'));
+      const targetEl = editor.dom.select(`#${escapedId},[name="${escapedId}"]`);
       if (targetEl.length) {
         editor.selection.scrollIntoView(targetEl[0], true);
       }

--- a/modules/tinymce/src/plugins/link/main/ts/core/OpenLink.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/OpenLink.ts
@@ -39,8 +39,8 @@ const gotoLink = (editor: Editor, a: HTMLAnchorElement | undefined): void => {
   if (a) {
     const href = Utils.getHref(a);
     if (/^#/.test(href)) {
-      const escapedId = CSS.escape(Strings.removeLeading(href, '#'));
-      const targetEl = editor.dom.select(`#${escapedId},[name="${escapedId}"]`);
+      const id = Strings.removeLeading(href, '#');
+      const targetEl = editor.dom.select(`[id="${id}"],[name="${id}"]`);
       if (targetEl.length) {
         editor.selection.scrollIntoView(targetEl[0], true);
       }

--- a/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkContextMenuTest.ts
@@ -105,4 +105,28 @@ describe('browser.tinymce.plugins.link.OpenLinkContextMenuTest', () => {
       'https://www.exampleimage.com/'
     ]);
   });
+
+  describe('Anchor links with special characters should not throw querySelectorAll errors', () => {
+    it('TINYMCE-8784: Should handle anchor link with one semicolon from context menu', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#someBookmark;somekey=somevalue">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark;somekey=somevalue"></a></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
+      await TinyUiActions.pTriggerContextMenu(editor, 'a', '.tox-silver-sink [role="menuitem"]');
+      TinyUiActions.keydown(editor, Keys.down());
+      TinyUiActions.keydown(editor, Keys.down());
+      await pAssertFocusOnItem('Open link', '.tox-collection__item:contains("Open link")');
+      TinyUiActions.keydown(editor, Keys.enter());
+      store.assertEq('Should not throw an error and should not attempt to open external link', []);
+    });
+
+    it('TINYMCE-8784: Should handle anchor link with multiple semicolons from Alt+Enter', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#someBookmark;somekey=somevalue;somekey2=somevalue2">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark;somekey=somevalue;somekey2=somevalue2"></a></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
+      TinyContentActions.keydown(editor, Keys.enter(), {
+        altKey: true,
+      });
+      store.assertEq('Should not throw an error and should not attempt to open external link', []);
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkToolbarButtonTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/OpenLinkToolbarButtonTest.ts
@@ -121,4 +121,22 @@ describe('browser.tinymce.plugins.link.OpenLinkToolbarButtonTest', () => {
       'https://www.exampleone.com/'
     ]);
   });
+
+  describe('Anchor links with special characters should not throw querySelectorAll errors', () => {
+    it('TINYMCE-8784: Should handle anchor link with one semicolon from toolbar button', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#someBookmark;somekey=somevalue">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark;somekey=somevalue"></a></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Open link"]');
+      store.assertEq('Should not throw an error and should not attempt to open external link', []);
+    });
+
+    it('TINYMCE-8784: Should handle anchor link with multiple semicolons from toolbar button', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p><a href="#someBookmark;somekey=somevalue;somekey2=somevalue2">internal bookmark</a></p><div style="padding-top: 2000px;"></div><p><a id="someBookmark;somekey=somevalue;somekey2=somevalue2"></a></p>');
+      TinySelections.setCursor(editor, [ 0, 0, 0 ], 4);
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Open link"]');
+      store.assertEq('Should not throw an error and should not attempt to open external link', []);
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: [TINYMCE-8784](https://tiugotech.atlassian.net/browse/TINYMCE-8784)

Description of Changes:
* Clicking anchor links with special characters (like semicolons) or via the link plugin threw a querySelector syntax error because the fragment identifier was used directly in a CSS selector.
* We've fixed this by using attribute selectors (e.g. `[id="..."]` instead of ID selectors which handle special characters correctly without syntax errors or matching issues.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable): https://github.com/tinymce/tinymce/issues/7881


[TINYMCE-8784]: https://tiugotech.atlassian.net/browse/TINYMCE-8784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ