### PR TITLE
TINYMCE-14555: scale different size icons

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
+++ b/modules/oxide/src/less/theme/components/ai-chat/ai-chat.less
@@ -555,15 +555,15 @@
 
       // scale down bigger icons to fit the 16px icon size of the action button. 
       // This is a temporary solution until we have a proper icon size system in place
-      svg[width='24'] {
+      svg[width='24'], svg[width='24px'] {
         transform: scale(calc(16 / 24));
       }
 
-      svg[width="20"] {
+      svg[width='20'], svg[width='20px'] {
         transform: scale(calc(16 / 20));
       }
       
-      svg[width="18"] {
+      svg[width='18'], svg[width='18px'] {
         transform: scale(calc(16 / 18));
       }
     }


### PR DESCRIPTION
Related Ticket: TINYMCE-14555

Description of Changes:

- Extended SVG icon scaling selectors in the AI chat action button styles to also match `px`\-suffixed width attributes (e.g., `width='24px'`, `width='20px'`, `width='18px'`), ensuring icons are correctly scaled to 16px regardless of whether the width attribute is specified with or without the `px` unit.

Pre-checks:

- [x] ~~Changelog entry added~~
- [x] ~~Tests have been added (if applicable)~~
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] ~~Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI chat action button icon scaling so SVG icons size consistently when their `width` is provided either as a plain number or as a `px` value.
  * Updated styling rules to apply the existing scale-down behavior uniformly across the supported SVG width attribute formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->