### PR TITLE
TINYMCE-14533: implement small-device breakpoint

### DIFF
--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
@@ -36,7 +36,9 @@
     // overflow: auto.
     min-height: 0;
 
-    // TODO: add some smart comment
+    // Toggled from JS (SidebarResize.setupCompactObserver) via a ResizeObserver on
+    // the wrap element: when its rendered border-box width is <= 1024px the sidebar
+    // switches to a fixed 300px pane and the resize handle is disabled.
     &--compact {
       grid-template-columns: 1fr max-content;
 

--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
@@ -35,6 +35,24 @@
     // as the sidebar contents does. This happens even if the sidebar contents has
     // overflow: auto.
     min-height: 0;
+
+    // TODO: add some smart comment
+    &--compact {
+      grid-template-columns: 1fr max-content;
+
+      .tox-sidebar__pane-container {
+        width: 300px;
+      }
+
+      .tox-sidebar__resize-handle {
+        cursor: inherit;
+
+        // If I do it like that then the element is still there and can hijack click events, I need to address that
+        &:hover::before {
+          border-left: 0px solid transparent; 
+        }        
+      }
+    }
   }
 
   .tox-sidebar {

--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
@@ -36,9 +36,7 @@
     // overflow: auto.
     min-height: 0;
 
-    // Toggled from JS (SidebarResize.setupCompactObserver) via a ResizeObserver on
-    // the wrap element: when its rendered border-box width is <= 1024px the sidebar
-    // switches to a fixed 300px pane and the resize handle is disabled.
+    // Toggled from by ResizeObserver on the wrap element when the editor is narrow
     &--compact {
       grid-template-columns: 1fr max-content;
 
@@ -49,9 +47,8 @@
       .tox-sidebar__resize-handle {
         cursor: inherit;
 
-        // If I do it like that then the element is still there and can hijack click events, I need to address that
-        &:hover::before {
-          border-left: 0px solid transparent; 
+        &::before {
+          display: none;
         }        
       }
     }

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -283,7 +283,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
           [SidebarResize.minEditingAreaWidthProperty]: Utils.numToPx(SidebarResize.minEditingAreaWidth)
         }
       },
-      behaviours: SidebarResize.setupCompactObserver(),
+      // behaviours: SidebarResize.setupCompactObserver(), // TODO: Temporarily commented breakpoint for demo purposes
       components: [
         partSocket,
         partSidebar

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -283,6 +283,7 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
           [SidebarResize.minEditingAreaWidthProperty]: Utils.numToPx(SidebarResize.minEditingAreaWidth)
         }
       },
+      behaviours: SidebarResize.setupCompactObserver(),
       components: [
         partSocket,
         partSidebar

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
@@ -1,11 +1,46 @@
-import { Css, type SugarElement } from '@ephox/sugar';
+import { AlloyEvents, type Behaviour } from '@ephox/alloy';
+import { Arr, Singleton } from '@ephox/katamari';
+import { Class, Css, type SugarElement, Width } from '@ephox/sugar';
 
+import { SimpleBehaviours } from '../alien/SimpleBehaviours';
 import { numToPx } from '../sizing/Utils';
 
 export const requestedWidthProperty = '--tox-private-requested-sidebar-width';
 export const minEditingAreaWidthProperty = '--tox-private-min-editing-area-width';
 export const minEditingAreaWidth = 280;
+export const compactBreakpoint = 1024;
+export const compactClass = 'tox-sidebar-wrap--compact';
 
 export const applyWidth = (sidebar: SugarElement<HTMLElement>, width: number): void => {
   Css.set(sidebar, requestedWidthProperty, numToPx(width));
+};
+
+export const setupCompactObserver = (): Behaviour.AlloyBehaviourRecord => {
+  const observerSingleton = Singleton.value<ResizeObserver>();
+  return SimpleBehaviours.unnamedEvents([
+    AlloyEvents.runOnAttached((comp) => {
+      const update = (width: number) => {
+        const shouldBeCompact = width <= compactBreakpoint;
+        if (shouldBeCompact && !Class.has(comp.element, compactClass)) {
+          Class.add(comp.element, compactClass);
+        } else if (!shouldBeCompact && Class.has(comp.element, compactClass)) {
+          Class.remove(comp.element, compactClass);
+        }
+      };
+      const observer = new window.ResizeObserver((entries) => {
+        Arr.each(entries, (entry) => {
+          // borderBoxSize reflects the element's real box (border-box), matching Width.get
+          update(entry.borderBoxSize[0].inlineSize);
+        });
+      });
+      observer.observe(comp.element.dom);
+      observerSingleton.set(observer);
+      // initial state
+      update(Width.get(comp.element));
+    }),
+    AlloyEvents.runOnDetached(() => {
+      observerSingleton.on((observer) => observer.disconnect());
+      observerSingleton.clear();
+    })
+  ]);
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
@@ -8,7 +8,12 @@ import { numToPx } from '../sizing/Utils';
 export const requestedWidthProperty = '--tox-private-requested-sidebar-width';
 export const minEditingAreaWidthProperty = '--tox-private-min-editing-area-width';
 export const minEditingAreaWidth = 280;
-export const compactBreakpoint = 1024;
+// The compact breakpoint is defined as a total editor width of 1024px. However, we measure
+// against `.tox-sidebar-wrapper`, whose width excludes the editor's border (2px on each side,
+// 4px total). We subtract that border width here so the breakpoint still triggers at an overall
+// editor width of 1024px.
+const editorBorderWidth = 4;
+export const compactBreakpoint = 1024 - editorBorderWidth;
 export const compactClass = 'tox-sidebar-wrap--compact';
 
 export const applyWidth = (sidebar: SugarElement<HTMLElement>, width: number): void => {
@@ -29,13 +34,12 @@ export const setupCompactObserver = (): Behaviour.AlloyBehaviourRecord => {
       };
       const observer = new window.ResizeObserver((entries) => {
         Arr.each(entries, (entry) => {
-          // borderBoxSize reflects the element's real box (border-box), matching Width.get
           update(entry.borderBoxSize[0].inlineSize);
         });
       });
       observer.observe(comp.element.dom);
       observerSingleton.set(observer);
-      // initial state
+
       update(Width.get(comp.element));
     }),
     AlloyEvents.runOnDetached(() => {

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
@@ -1,6 +1,6 @@
 import { type AlloyComponent, type AlloySpec, Behaviour, Dragging, Resizing } from '@ephox/alloy';
-import type { Optional } from '@ephox/katamari';
-import { Height, SelectorFind, type SugarElement, SugarPosition, Width } from '@ephox/sugar';
+import { type Optional, Optionals } from '@ephox/katamari';
+import { Class, Height, SelectorFind, type SugarElement, SugarPosition, Width } from '@ephox/sugar';
 
 import type { SidebarSizeConstraints } from './Sidebar';
 import * as SidebarResize from './SidebarResize';
@@ -24,16 +24,14 @@ export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints)
         mode: 'pointer',
         repositionTarget: false,
         onDragStart: (handle) => {
-          findSidebar(handle).each((sidebar) => {
+          Optionals.lift2(findSidebar(handle), findSidebarWrap(handle), (sidebar, wrap) => {
             const sidebarWidth = Width.get(sidebar);
-            const availableMax = findSidebarWrap(handle)
-              .map((wrap) => Math.floor(Width.get(wrap)) - SidebarResize.minEditingAreaWidth)
-              .getOr(maxWidth);
+            const availableMax = Math.floor(Width.get(wrap)) - SidebarResize.minEditingAreaWidth;
             const effectiveMax = Math.min(maxWidth, availableMax);
             // When the editor is too narrow to honour both the sidebar's configured minimum
             // and the editing area's minimum, the range is unsatisfiable. Skip the resize so a
             // drag can't clobber the preserved requested width with the clamped value.
-            if (effectiveMax >= minWidth) {
+            if (effectiveMax >= minWidth && !Class.has(wrap, SidebarResize.compactClass)) {
               Resizing.start(handle, sidebarWidth, Height.get(sidebar), { minWidth, maxWidth: effectiveMax });
             }
           });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -392,7 +392,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
     it('TINYMCE-14533: should shrink the editing area, not the fixed sidebar, when the editor is resized narrower', async () => {
       const editor = hook.editor();
 
-      await resizeEditorBy([ 500 - 1024, 0 ]);
+      await resizeEditorBy([ 500 - 1024, 0 ], 1);
 
       assert.equal(Width.get(TinyDom.container(editor)), 500, 'The editor should shrink');
       assert.equal(SidebarUtils.getSidebarRequestedWidth(), 500, 'The requested sidebar width should be preserved');

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -370,4 +370,34 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
       });
     });
   });
+
+  context('TINYMCE-14533: Sidebar resizing should be turned off when the editor is narrow', () => {
+    const fixedSidebarWidth = 300;
+    const editorInitialWidth = 1024;
+
+    const hook = setupEditorHook({ sidebar_show: 'sidebarone', width: editorInitialWidth, sidebar_width: 500, statusbar: true, resize: 'both' });
+
+    afterEach(async () => resetEditorWidth(hook.editor(), editorInitialWidth));
+
+    it('TINYMCE-14533: should fix the sidebar at 300px and ignore attempts to shrink it when the editor is narrow', async () => {
+      assert.equal(SidebarUtils.getSidebarRequestedWidth(), 500, 'The requested width should match the configured sidebar width');
+      assertSidebarWidth(fixedSidebarWidth, 'The sidebar should be clamped to 300px because the editor is narrow');
+
+      await SidebarUtils.resizeSidebarBy([ 100, 0 ]);
+
+      assertSidebarWidth(fixedSidebarWidth, 'The rendered width should be unchanged because resizing is disabled while the editor is narrow');
+      assert.equal(SidebarUtils.getSidebarRequestedWidth(), 500, 'The requested width should be unchanged because resizing is disabled while the editor is narrow');
+    });
+
+    it('TINYMCE-14533: should shrink the editing area, not the fixed sidebar, when the editor is resized narrower', async () => {
+      const editor = hook.editor();
+
+      await resizeEditorBy([ 500 - 1024, 0 ]);
+
+      assert.equal(Width.get(TinyDom.container(editor)), 500, 'The editor should shrink');
+      assert.equal(SidebarUtils.getSidebarRequestedWidth(), 500, 'The requested sidebar width should be preserved');
+      assertSidebarWidth(fixedSidebarWidth, 'The sidebar should stay fixed');
+      assert.equal(Width.get(SidebarUtils.getEditArea()), 500 - fixedSidebarWidth - editorBorderLeft - editorBorderRight, 'The editing area should shrink');
+    });
+  });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -1,8 +1,8 @@
-import { Pointer } from '@ephox/agar';
+import { Pointer, Waiter } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import type { Sidebar } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
-import { Css, Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { Class, Css, Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -64,7 +64,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
 
   const resetEditorWidth = async (editor: Editor, initialWidth: number) => {
     const container = TinyDom.container(editor);
-    await resizeEditorBy([ initialWidth - Width.get(container), 0 ]);
+    await resizeEditorBy([ initialWidth - Width.get(container), 0 ], 1);
   };
 
   context('TINYMCE-14527: Resizing the sidebar', () => {
@@ -374,10 +374,15 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
   context('TINYMCE-14533: Sidebar resizing should be turned off when the editor is narrow', () => {
     const fixedSidebarWidth = 300;
     const editorInitialWidth = 1024;
+    const compactClass = 'tox-sidebar-wrap--compact';
 
     const hook = setupEditorHook({ sidebar_show: 'sidebarone', width: editorInitialWidth, sidebar_width: 500, statusbar: true, resize: 'both' });
 
-    afterEach(async () => resetEditorWidth(hook.editor(), editorInitialWidth));
+    afterEach(async () => {
+      await resetEditorWidth(hook.editor(), editorInitialWidth);
+      const wrap = SidebarUtils.getSidebarWrap();
+      await Waiter.pTryUntilPredicate('The sidebar-wrap should be compact', () => Class.has(wrap, compactClass));
+    });
 
     it('TINYMCE-14533: should fix the sidebar at 300px and ignore attempts to shrink it when the editor is narrow', async () => {
       assert.equal(SidebarUtils.getSidebarRequestedWidth(), 500, 'The requested width should match the configured sidebar width');
@@ -398,6 +403,25 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
       assert.equal(SidebarUtils.getSidebarRequestedWidth(), 500, 'The requested sidebar width should be preserved');
       assertSidebarWidth(fixedSidebarWidth, 'The sidebar should stay fixed');
       assert.equal(Width.get(SidebarUtils.getEditArea()), 500 - fixedSidebarWidth - editorBorderLeft - editorBorderRight, 'The editing area should shrink');
+    });
+
+    it('TINYMCE-14533: should toggle the compact class at the breakpoint', async () => {
+      const editor = hook.editor();
+      const wrap = SidebarUtils.getSidebarWrap();
+
+      await resizeEditorBy([ 1, 0 ], 1);
+      assert.equal(Width.get(TinyDom.container(editor)), 1025, 'The editor should grow');
+      await Waiter.pTryUntilPredicate(
+        'The sidebar-wrap should not be compact above the breakpoint',
+        () => !Class.has(wrap, compactClass)
+      );
+
+      await resizeEditorBy([ -1, 0 ], 1);
+      assert.equal(Width.get(TinyDom.container(editor)), 1024, 'The editor should shrink');
+      await Waiter.pTryUntilPredicate(
+        'The sidebar-wrap should be compact at the breakpoint',
+        () => Class.has(wrap, compactClass)
+      );
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINYMCE-14533

Description of Changes:

- Added a `ResizeObserver` on the sidebar wrap element that toggles a `tox-sidebar-wrap--compact` CSS class when the editor width is at or below 1024px
- When in compact mode, the sidebar is fixed at 300px wide and the resize handle is non-interactive
- Drag-to-resize is disabled while the compact class is present, preventing the stored requested width from being overwritten when the editor is narrow

Pre-checks:

~~\- [ ] Changelog entry added~~

- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`
- [ ] Uncomment the breakpoint

Review:

- [ ] Milestone set
- [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added a compact sidebar mode for narrow editor widths.
    - Sidebar resizing now adapts automatically when space is limited, keeping the editor usable on smaller screens.
- **Bug Fixes**
    - Improved sidebar drag behavior so resizing is disabled in compact mode.
    - Sidebar width is now constrained more consistently, preventing layout overflow and preserving the editing area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->