### PR TITLE
TINYMCE-14529: Add sidebar resize start/stop events

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/EventTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/EventTypes.ts
@@ -64,6 +64,10 @@ export interface ObjectResizeEvent {
   origin: string;
 }
 
+export interface SidebarResizedEvent {
+  width: number;
+}
+
 export interface ObjectSelectedEvent {
   target: Node;
   targetClone?: Node;
@@ -194,6 +198,8 @@ export interface EditorEventMap extends Omit<NativeEventMap, 'blur' | 'focus'> {
   AfterScrollIntoView: ScrollIntoViewEvent;
   ObjectResized: ObjectResizeEvent;
   ObjectResizeStart: ObjectResizeEvent;
+  SidebarResizeStart: { };
+  SidebarResized: SidebarResizedEvent;
   SwitchMode: SwitchModeEvent;
   ScrollWindow: Event;
   ResizeWindow: UIEvent;

--- a/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Events.ts
@@ -1,5 +1,7 @@
 import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEventMap } from 'tinymce/core/api/EventTypes';
 import type { EditorEvent } from 'tinymce/core/api/util/EventDispatcher';
+import type Observable from 'tinymce/core/api/util/Observable';
 
 const fireSkinLoaded = (editor: Editor): void => {
   editor.dispatch('SkinLoaded');
@@ -67,6 +69,14 @@ const fireToggleSidebar = (editor: Editor): void => {
   editor.dispatch('ToggleSidebar');
 };
 
+const fireSidebarResizeStart = (dispatcher: Observable<EditorEventMap>): void => {
+  dispatcher.dispatch('SidebarResizeStart');
+};
+
+const fireSidebarResized = (dispatcher: Observable<EditorEventMap>, width: number): void => {
+  dispatcher.dispatch('SidebarResized', { width });
+};
+
 const fireToggleView = (editor: Editor): void => {
   editor.dispatch('ToggleView');
 };
@@ -96,6 +106,8 @@ export {
   fireBlocksTextUpdate,
   fireFontFamilyTextUpdate,
   fireToggleSidebar,
+  fireSidebarResizeStart,
+  fireSidebarResized,
   fireToggleView,
   fireContextToolbarClose,
   fireContextFormSlideBack

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -117,7 +117,8 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
       {
         minWidth: Options.getSidebarMinWidth(editor),
         maxWidth: Options.getSidebarMaxWidth(editor)
-      }
+      },
+      editor
     );
 
     OuterContainer.setViews(

--- a/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/general/OuterContainer.ts
@@ -5,6 +5,9 @@ import { FieldSchema } from '@ephox/boulder';
 import { Arr, Id, Obj, Optional, Optionals, Type, type Result } from '@ephox/katamari';
 import { Attribute, Css, SelectorFind, type SugarElement } from '@ephox/sugar';
 
+import type { EditorEventMap } from 'tinymce/core/api/EventTypes';
+import type Observable from 'tinymce/core/api/util/Observable';
+
 import { ToolbarMode } from '../../api/Options';
 import type { UiFactoryBackstageProviders } from '../../backstage/Backstage';
 import { type HeaderSpec, renderHeader } from '../header/CommonHeader';
@@ -57,7 +60,7 @@ interface ToolbarSketchSpec extends MoreDrawerData {
 interface OuterContainerApis {
   readonly getHeader: (comp: AlloyComponent) => Optional<AlloyComponent>;
   readonly getSocket: (comp: AlloyComponent) => Optional<AlloyComponent>;
-  readonly setSidebar: (comp: AlloyComponent, panelConfigs: Sidebar.SidebarConfig, showSidebar: string | undefined, sizeConstraints: Sidebar.SidebarSizeConstraints) => void;
+  readonly setSidebar: (comp: AlloyComponent, panelConfigs: Sidebar.SidebarConfig, showSidebar: string | undefined, sizeConstraints: Sidebar.SidebarSizeConstraints, eventDispatcher: Observable<EditorEventMap>) => void;
   readonly toggleSidebar: (comp: AlloyComponent, name: string) => void;
   readonly whichSidebar: (comp: AlloyComponent) => string | null;
   // Maybe just change to ToolbarAnchor.
@@ -106,9 +109,9 @@ const factory: UiSketcher.CompositeSketchFactory<OuterContainerSketchDetail, Out
     getSocket: (comp) => {
       return Composite.parts.getPart(comp, detail, 'socket');
     },
-    setSidebar: (comp, panelConfigs, showSidebar, sizeConstraints) => {
+    setSidebar: (comp, panelConfigs, showSidebar, sizeConstraints, eventDispatcher) => {
       Composite.parts.getPart(comp, detail, 'sidebar').each(
-        (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs, showSidebar, sizeConstraints)
+        (sidebar) => Sidebar.setSidebar(sidebar, panelConfigs, showSidebar, sizeConstraints, eventDispatcher)
       );
     },
     toggleSidebar: (comp, name) => {
@@ -422,8 +425,8 @@ export default Sketcher.composite<OuterContainerSketchSpec, OuterContainerSketch
     getSocket: (apis, comp) => {
       return apis.getSocket(comp);
     },
-    setSidebar: (apis, comp, panelConfigs, showSidebar, sizeConstraints) => {
-      apis.setSidebar(comp, panelConfigs, showSidebar, sizeConstraints);
+    setSidebar: (apis, comp, panelConfigs, showSidebar, sizeConstraints, eventDispatcher) => {
+      apis.setSidebar(comp, panelConfigs, showSidebar, sizeConstraints, eventDispatcher);
     },
     toggleSidebar: (apis, comp, name) => {
       apis.toggleSidebar(comp, name);

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -10,6 +10,8 @@ import { Arr, Cell, Fun, Id, Obj, Optional, Optionals, Type } from '@ephox/katam
 import { Attribute, Css, type SugarElement, Width } from '@ephox/sugar';
 
 import type Editor from 'tinymce/core/api/Editor';
+import type { EditorEventMap } from 'tinymce/core/api/EventTypes';
+import type Observable from 'tinymce/core/api/util/Observable';
 import { onControlAttached, onControlDetached } from 'tinymce/themes/silver/ui/controls/Controls';
 
 import { ComposingConfigs } from '../alien/ComposingConfigs';
@@ -101,13 +103,13 @@ const makePanels = (parts: SlotContainerTypes.SlotContainerParts, panelConfigs: 
   });
 };
 
-const makeSidebar = (panelConfigs: SidebarConfig, sizeConstraints: SidebarSizeConstraints) => SlotContainer.sketch((parts) => ({
+const makeSidebar = (panelConfigs: SidebarConfig, sizeConstraints: SidebarSizeConstraints, eventDispatcher: Observable<EditorEventMap>) => SlotContainer.sketch((parts) => ({
   dom: {
     tag: 'div',
     classes: [ 'tox-sidebar__pane-container' ]
   },
   components: [
-    makeSidebarResizeHandle(sizeConstraints),
+    makeSidebarResizeHandle(sizeConstraints, eventDispatcher),
     ...makePanels(parts, panelConfigs)
   ],
   slotBehaviours: SimpleBehaviours.unnamedEvents([
@@ -115,11 +117,11 @@ const makeSidebar = (panelConfigs: SidebarConfig, sizeConstraints: SidebarSizeCo
   ])
 }));
 
-const setSidebar = (sidebar: AlloyComponent, panelConfigs: SidebarConfig, showSidebar: string | undefined, sizeConstraints: SidebarSizeConstraints): void => {
+const setSidebar = (sidebar: AlloyComponent, panelConfigs: SidebarConfig, showSidebar: string | undefined, sizeConstraints: SidebarSizeConstraints, eventDispatcher: Observable<EditorEventMap>): void => {
   const optSlider = Composing.getCurrent(sidebar);
 
   optSlider.each((slider) => {
-    Replacing.set(slider, [ makeSidebar(panelConfigs, sizeConstraints) ]);
+    Replacing.set(slider, [ makeSidebar(panelConfigs, sizeConstraints, eventDispatcher) ]);
 
     // Show the default sidebar
     const configKey = showSidebar?.toLowerCase();

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
@@ -37,6 +37,7 @@ export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints)
             // drag can't clobber the preserved requested width with the clamped value.
             if (effectiveMax >= minWidth) {
               Resizing.start(handle, sidebarWidth, Height.get(sidebar), { minWidth, maxWidth: effectiveMax });
+              // TODO: Emit SidebarResizeStart event with no payload
             }
           });
         },
@@ -47,7 +48,9 @@ export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints)
           });
         },
         onDrop: (handle) => {
-          Resizing.stop(handle);
+          Resizing.stop(handle).each(({ width }) => {
+            // TODO: Emit SidebarResized event with width as a payload
+          });
         }
       }),
       Resizing.config({})

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResizeHandle.ts
@@ -2,6 +2,11 @@ import { type AlloyComponent, type AlloySpec, Behaviour, Dragging, Resizing } fr
 import { Optionals, type Optional } from '@ephox/katamari';
 import { Height, SelectorFind, type SugarElement, SugarPosition, Width } from '@ephox/sugar';
 
+import type { EditorEventMap } from 'tinymce/core/api/EventTypes';
+import type Observable from 'tinymce/core/api/util/Observable';
+
+import * as Events from '../../api/Events';
+
 import type { SidebarSizeConstraints } from './Sidebar';
 import * as SidebarResize from './SidebarResize';
 
@@ -11,7 +16,7 @@ const findSidebar = (handle: AlloyComponent): Optional<SugarElement<HTMLElement>
 const findSidebarWrap = (handle: AlloyComponent): Optional<SugarElement<HTMLElement>> =>
   SelectorFind.ancestor<HTMLElement>(handle.element, '.tox-sidebar-wrap');
 
-export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints): AlloySpec => {
+export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints, eventDispatcher: Observable<EditorEventMap>): AlloySpec => {
   const { minWidth, maxWidth } = sizeConstraints;
 
   return {
@@ -37,7 +42,7 @@ export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints)
             // drag can't clobber the preserved requested width with the clamped value.
             if (effectiveMax >= minWidth) {
               Resizing.start(handle, sidebarWidth, Height.get(sidebar), { minWidth, maxWidth: effectiveMax });
-              // TODO: Emit SidebarResizeStart event with no payload
+              Events.fireSidebarResizeStart(eventDispatcher);
             }
           });
         },
@@ -49,7 +54,7 @@ export const makeSidebarResizeHandle = (sizeConstraints: SidebarSizeConstraints)
         },
         onDrop: (handle) => {
           Resizing.stop(handle).each(({ width }) => {
-            // TODO: Emit SidebarResized event with width as a payload
+            Events.fireSidebarResized(eventDispatcher, width);
           });
         }
       }),

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -1,7 +1,5 @@
-import { Pointer } from '@ephox/agar';
-import { afterEach, context, describe, it } from '@ephox/bedrock-client';
-import { TestStore } from '@ephox/agar';
-import { beforeEach } from '@ephox/bedrock-client';
+import { Pointer, TestStore } from '@ephox/agar';
+import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import type { Sidebar } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -1,5 +1,7 @@
 import { Pointer } from '@ephox/agar';
 import { afterEach, context, describe, it } from '@ephox/bedrock-client';
+import { TestStore } from '@ephox/agar';
+import { beforeEach } from '@ephox/bedrock-client';
 import type { Sidebar } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
 import { Css, Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
@@ -16,7 +18,18 @@ import { resizeEditorBy } from '../../module/UiUtils';
 const editorBorderLeft = 2;
 const editorBorderRight = 2;
 
+type SidebarResizeEvent =
+  | { type: 'SidebarResizeStart' }
+  | { type: 'SidebarResized'; width: number };
+
 describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
+  const resizeStartEvent = (): SidebarResizeEvent => ({ type: 'SidebarResizeStart' });
+  const resizedEvent = (width: number): SidebarResizeEvent => ({ type: 'SidebarResized', width });
+
+  const store = TestStore<SidebarResizeEvent>();
+
+  beforeEach(() => store.clear());
+
   const setupEditorHook = (configOverrides: {
     sidebar_show?: string;
     sidebar_min_width?: number;
@@ -43,6 +56,8 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
           });
         register('sidebarone', 'side bar one');
         register('sidebartwo', 'side bar two');
+        editor.on('SidebarResizeStart', () => store.add(resizeStartEvent()));
+        editor.on('SidebarResized', (e) => store.add(resizedEvent(e.width)));
       },
       ...settings
     };
@@ -137,9 +152,12 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
 
         await SidebarUtils.resizeSidebarBy([ -1000, 0 ]);
         assertSidebarWidth(800, 'The sidebar should be capped at the max width');
+        store.assertEq('Dragging to the max should emit start and resized with the max-clamped width', [ resizeStartEvent(), resizedEvent(800) ]);
+        store.clear();
 
         await SidebarUtils.resizeSidebarBy([ 1000, 0 ]);
         assertSidebarWidth(300, 'The sidebar should be capped at the min width');
+        store.assertEq('Dragging to the min should emit start and resized with the min-clamped width', [ resizeStartEvent(), resizedEvent(300) ]);
       });
     });
 
@@ -151,9 +169,12 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
 
         await SidebarUtils.resizeSidebarBy([ -1000, 0 ]);
         assertSidebarWidth(600, 'The sidebar should be capped at the max width');
+        store.assertEq('Dragging to the max should emit start and resized with the max-clamped width', [ resizeStartEvent(), resizedEvent(600) ]);
+        store.clear();
 
         await SidebarUtils.resizeSidebarBy([ 1000, 0 ]);
         assertSidebarWidth(100, 'The sidebar should be capped at the min width');
+        store.assertEq('Dragging to the min should emit start and resized with the min-clamped width', [ resizeStartEvent(), resizedEvent(100) ]);
       });
     });
   });
@@ -223,6 +244,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
         await SidebarUtils.resizeSidebarBy([ -1000, 0 ]);
         assertSidebarWidth(remainingSpace, 'The sidebar should be capped so the editing area keeps its minimum width');
         assert.equal(SidebarUtils.getSidebarRequestedWidth(), remainingSpace, 'The requested width should also be capped, since the drag logic clamps it directly rather than relying on the CSS clamp');
+        store.assertEq('Dragging past the editing-area limit should emit start and resized with the effective-max-clamped width', [ resizeStartEvent(), resizedEvent(remainingSpace) ]);
         assert.equal(Width.get(SidebarUtils.getEditArea()), minEditingAreaWidth, 'The editing area must not shrink below its minimum width');
       });
     });
@@ -367,7 +389,33 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
         await SidebarUtils.resizeSidebarBy([ 10, 0 ]);
         assertSidebarWidth(1000 - minEditingAreaWidth - editorBorderLeft - editorBorderRight, 'Dragging should not move the sidebar');
         assert.equal(SidebarUtils.getSidebarRequestedWidth(), 1000, 'The requested width should be preserved because the drag cannot change the clamped width');
+        store.assertEq('No resize events should be emitted while the sidebar is clamped below its configured min width', []);
       });
+    });
+  });
+
+  context('TINYMCE-14529: Sidebar resize events', () => {
+    setupEditorHook({ sidebar_show: 'sidebarone', sidebar_width: 440, sidebar_min_width: 300, sidebar_max_width: 800 });
+
+    it('TINYMCE-14529: should emit SidebarResizeStart on drag start and SidebarResized with the final width on drag stop', async () => {
+      const resizeHandle = SidebarUtils.getSidebarResizeHandle();
+
+      await Pointer.pWithMockPointerCapture(resizeHandle, {}, async () => {
+        Pointer.pointerDown(resizeHandle);
+        Pointer.pointerMoveBy(resizeHandle, 0, 0);
+        store.assertEq('SidebarResizeStart should be emitted when dragging starts', [ resizeStartEvent() ]);
+
+        Pointer.pointerMoveBy(resizeHandle, -40, 0);
+        assertSidebarWidth(480, 'Dragging the handle left should grow the sidebar');
+        store.assertEq('SidebarResized should not be emitted mid-drag', [ resizeStartEvent() ]);
+
+        Pointer.pointerUp(resizeHandle);
+      });
+
+      store.assertEq(
+        'SidebarResized should be emitted once with the final width when dragging stops',
+        [ resizeStartEvent(), resizedEvent(480) ]
+      );
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINYMCE-14529

Description of Changes:

- Added `SidebarResizeStart` and `SidebarResized` events to the editor event map, fired when a sidebar drag begins and ends respectively
- `SidebarResized` includes the final `width` of the sidebar after the drag completes
- These events are not fired when resizing is blocked (e.g. when the editor is too narrow or the sidebar is clamped below its configured minimum width)
- Added tests verifying the events are emitted at the correct times, with correct width values, including clamped widths from min/max constraints and editing area limits

Pre-checks:

~~- [ ] Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar resize lifecycle events to the editor, including a start event and a completed resize event with the final width.
  * Sidebar resizing now emits events when dragging begins and when the resize is finished.

* **Bug Fixes**
  * Improved resize event behavior in constrained layouts, including minimum and maximum width limits.
  * Ensured resize events are only emitted at the correct points during drag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->