### PR TITLE
TINYMCE-13235: Fix list formatting applying to unselected table cells

### DIFF
--- a/.changes/unreleased/tinymce-TINY-13235-2026-07-08.yaml
+++ b/.changes/unreleased/tinymce-TINY-13235-2026-07-08.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Applying or removing formatting on a multi-cell table selection incorrectly styled list items in cells that were not selected.
+time: 2026-07-08T16:20:32.989688+10:00
+custom:
+    Issue: TINY-13235

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -347,7 +347,7 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
       }
 
       ListItemFormat.getExpandedListItemFormat(ed.formatter, name).each((liFmt) => {
-        const list = ListItemFormat.getFullySelectedListItems(ed.selection);
+        const list = ListItemFormat.getFullySelectedListItems(ed);
         Arr.each(list, (li) => ApplyElementFormat.applyStyles(dom, li, liFmt as ApplyFormat, vars));
       });
     }

--- a/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
@@ -1,11 +1,14 @@
 import { Arr, Obj, Optional, Type } from '@ephox/katamari';
+import { SelectorFilter } from '@ephox/sugar';
 
 import type DOMUtils from '../api/dom/DOMUtils';
 import type EditorSelection from '../api/dom/Selection';
+import type Editor from '../api/Editor';
 import type Formatter from '../api/Formatter';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as NodeType from '../dom/NodeType';
+import * as TableCellSelection from '../selection/TableCellSelection';
 
 import type { Format, InlineFormat } from './FormatTypes';
 import * as FormatUtils from './FormatUtils';
@@ -43,6 +46,19 @@ const getAndOnlyNormalizeFirstBlockIf = (selection: EditorSelection, pred: (bloc
     }
   });
 
+// When a fake (multi-cell table) selection is active, the DOM range spans from the first to the
+// last selected cell and would sweep in list items from unselected cells in between. Resolve list
+// items from the actually selected cells instead, matching how SelectionUtils.runOnRanges works.
+const getCellSelectionListItems = (editor: Editor): Optional<Element[]> => {
+  const fakeSelectionNodes = TableCellSelection.getCellsFromEditor(editor);
+  if (fakeSelectionNodes.length > 0) {
+    const listItems = Arr.bind(fakeSelectionNodes, (cell) => SelectorFilter.descendants(cell, 'li'));
+    return Optional.some(Arr.map(listItems, (item) => item.dom));
+  } else {
+    return Optional.none();
+  }
+};
+
 const getFullySelectedBlocks = (selection: EditorSelection) => {
   if (selection.isCollapsed()) {
     return [];
@@ -64,10 +80,13 @@ const getFullySelectedBlocks = (selection: EditorSelection) => {
   }
 };
 
-export const getFullySelectedListItems = (selection: EditorSelection): Element[] =>
-  Arr.filter(getFullySelectedBlocks(selection), isEditableListItem(selection.dom));
+export const getFullySelectedListItems = (editor: Editor): Element[] => {
+  const items = getCellSelectionListItems(editor).getOrThunk(() => getFullySelectedBlocks(editor.selection));
+  return Arr.filter(items, isEditableListItem(editor.selection.dom));
+};
 
-export const getPartiallySelectedListItems = (selection: EditorSelection): Element[] => Arr.filter(
-  getAndOnlyNormalizeFirstBlockIf(selection, (el) => !NodeType.isListItem(el)),
-  isEditableListItem(selection.dom)
-);
+export const getPartiallySelectedListItems = (editor: Editor): Element[] => {
+  const items = getCellSelectionListItems(editor)
+    .getOrThunk(() => getAndOnlyNormalizeFirstBlockIf(editor.selection, (el) => !NodeType.isListItem(el)));
+  return Arr.filter(items, isEditableListItem(editor.selection.dom));
+};

--- a/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ListItemFormat.ts
@@ -46,9 +46,8 @@ const getAndOnlyNormalizeFirstBlockIf = (selection: EditorSelection, pred: (bloc
     }
   });
 
-// When a fake (multi-cell table) selection is active, the DOM range spans from the first to the
-// last selected cell and would sweep in list items from unselected cells in between. Resolve list
-// items from the actually selected cells instead, matching how SelectionUtils.runOnRanges works.
+// Resolve list items from the
+// selected cells directly instead, matching how SelectionUtils.runOnRanges resolves fake selections.
 const getCellSelectionListItems = (editor: Editor): Optional<Element[]> => {
   const fakeSelectionNodes = TableCellSelection.getCellsFromEditor(editor);
   if (fakeSelectionNodes.length > 0) {

--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -223,13 +223,13 @@ const removeStyles = (dom: DOMUtils, elm: Element, format: Format, vars: FormatV
 
 const removeListStyleFormats = (editor: Editor, name: string, vars: FormatVars | undefined) => {
   if (name === 'removeformat') {
-    Arr.each(ListItemFormat.getPartiallySelectedListItems(editor.selection), (li) => {
+    Arr.each(ListItemFormat.getPartiallySelectedListItems(editor), (li) => {
       Arr.each(ListItemFormat.listItemStyles, (name) => editor.dom.setStyle(li, name, ''));
       removeEmptyStyleAttributeIfNeeded(editor.dom, li);
     });
   } else {
     ListItemFormat.getExpandedListItemFormat(editor.formatter, name).each((liFmt) => {
-      Arr.each(ListItemFormat.getPartiallySelectedListItems(editor.selection), (li) => removeStyles(editor.dom, li, liFmt, vars, null));
+      Arr.each(ListItemFormat.getPartiallySelectedListItems(editor), (li) => removeStyles(editor.dom, li, liFmt, vars, null));
     });
   }
 };

--- a/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/ListItemFormatTest.ts
@@ -523,4 +523,81 @@ describe('browser.tinymce.core.fmt.ListItemFormatTest', () => {
       );
     });
   });
+
+  context('Inline formats on LIs within a table cell selection', () => {
+    // data-mce-selected marks the fake (multi-cell) selection; the internal attribute is stripped from getContent output.
+    const cell = (contents: string, selected: boolean) =>
+      `<td${selected ? ' data-mce-selected="1"' : ''}>${contents}</td>`;
+    const list = (styleAttr: string = '') =>
+      `<ul><li${styleAttr}>Item 1</li><li${styleAttr}>Item 2</li></ul>`;
+    const table = (cells: string[]) =>
+      `<table><tbody><tr>${cells.join('')}</tr></tbody></table>`;
+
+    it('TINYMCE-13235: applying bold to a table cell selection only styles the LIs in selected cells', () => {
+      const editor = hook.editor();
+      editor.setContent(table([
+        cell(list(), true),
+        cell(list(), false)
+      ]));
+      editor.formatter.apply('bold');
+      TinyAssertions.assertContent(editor, table([
+        cell('<ul><li style="font-weight: bold;"><strong>Item 1</strong></li><li style="font-weight: bold;"><strong>Item 2</strong></li></ul>', false),
+        cell(list(), false)
+      ]));
+    });
+
+    it('TINYMCE-13235: applying text color to a table cell selection only colors the LIs (and their markers) in selected cells', () => {
+      const editor = hook.editor();
+      editor.setContent(table([
+        cell(list(), true),
+        cell(list(), false)
+      ]));
+      editor.formatter.apply('forecolor', { value: 'red' });
+      TinyAssertions.assertContent(editor, table([
+        cell('<ul><li style="color: red;"><span style="color: red;">Item 1</span></li><li style="color: red;"><span style="color: red;">Item 2</span></li></ul>', false),
+        cell(list(), false)
+      ]));
+    });
+
+    it('TINYMCE-13235: applying bold to a cell that also contains a paragraph before the list only styles the selected cells', () => {
+      const editor = hook.editor();
+      editor.setContent(table([
+        cell(`<p>hello</p>${list()}`, true),
+        cell(list(), false)
+      ]));
+      editor.formatter.apply('bold');
+      TinyAssertions.assertContent(editor, table([
+        cell('<p><strong>hello</strong></p><ul><li style="font-weight: bold;"><strong>Item 1</strong></li><li style="font-weight: bold;"><strong>Item 2</strong></li></ul>', false),
+        cell(list(), false)
+      ]));
+    });
+
+    it('TINYMCE-13235: removing formats from a table cell selection only clears the LIs in selected cells', () => {
+      const editor = hook.editor();
+      const styled = ' style="font-weight: bold;"';
+      editor.setContent(table([
+        cell(`<ul><li${styled}><strong>Item 1</strong></li><li${styled}><strong>Item 2</strong></li></ul>`, true),
+        cell(`<ul><li${styled}><strong>Item 1</strong></li><li${styled}><strong>Item 2</strong></li></ul>`, false)
+      ]));
+      editor.formatter.remove('bold');
+      TinyAssertions.assertContent(editor, table([
+        cell('<ul><li>Item 1</li><li>Item 2</li></ul>', false),
+        cell(`<ul><li${styled}><strong>Item 1</strong></li><li${styled}><strong>Item 2</strong></li></ul>`, false)
+      ]));
+    });
+
+    it('TINYMCE-13235: clearing formats (removeformat) from a table cell selection only clears the LIs in selected cells', () => {
+      const editor = hook.editor();
+      const styled = ' style="font-weight: bold;"';
+      editor.setContent(table([
+        cell(`<ul><li${styled}><strong>Item 1</strong></li><li${styled}><strong>Item 2</strong></li></ul>`, true),
+        cell(`<ul><li${styled}><strong>Item 1</strong></li><li${styled}><strong>Item 2</strong></li></ul>`, false)
+      ]));
+      editor.formatter.remove('removeformat');
+      TinyAssertions.assertContent(editor, table([
+        cell('<ul><li>Item 1</li><li>Item 2</li></ul>', false),
+        cell(`<ul><li${styled}><strong>Item 1</strong></li><li${styled}><strong>Item 2</strong></li></ul>`, false)
+      ]));
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINY-13235

Description of Changes:

- Fixed a bug where applying or removing formatting on a multi-cell table selection incorrectly styled list items in cells that were not selected.

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)
- [x]  Don't merge until after 8.8

GitHub issues (if applicable):