### PR TITLE
TINYMCE-14506: close `tooltips` on `escape`

### DIFF
--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ import {
 import * as Browser from '../../utils/Browser';
 import { DropdownContext } from '../dropdown/internals/Context';
 
-import { closeActiveTooltips, TooltipContext, useTooltip } from './internals/Context';
+import { TooltipContext, tooltipsEventTarget, useTooltip } from './internals/Context';
 
 interface RootProps extends PropsWithChildren {
   readonly showCondition?: 'always' | 'overflow';
@@ -29,13 +29,28 @@ const isOverflowingDeep = (root: HTMLElement) =>
     (child) => SugarNode.isHTMLElement(child) && isOverflowing(child.dom));
 
 const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
-  const { setIsOpen, showCondition, triggerRef, setCanShow, popupAnchor } = useTooltip();
+  const { setIsOpen, isOpen, showCondition, triggerRef, setCanShow, popupAnchor } = useTooltip();
+
+  const onKeyUp = useCallback((e: Event) => {
+    const keyboardEvent = e as KeyboardEvent;
+    if (keyboardEvent.code === 'Escape' && isOpen) {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsOpen(false);
+      tooltipsEventTarget.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
+    }
+  }, [ isOpen, setIsOpen ]);
 
   useLayoutEffect(() => {
-    const handler = () => setIsOpen(false);
-    closeActiveTooltips.addEventListener('CloseActiveTooltips', handler);
-    return () => closeActiveTooltips.removeEventListener('CloseActiveTooltips', handler);
-  }, [ setIsOpen ]);
+    if (!isOpen) {
+      return;
+    }
+
+    window.document.addEventListener('keydown', onKeyUp, { capture: true });
+    return () => {
+      window.document.removeEventListener('keydown', onKeyUp, { capture: true });
+    };
+  }, [ isOpen, onKeyUp ]);
 
   useLayoutEffect(() => {
     if (showCondition === 'always') {
@@ -123,7 +138,7 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
       theChild.props.onMouseEnter?.(e);
       props.onMouseEnter?.(e);
       if (!e.isDefaultPrevented()) {
-        closeActiveTooltips.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
+        tooltipsEventTarget.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
         setIsOpen(true);
       }
     },
@@ -138,7 +153,7 @@ const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, .
       theChild.props.onFocus?.(e);
       props.onFocus?.(e);
       if (!e.isDefaultPrevented()) {
-        closeActiveTooltips.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
+        tooltipsEventTarget.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
         setIsOpen(true);
       }
     },

--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -31,27 +31,6 @@ const isOverflowingDeep = (root: HTMLElement) =>
 const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
   const { setIsOpen, isOpen, showCondition, triggerRef, setCanShow, popupAnchor } = useTooltip();
 
-  // this is needed to avoid that navigation move the focus
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const onKeyUp = (e: Event) => {
-      const keyboardEvent = e as KeyboardEvent;
-      if (keyboardEvent.code === 'Escape' && isOpen) {
-        e.preventDefault();
-        e.stopPropagation();
-        setIsOpen(false);
-        tooltipsEventTarget.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
-      }
-    };
-
-    window.document.addEventListener('keydown', onKeyUp, { capture: true });
-    return () => {
-      window.document.removeEventListener('keydown', onKeyUp, { capture: true });
-    };
-  }, [ isOpen, setIsOpen ]);
-
   useLayoutEffect(() => {
     const closeTooltipHandler = (e: Event) => {
       if (isOpen) {

--- a/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/Tooltip.tsx
@@ -31,26 +31,39 @@ const isOverflowingDeep = (root: HTMLElement) =>
 const TriggerImpl = forwardRef<HTMLElement, TriggerInternalProps>(({ children, ...props }, ref) => {
   const { setIsOpen, isOpen, showCondition, triggerRef, setCanShow, popupAnchor } = useTooltip();
 
-  const onKeyUp = useCallback((e: Event) => {
-    const keyboardEvent = e as KeyboardEvent;
-    if (keyboardEvent.code === 'Escape' && isOpen) {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsOpen(false);
-      tooltipsEventTarget.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
-    }
-  }, [ isOpen, setIsOpen ]);
-
+  // this is needed to avoid that navigation move the focus
   useLayoutEffect(() => {
     if (!isOpen) {
       return;
     }
+    const onKeyUp = (e: Event) => {
+      const keyboardEvent = e as KeyboardEvent;
+      if (keyboardEvent.code === 'Escape' && isOpen) {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsOpen(false);
+        tooltipsEventTarget.dispatchEvent(new window.CustomEvent('CloseActiveTooltips', { bubbles: true, cancelable: true }));
+      }
+    };
 
     window.document.addEventListener('keydown', onKeyUp, { capture: true });
     return () => {
       window.document.removeEventListener('keydown', onKeyUp, { capture: true });
     };
-  }, [ isOpen, onKeyUp ]);
+  }, [ isOpen, setIsOpen ]);
+
+  useLayoutEffect(() => {
+    const closeTooltipHandler = (e: Event) => {
+      if (isOpen) {
+        e.preventDefault();
+        setIsOpen(false);
+      }
+    };
+    tooltipsEventTarget.addEventListener('CloseActiveTooltips', closeTooltipHandler);
+    return () => {
+      tooltipsEventTarget.removeEventListener('CloseActiveTooltips', closeTooltipHandler);
+    };
+  }, [ isOpen, setIsOpen ]);
 
   useLayoutEffect(() => {
     if (showCondition === 'always') {

--- a/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
@@ -23,4 +23,5 @@ export const useTooltip = (): TooltipContext => {
   return context;
 };
 
-export const closeActiveTooltips = new window.EventTarget();
+export const tooltipsEventTarget = new window.EventTarget();
+

--- a/modules/oxide-components/src/main/ts/main.ts
+++ b/modules/oxide-components/src/main/ts/main.ts
@@ -20,6 +20,7 @@ import * as Menu from './components/menu/Menu';
 import * as MenuRenderer from './components/menu/MenuRenderer';
 import * as SegmentedControl from './components/segmentedcontrol/SegmentedControl';
 import { ToolbarInputForm } from './components/toolbarInputForm/ToolbarInputForm';
+import { tooltipsEventTarget } from './components/tooltip/internals/Context';
 import * as Tooltip from './components/tooltip/Tooltip';
 import { useUniverse } from './contexts/UniverseContext/Universe';
 import { UniverseProvider } from './contexts/UniverseContext/UniverseProvider';
@@ -56,6 +57,7 @@ export {
   Tag,
   ToolbarInputForm,
   Tooltip,
+  tooltipsEventTarget,
   SegmentedControl,
   UniverseProvider,
   useConfirmationApi,

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -56,8 +56,8 @@ const initTooltipClosing = (editor: Editor) => {
         event.preventDefault();
       }
       Arr.each(editor.editorManager.get(), (otherEditor) => {
-        if (otherEditor !== editor) {
-          Events.fireCloseTooltips(otherEditor);
+        if (Events.fireCloseTooltips(otherEditor).isDefaultPrevented()) {
+          event.preventDefault();
         }
       });
     }

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -55,6 +55,11 @@ const initTooltipClosing = (editor: Editor) => {
       if (Events.fireCloseTooltips(editor).isDefaultPrevented()) {
         event.preventDefault();
       }
+      Arr.each(editor.editorManager.get(), (otherEditor) => {
+        if (otherEditor !== editor) {
+          Events.fireCloseTooltips(otherEditor);
+        }
+      });
     }
   };
 

--- a/modules/tinymce/src/core/main/ts/init/Init.ts
+++ b/modules/tinymce/src/core/main/ts/init/Init.ts
@@ -52,11 +52,8 @@ const initPlugin = (editor: Editor, initializedPlugins: string[], plugin: string
 const initTooltipClosing = (editor: Editor) => {
   const closeTooltipsListener = (event: KeyboardEvent | EditorEvent<KeyboardEvent>) => {
     if (event.keyCode === VK.ESC && !event.defaultPrevented) {
-      if (Events.fireCloseTooltips(editor).isDefaultPrevented()) {
-        event.preventDefault();
-      }
-      Arr.each(editor.editorManager.get(), (otherEditor) => {
-        if (Events.fireCloseTooltips(otherEditor).isDefaultPrevented()) {
+      Arr.each(editor.editorManager.get(), (ed) => {
+        if (Events.fireCloseTooltips(ed).isDefaultPrevented()) {
           event.preventDefault();
         }
       });


### PR DESCRIPTION
Related Ticket: TINYMCE-14506

Description of Changes:
to close the tooltips on escape event when the focus is inside the content of the editor (so inside the iframe) or on another editor and to prevent the navigation via escape, we need an event listener to the event `CloseActiveTooltips` which is the one used in Alloy

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip dismissal so tooltips reliably close when the global “close active tooltips” event is triggered, including keyboard-driven interactions.
  * When a tooltip opens or receives focus, any other open tooltip is dismissed first for consistent behavior.
  * Pressing **Esc** now closes tooltips across multiple open editors, improving consistency in multi-editor scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->