### PR TITLE
TINYMCE-14675: Fix dim active card regression in Suggested Edits

### DIFF
--- a/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
+++ b/modules/oxide/src/less/theme/components/suggestededits/suggestededits.less
@@ -333,7 +333,7 @@
           }
         }
 
-        .tox-suggestededits__card.tox-suggestededits__card--hidden {
+        .tox-suggestededits__card.tox-suggestededits__card--hidden:not(.tox-suggestededits__card--active) {
           opacity: 0.5;
         }
 


### PR DESCRIPTION
Related Ticket: TINYMCE-14675

Description of Changes:
* Fixed regression where an active card stayed dimmed when "Show edits" was toggled off

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
