### PR TITLE
TINYMCE-14678: add resizable flag to addSidebar

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/sidebar/Sidebar.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/sidebar/Sidebar.ts
@@ -10,6 +10,7 @@ export interface SidebarInstanceApi {
 export interface SidebarSpec {
   icon?: string;
   tooltip?: string;
+  resizable?: boolean;
   onShow?: (api: SidebarInstanceApi) => void;
   onSetup?: (api: SidebarInstanceApi) => (api: SidebarInstanceApi) => void;
   onHide?: (api: SidebarInstanceApi) => void;
@@ -18,6 +19,7 @@ export interface SidebarSpec {
 export interface Sidebar {
   icon: Optional<string>;
   tooltip: Optional<string>;
+  resizable: boolean;
   onShow: (api: SidebarInstanceApi) => void;
   onSetup: (api: SidebarInstanceApi) => (api: SidebarInstanceApi) => void;
   onHide: (api: SidebarInstanceApi) => void;
@@ -26,6 +28,7 @@ export interface Sidebar {
 export const sidebarSchema = StructureSchema.objOf([
   ComponentSchema.optionalIcon,
   ComponentSchema.optionalTooltip,
+  FieldSchema.defaultedBoolean('resizable', false),
   FieldSchema.defaultedFunction('onShow', Fun.noop),
   FieldSchema.defaultedFunction('onHide', Fun.noop),
   ComponentSchema.onSetup

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -3,7 +3,7 @@ import {
 } from '@ephox/alloy';
 import { Arr, Merger, Obj, Optional, Result, Singleton } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { Compare, Css, SugarBody, SugarShadowDom, type SugarElement } from '@ephox/sugar';
+import { Class, Compare, Css, SugarBody, SugarShadowDom, type SugarElement } from '@ephox/sugar';
 
 import type Editor from 'tinymce/core/api/Editor';
 import type { ExecCommandArgs } from 'tinymce/core/api/EditorCommands';
@@ -18,6 +18,7 @@ import * as DomEvents from './Events';
 import * as Iframe from './modes/Iframe';
 import * as Inline from './modes/Inline';
 import { LazyUiReferences, type ReadyUiReferences, type SinkAndMothership } from './modes/UiReferences';
+import { SimpleBehaviours } from './ui/alien/SimpleBehaviours';
 import * as ContextToolbar from './ui/context/ContextToolbar';
 import * as FormatControls from './ui/core/FormatControls';
 import OuterContainer from './ui/general/OuterContainer';
@@ -27,6 +28,7 @@ import * as SilverContextMenu from './ui/menus/contextmenu/SilverContextMenu';
 import type { MenuRegistry } from './ui/menus/menubar/Integration';
 import * as TableSelectorHandles from './ui/selector/TableSelectorHandles';
 import * as Sidebar from './ui/sidebar/Sidebar';
+import * as SidebarResize from './ui/sidebar/SidebarResize';
 import * as EditorSize from './ui/sizing/EditorSize';
 import * as Utils from './ui/sizing/Utils';
 import { renderStatusbar } from './ui/statusbar/Statusbar';
@@ -277,12 +279,19 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
     return {
       dom: {
         tag: 'div',
-        classes: [ 'tox-sidebar-wrap', 'tox-sidebar-wrap--resizable' ]
+        classes: [ 'tox-sidebar-wrap' ]
       },
       components: [
         partSocket,
         partSidebar
-      ]
+      ],
+      behaviours: SimpleBehaviours.unnamedEvents([
+        AlloyEvents.run<Sidebar.SidebarContentChangedEvent>(Sidebar.sidebarContentChanged, (comp, se) => {
+          const shouldBeResizable = se.event.visible && se.event.resizable;
+          const toggle = shouldBeResizable ? Class.add : Class.remove;
+          toggle(comp.element, SidebarResize.resizableClass);
+        })
+      ])
     };
   };
 

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -96,7 +96,7 @@ const makePanels = (parts: SlotContainerTypes.SlotContainerParts, panelConfigs: 
             optSidePanelSpec.each((sidePanelSpec) => {
               AlloyTriggers.emitWith(
                 sidepanel,
-                sidebarContentChanged, 
+                sidebarContentChanged,
                 data.visible ? { visible: true, resizable: sidePanelSpec.resizable } : { visible: false }
               );
               const handler = data.visible ? sidePanelSpec.onShow : sidePanelSpec.onHide;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -73,7 +73,8 @@ const makePanels = (parts: SlotContainerTypes.SlotContainerParts, panelConfigs: 
       getApi,
       onSetup: bridged.onSetup,
       onShow: bridged.onShow,
-      onHide: bridged.onHide
+      onHide: bridged.onHide,
+      resizable: bridged.resizable
     };
   });
 
@@ -93,6 +94,11 @@ const makePanels = (parts: SlotContainerTypes.SlotContainerParts, panelConfigs: 
             const data = se.event;
             const optSidePanelSpec = Arr.find(specs, (config) => config.name === data.name);
             optSidePanelSpec.each((sidePanelSpec) => {
+              AlloyTriggers.emitWith(
+                sidepanel,
+                sidebarContentChanged, 
+                data.visible ? { visible: true, resizable: sidePanelSpec.resizable } : { visible: false }
+              );
               const handler = data.visible ? sidePanelSpec.onShow : sidePanelSpec.onHide;
               handler(sidePanelSpec.getApi(sidepanel));
             });
@@ -189,6 +195,12 @@ interface FixSizeEvent extends CustomEvent {
 }
 const fixSize = Id.generate('FixSizeEvent');
 const autoSize = Id.generate('AutoSizeEvent');
+
+export type SidebarContentChangedEvent = CustomEvent & (
+  | { readonly visible: true; readonly resizable: boolean }
+  | { readonly visible: false }
+);
+export const sidebarContentChanged = Id.generate('SidebarContentChanged');
 
 interface SidebarSpec extends SketchSpec {
   readonly configuredSidebarWidth: number;

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/SidebarResize.ts
@@ -7,6 +7,8 @@ export const requestedWidthProperty = '--tox-private-requested-sidebar-width';
 export const resolvedWidthProperty = '--tox-private-resolved-sidebar-width';
 export const minEditingAreaWidthProperty = '--tox-private-min-editing-area-width';
 
+export const resizableClass = 'tox-sidebar-wrap--resizable';
+
 export const applyWidth = (sidebar: SugarElement<HTMLElement>, width: number): void => {
   Css.set(sidebar, requestedWidthProperty, numToPx(width));
 };

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -38,7 +38,7 @@ const registerNotResizable = (editor: Editor, name: string, tooltip: string, col
     icon: 'comment',
     onSetup: (api: Sidebar.SidebarInstanceApi) => {
       const div = SugarElement.fromTag('div');
-      Css.setAll(div, { width: `${width}px`, 'background-color': color });
+      Css.setAll(div, { 'width': `${width}px`, 'background-color': color });
       api.element().appendChild(div.dom);
       return Fun.noop;
     },
@@ -81,7 +81,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
           icon: 'comment',
           onSetup: (api: Sidebar.SidebarInstanceApi) => {
             const div = SugarElement.fromTag('div');
-            Css.setAll(div, { width: '600px', 'background-color': 'green' });
+            Css.setAll(div, { 'width': '600px', 'background-color': 'green' });
             api.element().appendChild(div.dom);
             return Fun.noop;
           }
@@ -518,7 +518,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
 
         await SidebarUtils.resizeSidebarBy([ -40, 0 ]);
         assertSidebarWidth(480, 'Dragging the handle should resize a resizable sidebar');
-        store.assertEq('Resizing a resizable sidebar should emit the resize start and resized events', [resizeStartEvent(), resizedEvent(480)]);
+        store.assertEq('Resizing a resizable sidebar should emit the resize start and resized events', [ resizeStartEvent(), resizedEvent(480) ]);
       });
 
       it('TINYMCE-14678: should toggle the resizable class when switching between resizable and non-resizable panels', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -2,7 +2,7 @@ import { Pointer, TestStore } from '@ephox/agar';
 import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import type { Sidebar } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
-import { Css, Insert, Remove, SugarBody, SugarElement, Width } from '@ephox/sugar';
+import { Class, Css, Insert, Remove, SugarBody, SugarElement, Visibility, Width } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -19,6 +19,32 @@ const editorBorderRight = 2;
 type SidebarResizeEvent =
   | { type: 'SidebarResizeStart' }
   | { type: 'SidebarResized'; width: number };
+
+const registerResizable = (editor: Editor, name: string, tooltip: string): void => {
+  editor.ui.registry.addSidebar(name, {
+    tooltip,
+    icon: 'comment',
+    onSetup: (api: Sidebar.SidebarInstanceApi) => {
+      api.element().appendChild(SugarElement.fromText(name).dom);
+      return Fun.noop;
+    },
+    resizable: true
+  });
+};
+
+const registerNotResizable = (editor: Editor, name: string, tooltip: string, color: string, width: number): void => {
+  editor.ui.registry.addSidebar(name, {
+    tooltip,
+    icon: 'comment',
+    onSetup: (api: Sidebar.SidebarInstanceApi) => {
+      const div = SugarElement.fromTag('div');
+      Css.setAll(div, { width: `${width}px`, 'background-color': color });
+      api.element().appendChild(div.dom);
+      return Fun.noop;
+    },
+    resizable: false
+  });
+};
 
 describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
   const resizeStartEvent = (): SidebarResizeEvent => ({ type: 'SidebarResizeStart' });
@@ -41,19 +67,25 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
     const { setupElement, ...settings } = configOverrides;
     const config = {
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'sidebarone sidebartwo',
+      toolbar: 'sidebarone sidebartwo resizable-unset resizable-false w800-resizable-false w1000-resizable-false',
       setup: (editor: Editor) => {
-        const register = (name: string, tooltip: string) =>
-          editor.ui.registry.addSidebar(name, {
-            tooltip,
-            icon: 'comment',
-            onSetup: (api: Sidebar.SidebarInstanceApi) => {
-              api.element().appendChild(SugarElement.fromText(name).dom);
-              return Fun.noop;
-            }
-          });
-        register('sidebarone', 'side bar one');
-        register('sidebartwo', 'side bar two');
+        registerResizable(editor, 'sidebarone', 'side bar one');
+        registerResizable(editor, 'sidebartwo', 'side bar two');
+        registerNotResizable(editor, 'resizable-false', 'resizable false', 'yellow', 600);
+        registerNotResizable(editor, 'w800-resizable-false', 'w800 resizable false', 'orange', 800);
+        registerNotResizable(editor, 'w1000-resizable-false', 'w1000 resizable false', 'pink', 1000);
+
+        // Registered with the raw API and no resizable flag, to cover the "flag omitted" default case.
+        editor.ui.registry.addSidebar('resizable-unset', {
+          tooltip: 'resizable unset',
+          icon: 'comment',
+          onSetup: (api: Sidebar.SidebarInstanceApi) => {
+            const div = SugarElement.fromTag('div');
+            Css.setAll(div, { width: '600px', 'background-color': 'green' });
+            api.element().appendChild(div.dom);
+            return Fun.noop;
+          }
+        });
         editor.on('SidebarResizeStart', () => store.add(resizeStartEvent()));
         editor.on('SidebarResized', (e) => store.add(resizedEvent(e.width)));
       },
@@ -414,6 +446,159 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
         'SidebarResized should be emitted once with the final width when dragging stops',
         [ resizeStartEvent(), resizedEvent(480) ]
       );
+    });
+  });
+
+  context('TINYMCE-14678: Per-sidebar resizable flag', () => {
+    const resizableClass = 'tox-sidebar-wrap--resizable';
+
+    const assertWrapResizable = (message: string) =>
+      assert.isTrue(Class.has(SidebarUtils.getSidebarWrap(), resizableClass), message);
+
+    const assertWrapNotResizable = (message: string) =>
+      assert.isFalse(Class.has(SidebarUtils.getSidebarWrap(), resizableClass), message);
+
+    const assertHandleVisible = (message: string) =>
+      assert.isTrue(Visibility.isVisible(SidebarUtils.getSidebarResizeHandle()), message);
+
+    const assertHandleNotVisible = (message: string) =>
+      assert.isFalse(Visibility.isVisible(SidebarUtils.getSidebarResizeHandle()), message);
+
+    context('TINYMCE-14678: The resizable state follows the shown sidebar', () => {
+      const initialWidth = 440;
+      const hook = setupEditorHook({ sidebar_width: initialWidth, sidebar_min_width: 300, sidebar_max_width: 800 });
+
+      beforeEach(async () => {
+        const editor = hook.editor();
+        if (editor.queryCommandValue('ToggleSidebar') !== 'sidebarone') {
+          editor.execCommand('ToggleSidebar', false, 'sidebarone');
+          await SidebarUtils.pWaitForSidebarOpen();
+        }
+        await resetSidebarWidth(initialWidth);
+        editor.execCommand('ToggleSidebar', false, 'sidebarone');
+        await SidebarUtils.pWaitForSidebarClosed();
+        store.clear();
+      });
+
+      it('TINYMCE-14678: should not be resizable when the shown sidebar has resizable: false', async () => {
+        const editor = hook.editor();
+        assertWrapNotResizable('The wrap should not have the resizable class while no sidebar is shown');
+
+        editor.execCommand('ToggleSidebar', false, 'resizable-false');
+        assertWrapNotResizable('A resizable: false sidebar should not add the resizable class to the wrap');
+
+        await SidebarUtils.pWaitForSidebarOpen();
+        assertWrapNotResizable('The resizable class should still be absent once the resizable: false sidebar has finished opening');
+        assertHandleNotVisible('The resize handle should not be rendered when the sidebar is not resizable');
+      });
+
+      it('TINYMCE-14678: should not be resizable when the shown sidebar omits the resizable flag', async () => {
+        const editor = hook.editor();
+        assertWrapNotResizable('The wrap should not have the resizable class while no sidebar is shown');
+
+        editor.execCommand('ToggleSidebar', false, 'resizable-unset');
+        assertWrapNotResizable('A sidebar that omits the resizable flag should default to non-resizable and not add the resizable class');
+
+        await SidebarUtils.pWaitForSidebarOpen();
+        assertWrapNotResizable('The resizable class should still be absent once the sidebar that omits the flag has finished opening');
+        assertHandleNotVisible('The resize handle should not be rendered when the sidebar omits the resizable flag');
+      });
+
+      it('TINYMCE-14678: should be resizable when the shown sidebar has resizable: true', async () => {
+        const editor = hook.editor();
+        assertWrapNotResizable('The wrap should not have the resizable class while no sidebar is shown');
+
+        editor.execCommand('ToggleSidebar', false, 'sidebarone');
+        assertWrapResizable('A resizable: true sidebar should add the resizable class to the wrap');
+
+        await SidebarUtils.pWaitForSidebarOpen();
+        assertWrapResizable('The resizable class should still be present once the resizable sidebar has finished opening');
+        assertHandleVisible('The resize handle should be rendered when the sidebar is resizable');
+        assertSidebarWidth(440, 'The sidebar should start at its configured width');
+
+        await SidebarUtils.resizeSidebarBy([ -40, 0 ]);
+        assertSidebarWidth(480, 'Dragging the handle should resize a resizable sidebar');
+        store.assertEq('Resizing a resizable sidebar should emit the resize start and resized events', [resizeStartEvent(), resizedEvent(480)]);
+      });
+
+      it('TINYMCE-14678: should toggle the resizable class when switching between resizable and non-resizable panels', async () => {
+        const editor = hook.editor();
+        assertWrapNotResizable('The wrap should not have the resizable class while no sidebar is shown');
+
+        editor.execCommand('ToggleSidebar', false, 'sidebarone');
+        assertWrapResizable('A resizable: true sidebar should add the resizable class to the wrap');
+
+        await SidebarUtils.pWaitForSidebarOpen();
+        assertWrapResizable('The resizable class should still be present once the resizable sidebar has finished opening');
+        assertHandleVisible('The resize handle should be rendered while a resizable panel is shown');
+
+        editor.execCommand('ToggleSidebar', false, 'resizable-false');
+        assertWrapNotResizable('Switching to a non-resizable panel should remove the resizable class');
+        assertHandleNotVisible('The resize handle should not be rendered while a non-resizable panel is shown');
+
+        editor.execCommand('ToggleSidebar', false, 'sidebarone');
+        assertWrapResizable('Switching back to a resizable panel should restore the resizable class');
+        assertHandleVisible('The resize handle should be rendered again once the resizable panel is shown');
+      });
+
+      it('TINYMCE-14678: should remove the resizable class when a resizable sidebar is hidden', async () => {
+        const editor = hook.editor();
+
+        editor.execCommand('ToggleSidebar', false, 'sidebarone');
+        assertWrapResizable('Showing a resizable panel should add the resizable class immediately after toggling');
+
+        await SidebarUtils.pWaitForSidebarOpen();
+        assertWrapResizable('The resizable class should still be present once the resizable panel has finished opening');
+
+        // The slot is only hidden once the shrink animation finishes, so the class is removed after animation.
+        editor.execCommand('ToggleSidebar', false, 'sidebarone');
+        await SidebarUtils.pWaitForSidebarClosed();
+        assertWrapNotResizable('Hiding a resizable panel should remove the resizable class, since visibility wins over the panel being resizable');
+      });
+    });
+
+    context('TINYMCE-14678: A non-resizable sidebar shown on load via sidebar_show', () => {
+      setupEditorHook({ sidebar_show: 'resizable-false' });
+
+      it('TINYMCE-14678: should not be resizable when a non-resizable sidebar is shown on initial render', () => {
+        assertWrapNotResizable('A non-resizable sidebar shown via sidebar_show should not add the resizable class on initial render');
+        assertHandleNotVisible('The resize handle should not be rendered for a non-resizable sidebar shown on load');
+      });
+    });
+
+    context('TINYMCE-14678: Non-resizable sidebars ignore the width constraints', () => {
+      context('TINYMCE-14678: the configured sidebar_width and sidebar_max_width', () => {
+        const hook = setupEditorHook({ sidebar_width: 500, sidebar_min_width: 300, sidebar_max_width: 600, width: 1200 });
+
+        it('TINYMCE-14678: should render a non-resizable sidebar at its content width, ignoring sidebar_width and sidebar_max_width', async () => {
+          const editor = hook.editor();
+
+          editor.execCommand('ToggleSidebar', false, 'w800-resizable-false');
+          await SidebarUtils.pWaitForSidebarOpen();
+
+          assertSidebarWidth(800, 'A non-resizable sidebar should render at its content width, ignoring the configured sidebar_width and sidebar_max_width');
+        });
+      });
+
+      context('TINYMCE-14678: the editing area minimum width', () => {
+        const hook = setupEditorHook({ sidebar_max_width: 5000, width: 1200 });
+
+        it('TINYMCE-14678: should let a non-resizable sidebar shrink the editing area below its minimum width', async () => {
+          const editor = hook.editor();
+
+          editor.execCommand('ToggleSidebar', false, 'w1000-resizable-false');
+          await SidebarUtils.pWaitForSidebarOpen();
+
+          // The editing-area minimum width is enforced only for resizable sidebars, so a
+          // non-resizable sidebar keeps its full content width and lets the editing area take whatever is left.
+          assertSidebarWidth(1000, 'A non-resizable sidebar should render at its full content width');
+          assert.equal(
+            Width.get(SidebarUtils.getEditArea()),
+            1200 - editorBorderLeft - editorBorderRight - 1000,
+            'The editing area should keep the leftover space even though it drops below the minimum, since that protection only applies to resizable sidebars'
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINYMCE-14678

Description of Changes:

- Added a `resizable` boolean field to the `addSidebar` interface, defaulting to `false` when omitted
- The `tox-sidebar-wrap--resizable` CSS class is now toggled dynamically based on whether the currently visible sidebar has `resizable: true`, rather than being applied unconditionally to the sidebar wrap element
- A new `SidebarContentChangedEvent` is emitted when a sidebar's visibility changes, carrying the sidebar's `resizable` flag so the wrap can react accordingly
- The resize handle and drag-to-resize behaviour are only active when the visible sidebar opts in via `resizable: true`; non-resizable sidebars render at their natural content width and are not constrained by `sidebar_width`, `sidebar_max_width`,  `sidebar_min_width` or the editing area minimum width
- Added tests covering: resizable class toggling when switching between resizable and non-resizable panels, handle visibility, non-resizable sidebars shown via `sidebar_show` on load, and non-resizable sidebars ignoring width constraints

Pre-checks:

~~- [ ] Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebars can now be individually configured as resizable or non-resizable.
  * Resizing controls and behavior update automatically when switching between sidebar panels.
  * Sidebars without a resizable setting default to non-resizable.

* **Bug Fixes**
  * Non-resizable sidebars no longer display resize handles or apply resizing constraints.
  * Sidebar visibility and resizing states now remain synchronized when panels are shown or hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->