### PR TITLE
TINYMCE-14682: Fix common test flakes

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -59,7 +59,7 @@ interface Schema {
  * }
  */
 
-const mapCache: Record<string, SchemaMap> = {};
+let mapCache: Record<string, SchemaMap> = {};
 const makeMap = Tools.makeMap, each = Tools.each, extend = Tools.extend, explode = Tools.explode;
 
 const createMap = (defaultValue: string, extendWith: SchemaMap = {}): SchemaMap => {
@@ -782,6 +782,11 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
     addCustomElements,
     addValidChildren,
   };
+};
+
+// Internal function for testing
+export const _clearCache = (): void => {
+  mapCache = {};
 };
 
 export default Schema;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -59,7 +59,7 @@ interface Schema {
  * }
  */
 
-let mapCache: Record<string, SchemaMap> = {};
+const mapCache: Record<string, SchemaMap> = {};
 const makeMap = Tools.makeMap, each = Tools.each, extend = Tools.extend, explode = Tools.explode;
 
 const createMap = (defaultValue: string, extendWith: SchemaMap = {}): SchemaMap => {
@@ -786,7 +786,9 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
 
 // Internal function for testing to able to clear global schema cache between test cases
 export const _clearCache = (): void => {
-  mapCache = {};
+  Arr.each(Obj.keys(mapCache), (key) => {
+    delete mapCache[key];
+  });
 };
 
 export default Schema;

--- a/modules/tinymce/src/core/main/ts/api/html/Schema.ts
+++ b/modules/tinymce/src/core/main/ts/api/html/Schema.ts
@@ -784,7 +784,7 @@ const Schema = (settings: SchemaSettings = {}): Schema => {
   };
 };
 
-// Internal function for testing
+// Internal function for testing to able to clear global schema cache between test cases
 export const _clearCache = (): void => {
   mapCache = {};
 };

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
@@ -318,8 +318,7 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
         it('should have blue outline for nested editable region and blue outline for noneditable ancestor (editable region selected)', async () => {
           const editor = hook.editor();
           modeTestSetContent(editor, figureImageHtml);
-          // The selected (blue) CEF outline only renders while the editor is focused; ambient focus isn't
-          // guaranteed in a shared realm, so focus explicitly.
+          // The selected (blue) CEF outline only renders while the editor is focused
           editor.focus();
           // When in design mode, the bogus element is placed so the cursor location is correct, when we switched to cursor mode, we need to put the cursor in the correct location
           if (modeScenario.mode === 'normal') {
@@ -334,7 +333,7 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
         it('TINY-8698: should have blue outline for nested editable region when selected noneditable ancestor has a comment', async () => {
           const editor = hook.editor();
           modeTestSetContent(editor, figureImageHtml);
-          // The selected (blue) CEF outline only renders while the editor is focused.
+          // The selected (blue) CEF outline only renders while the editor is focused
           editor.focus();
           TinySelections.select(editor, 'figure.image', []);
           editor.annotator.annotate('test-comment', {});

--- a/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/annotate/AnnotationStylingTest.ts
@@ -318,6 +318,9 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
         it('should have blue outline for nested editable region and blue outline for noneditable ancestor (editable region selected)', async () => {
           const editor = hook.editor();
           modeTestSetContent(editor, figureImageHtml);
+          // The selected (blue) CEF outline only renders while the editor is focused; ambient focus isn't
+          // guaranteed in a shared realm, so focus explicitly.
+          editor.focus();
           // When in design mode, the bogus element is placed so the cursor location is correct, when we switched to cursor mode, we need to put the cursor in the correct location
           if (modeScenario.mode === 'normal') {
             TinySelections.setCursor(editor, [ 1, 1, 0 ], 1, true);
@@ -331,6 +334,8 @@ describe('browser.tinymce.core.annotate.AnnotationStylingTest', () => {
         it('TINY-8698: should have blue outline for nested editable region when selected noneditable ancestor has a comment', async () => {
           const editor = hook.editor();
           modeTestSetContent(editor, figureImageHtml);
+          // The selected (blue) CEF outline only renders while the editor is focused.
+          editor.focus();
           TinySelections.select(editor, 'figure.image', []);
           editor.annotator.annotate('test-comment', {});
           TinySelections.setCursor(editor, [ 0, 1, 0 ], 1, true);

--- a/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/BundledCssTest.ts
@@ -1,5 +1,5 @@
 import { after, before, context, describe, it } from '@ephox/bedrock-client';
-import { Arr, Fun } from '@ephox/katamari';
+import { Arr, Fun, Strings } from '@ephox/katamari';
 import { Insert, Remove, SelectorFilter, SugarBody, SugarElement, SugarHead, SugarShadowDom } from '@ephox/sugar';
 import { McEditor, TinyDom } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
@@ -42,8 +42,11 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
         container,
         'style'
       );
-    // An unrelated style tag is included in Firefox so fitler it out
-    const filterKeys = new Set([ 'mceDefaultStyles' ]);
+    // Only TinyMCE's keyed skin/content <style> tags are under test. Unkeyed <style> elements are
+    // injected by unrelated paths — browser quirks via editor.contentStyles, the content_style
+    // option, and an unrelated Firefox default style tag (mceDefaultStyles) — so exclude them to
+    // keep the assertions independent of what else has run in the shared realm.
+    const filterKeys = new Set([ 'mceDefaultStyles', '' ]);
     const style = Arr.filter(styleTags, (tag) => {
       const key = styleTagToKey(tag);
       return !filterKeys.has(key);
@@ -54,10 +57,12 @@ describe('browser.tinymce.core.dom.BundledCssTest', () => {
         container,
         'link'
       );
-    const filterHrefs = new Set([ '/css/bedrock.css', 'data:;base64,iVBORw0KGgo=' ]);
+    // Only TinyMCE skin/content stylesheet links (under the skins/ path) are under test. Bedrock's
+    // own stylesheet, the favicon, and stylesheets leaked into document.head by sibling tests (e.g.
+    // StyleSheetLoader tests loading test.css) are not, so keep only skins/ links.
     const link = Arr.filter(linkTags, (tag) => {
       const key = linkTagToKey(tag, basePath);
-      return !filterHrefs.has(key);
+      return Strings.contains(key, 'skins/');
     });
 
     return {

--- a/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/dom/ControlSelectionTest.ts
@@ -75,11 +75,24 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
   const pWaitForDragHandles = (container: SugarElement<Element>, resizeSelector: string) =>
     UiFinder.pWaitForVisible('Wait for resize handlers to show', container, resizeSelector);
 
-  const pResizeAndAssertDimensions = async (editor: Editor, targetSelector: string, resizeSelector: string, deltaX: number, deltaY: number, width: number, height: number) => {
+  const pWaitForElementDimensions = (editor: Editor, selector: string, width: number, height: number) =>
+    Waiter.pTryUntil('Wait for element layout to settle before selecting', () => {
+      const rect = UiFinder.findIn(TinyDom.body(editor), selector).getOrDie().dom.getBoundingClientRect();
+      assert.approximately(rect.width, width, 3, `Settled width ${rect.width}px ~= ${width}px`);
+      assert.approximately(rect.height, height, 3, `Settled height ${rect.height}px ~= ${height}px`);
+    });
+
+  const pResizeAndAssertDimensions = async (editor: Editor, selectSelector: string, selectPath: number[], targetSelector: string, resizeSelector: string, deltaX: number, deltaY: number, width: number, height: number) => {
     const expectedWidth = Strings.endsWith(resizeSelector, 'sw') || Strings.endsWith(resizeSelector, 'nw') ? width - deltaX : width + deltaX;
     const expectedHeight = Strings.endsWith(resizeSelector, 'nw') || Strings.endsWith(resizeSelector, 'ne') ? height - deltaY : height + deltaY;
 
     const editorBody = TinyDom.body(editor);
+    // ControlSelection freezes the target's measured size into the resize ghost at selection
+    // time. Wait for the freshly-set content to reach its final layout size before selecting,
+    // otherwise a mid-layout measurement (observed as e.g. 5px or 228px for a 600px table) is
+    // captured and the ghost is born at the wrong width.
+    await pWaitForElementDimensions(editor, targetSelector, width, height);
+    TinySelections.select(editor, selectSelector, selectPath);
     const resizeHandle = await UiFinder.pWaitForVisible('Wait for resize handlers to show', editorBody, resizeSelector);
     const target = UiFinder.findIn(editorBody, targetSelector).getOrDie();
     Mouse.mouseDown(resizeHandle);
@@ -146,54 +159,47 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
   it('TINY-4161: Resize ghost element dimensions match target element when using fixed width', async () => {
     const editor = hook.editor();
     editor.setContent('<p><table style="width: 600px; height: 100px"><tbody><tr><td>Cell</td><td>Cell</td></tr></tbody></table></p>');
-    TinySelections.select(editor, 'td', [ 0 ]);
-    await pResizeAndAssertDimensions(editor, 'table', '#mceResizeHandlesw', 10, 10, 600, 100);
+    await pResizeAndAssertDimensions(editor, 'td', [ 0 ], 'table', '#mceResizeHandlesw', 10, 10, 600, 100);
   });
 
   it('TINY-13166: Resize ghost element dimensions match target element when using fixed width (uc-video)', async () => {
     const editor = hook.editor();
     await testEditorWidthUcVideo(editor, async () => {
       editor.resetContent('<p><uc-video contenteditable="false" class="tox-uc-video" style="width: 600px; height: 100px"></uc-video></p>');
-      TinySelections.select(editor, 'uc-video', [ 0 ]);
-      await pResizeAndAssertDimensions(editor, 'uc-video', '#mceResizeHandlenw', 10, 10, 600, 100);
+      await pResizeAndAssertDimensions(editor, 'uc-video', [ 0 ], 'uc-video', '#mceResizeHandlenw', 10, 10, 600, 100);
     });
   });
 
   it('TINY-4161: Resize ghost element dimensions match target element when using relative width', async () => {
     const editor = hook.editor();
     editor.setContent('<p><table style="width: 100%; height: 50px"><tbody><tr><td>Cell</td><td>Cell</td></tr></tbody></table></p>');
-    TinySelections.select(editor, 'td', [ 0 ]);
-    await pResizeAndAssertDimensions(editor, 'table', '#mceResizeHandlese', -10, -10, 798, 50);
+    await pResizeAndAssertDimensions(editor, 'td', [ 0 ], 'table', '#mceResizeHandlese', -10, -10, 798, 50);
   });
 
   it('TINY-13166: Resize ghost element dimensions match target element when using relative width (uc-video)', async () => {
     const editor = hook.editor();
     await testEditorWidthUcVideo(editor, async () => {
       editor.resetContent('<p><uc-video contenteditable="false" class="tox-uc-video" style="width: 100%; height: 50px"></uc-video></p>');
-      TinySelections.select(editor, 'uc-video', [ 0 ]);
-      await pResizeAndAssertDimensions(editor, 'uc-video', '#mceResizeHandlenw', -10, -10, 798, 50);
+      await pResizeAndAssertDimensions(editor, 'uc-video', [ 0 ], 'uc-video', '#mceResizeHandlenw', -10, -10, 798, 50);
     });
   });
 
   it('TINY-6229: Resize video element', async () => {
     const editor = hook.editor();
     editor.setContent('<p><video controls width="300" height="150"></video></p>');
-    TinySelections.select(editor, 'video', []);
-    await pResizeAndAssertDimensions(editor, 'video', '#mceResizeHandlese', 300, 150, 300, 150);
+    await pResizeAndAssertDimensions(editor, 'video', [], 'video', '#mceResizeHandlese', 300, 150, 300, 150);
   });
 
   it('TINY-6229: Resize video media element', async () => {
     const editor = hook.editor();
     editor.setContent('<p><span contenteditable="false" class="mce-preview-object mce-object-video"><video controls width="300" height="150"></video></span></p>');
-    TinySelections.select(editor, 'span', []);
-    await pResizeAndAssertDimensions(editor, 'video', '#mceResizeHandlese', -150, -75, 300, 150);
+    await pResizeAndAssertDimensions(editor, 'span', [], 'video', '#mceResizeHandlese', -150, -75, 300, 150);
   });
 
   it('TINY-6229: Resize iframe media element', async () => {
     const editor = hook.editor();
     editor.setContent('<p><span contenteditable="false" class="mce-preview-object mce-object-iframe"><iframe style="border: 1px solid black" width="400" height="200" src="' + Env.transparentSrc + '" allowfullscreen></iframe></span></p>');
-    TinySelections.select(editor, 'span', []);
-    await pResizeAndAssertDimensions(editor, 'iframe', '#mceResizeHandlese', 100, 50, 402, 202);
+    await pResizeAndAssertDimensions(editor, 'span', [], 'iframe', '#mceResizeHandlese', 100, 50, 402, 202);
   });
 
   it('TINY-6229: data-mce-selected attribute value retained when selecting the same element', async () => {
@@ -233,8 +239,7 @@ describe('browser.tinymce.core.dom.ControlSelectionTest', () => {
   it('TINY-7074: Resizing a media element should update both the root and wrapper element dimensions', async () => {
     const editor = hook.editor();
     editor.setContent(`<p><span contenteditable="false" class="mce-preview-object mce-object-iframe"><iframe style="border: 1px solid black; width: 400px; height: 200px" src="${Env.transparentSrc}"></iframe></span></p>`);
-    TinySelections.select(editor, 'span', []);
-    await pResizeAndAssertDimensions(editor, 'iframe', '#mceResizeHandlese', 100, 50, 402, 202);
+    await pResizeAndAssertDimensions(editor, 'span', [], 'iframe', '#mceResizeHandlese', 100, 50, 402, 202);
     const wrapper = UiFinder.findIn(TinyDom.body(editor), 'span.mce-preview-object').getOrDie();
     getAndAssertDimensions(wrapper, 402 + 100, 202 + 50);
   });

--- a/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/SchemaTest.ts
@@ -1,13 +1,17 @@
-import { context, describe, it } from '@ephox/bedrock-client';
+import { beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { Arr, Obj, Type } from '@ephox/katamari';
 import { SugarElement, SugarNode } from '@ephox/sugar';
 import { assert } from 'chai';
 
 import DomParser from 'tinymce/core/api/html/DomParser';
-import Schema, { type AttributePattern, type SchemaElement } from 'tinymce/core/api/html/Schema';
+import Schema, { type AttributePattern, type SchemaElement, _clearCache } from 'tinymce/core/api/html/Schema';
 import HtmlSerializer from 'tinymce/core/api/html/Serializer';
 
 describe('browser.tinymce.core.html.SchemaTest', () => {
+  beforeEach(() => {
+    _clearCache();
+  });
+
   const getElementRule = (schema: Schema, name: string) =>
     schema.getElementRule(name) as SchemaElement;
 

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -1,6 +1,6 @@
 import { Clipboard as AgarClipboard, Waiter } from '@ephox/agar';
 import { afterEach, beforeEach, describe, it } from '@ephox/bedrock-client';
-import { Fun, Singleton } from '@ephox/katamari';
+import { Arr, Fun, Singleton } from '@ephox/katamari';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -90,10 +90,20 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
 
   const pAssertInputEvents = () => PasteEventUtils.pWaitForAndAssertInputEvents(lastBeforeInputEvent, lastInputEvent);
 
+  // Pasted images load asynchronously; wait for the img elements to finish loading
+  // so their load handlers don't settle after teardown and corrupt a later test.
+  const pWaitForImagesLoaded = (editor: Editor, count: number) =>
+    Waiter.pTryUntilPredicate('Wait for images to finish loading', () => {
+      const imgs = editor.dom.select('img') as HTMLImageElement[];
+      return imgs.length === count && Arr.forall(imgs, (img) => img.complete && img.naturalWidth > 0);
+    });
+
   it('TBA: pasteImages should set unique id in blobcache', async () => {
     const editor = hook.editor();
 
-    const hasCachedItem = (name: string) => !!editor.editorUpload.blobCache.get(name);
+    // The mceclip blob-id counter is module-level and advanced by any earlier image
+    // paste, so look entries up by data rather than asserting literal mceclipN ids.
+    const getCachedByData = (base64: string) => editor.editorUpload.blobCache.getByData(base64, 'image/gif');
 
     const event = mockEvent('paste', [
       base64ToBlob(base64ImgSrc, 'image/gif', 'image.gif'),
@@ -103,12 +113,18 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
 
     await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
-    await Waiter.pTryUntilPredicate('Wait for image to be cached', () => hasCachedItem('mceclip0') && hasCachedItem('mceclip1'));
+    await Waiter.pTryUntilPredicate('Wait for images to be cached', () =>
+      !!getCachedByData(base64ImgSrc) && !!getCachedByData(base64ImgSrc2));
 
-    const cachedBlob1 = editor.editorUpload.blobCache.get('mceclip0');
-    const cachedBlob2 = editor.editorUpload.blobCache.get('mceclip1');
+    const cachedBlob1 = getCachedByData(base64ImgSrc);
+    const cachedBlob2 = getCachedByData(base64ImgSrc2);
     assert.equal(cachedBlob1?.base64(), base64ImgSrc);
     assert.equal(cachedBlob2?.base64(), base64ImgSrc2);
+    assert.match(cachedBlob1?.id() ?? '', /^mceclip\d+$/, 'first image should have an mceclip id');
+    assert.match(cachedBlob2?.id() ?? '', /^mceclip\d+$/, 'second image should have an mceclip id');
+    assert.notEqual(cachedBlob1?.id(), cachedBlob2?.id(), 'pasted images should have unique ids');
+
+    await pWaitForImagesLoaded(editor, 2);
   });
 
   it('TBA: dropImages', async () => {
@@ -119,8 +135,9 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     ]);
     Clipboard.pasteImageData(editor, event, editor.selection.getRng());
 
-    await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
+    await pWaitForImagesLoaded(editor, 1);
+    await pAssertInputEvents();
     TinyAssertions.assertContent(editor, '<p><img src=\"data:image/gif;base64,' + base64ImgSrc + '" width="100" height="100">a</p>');
     assert.strictEqual(editor.dom.select('img')[0].src.indexOf('blob:'), 0);
   });

--- a/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/paste/ImagePasteTest.ts
@@ -1,6 +1,6 @@
 import { Clipboard as AgarClipboard, Waiter } from '@ephox/agar';
 import { afterEach, beforeEach, describe, it } from '@ephox/bedrock-client';
-import { Arr, Fun, Singleton } from '@ephox/katamari';
+import { Arr, Fun, Singleton, Type } from '@ephox/katamari';
 import { TinyAssertions, TinyDom, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -114,7 +114,7 @@ describe('browser.tinymce.core.paste.ImagePasteTest', () => {
     await pAssertInputEvents();
     await pWaitForSelector(editor, 'img');
     await Waiter.pTryUntilPredicate('Wait for images to be cached', () =>
-      !!getCachedByData(base64ImgSrc) && !!getCachedByData(base64ImgSrc2));
+      Type.isNonNullable(getCachedByData(base64ImgSrc)) && Type.isNonNullable(getCachedByData(base64ImgSrc2)));
 
     const cachedBlob1 = getCachedByData(base64ImgSrc);
     const cachedBlob2 = getCachedByData(base64ImgSrc2);

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -67,7 +67,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
 
     it('TINY-13108: CEF element before link', async () => {
       const editor = hook.editor();
-      // Prevent fake cursor showing for CEF element which skews setCursor path
+      // Prevent fake cursor showing for CEF element which skews setCursor path by adding normal text before
       editor.setContent('<p>before<span data-keep-span="YES" contenteditable="false">Content</span><a href="Link">Link</a></p>');
       TinySelections.setCursor(editor, [ 0, 2, 0 ], 1);
       await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
@@ -78,7 +78,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
 
     it('TINY-13108: CEF NBSP element before link', async () => {
       const editor = hook.editor();
-      // Prevent fake cursor showing for CEF element which skews setCursor path
+      // Prevent fake cursor showing for CEF element which skews setCursor path by adding normal text before
       editor.setContent('<p>before<span data-keep-span="YES" contenteditable="false">&nbsp;</span><a href="Link">Link</a></p>');
       TinySelections.setCursor(editor, [ 0, 2, 0 ], 1);
       await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -1,3 +1,4 @@
+import { Waiter } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
 import { TinyAssertions, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
@@ -12,13 +13,18 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     indent: false
   }, [ Plugin ]);
 
+  const pAssertLinkPresence = (editor: Editor, expected: Record<string, number>) =>
+    Waiter.pTryUntil('check link presence', () => {
+      TinyAssertions.assertContentPresence(editor, expected);
+    });
+
   it('TBA: Removing a link with a collapsed selection', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a></p>');
     TinySelections.setCursor(editor, [ 0, 0, 0 ], 2);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
     TinyUiActions.clickOnUi(editor, 'div[aria-label="Remove link"]');
-    TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
+    await pAssertLinkPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
   });
 
   it('TBA: Removing a link with some text selected', async () => {
@@ -27,7 +33,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 0, [ 0, 0, 0 ], 2);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
     TinyUiActions.clickOnUi(editor, 'div[aria-label="Remove link"]');
-    TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
+    await pAssertLinkPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
   });
 
   it('TBA: Removing a link from an image', async () => {
@@ -36,69 +42,78 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
     TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 1);
     await TinyUiActions.pTriggerContextMenu(editor, 'a[href="http://tiny.cloud"]', '.tox-silver-sink [role="menuitem"]');
     TinyUiActions.clickOnUi(editor, 'div[aria-label="Remove link"]');
-    TinyAssertions.assertContentPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
+    await pAssertLinkPresence(editor, { 'a[href="http://tiny.cloud"]': 0 });
   });
 
-  it('TINY-4867: Removing multiple links in the selection', () => {
+  it('TINY-4867: Removing multiple links in the selection', async () => {
     const editor = hook.editor();
     editor.setContent('<p><a href="http://tiny.cloud">tiny</a> content <a href="http://tiny.cloud">link</a> with <a href="http://tiny.cloud">other</a></p>');
     TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 4, 0 ], 2);
+    await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
     TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-    TinyAssertions.assertContentPresence(editor, { a: 0 });
+    await pAssertLinkPresence(editor, { a: 0 });
     TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 4 ], 2);
   });
 
   context('Near other CET/CEF elements', () => {
-    it('TINY-13108: CET element before link', () => {
+    it('TINY-13108: CET element before link', async () => {
       const editor = hook.editor();
       editor.setContent('<p><span data-keep-span="YES">Content</span><a href="Link">Link</a></p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      await pAssertLinkPresence(editor, { a: 0 });
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
     });
 
-    it('TINY-13108: CEF element before link', () => {
+    it('TINY-13108: CEF element before link', async () => {
       const editor = hook.editor();
-      editor.setContent('<p><span data-keep-span="YES" contenteditable="false">Content</span><a href="Link">Link</a></p>');
-      TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+      // Prevent fake cursor showing for CEF element which skews setCursor path
+      editor.setContent('<p>before<span data-keep-span="YES" contenteditable="false">Content</span><a href="Link">Link</a></p>');
+      TinySelections.setCursor(editor, [ 0, 2, 0 ], 1);
+      await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-      TinyAssertions.assertContentPresence(editor, { a: 0 });
-      TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
+      await pAssertLinkPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 2 ], 1, [ 0, 2 ], 1);
     });
 
-    it('TINY-13108: CEF NBSP element before link', () => {
+    it('TINY-13108: CEF NBSP element before link', async () => {
       const editor = hook.editor();
-      editor.setContent('<p><span data-keep-span="YES" contenteditable="false">&nbsp;</span><a href="Link">Link</a></p>');
-      TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+      // Prevent fake cursor showing for CEF element which skews setCursor path
+      editor.setContent('<p>before<span data-keep-span="YES" contenteditable="false">&nbsp;</span><a href="Link">Link</a></p>');
+      TinySelections.setCursor(editor, [ 0, 2, 0 ], 1);
+      await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-      TinyAssertions.assertContentPresence(editor, { a: 0 });
-      TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);
+      await pAssertLinkPresence(editor, { a: 0 });
+      TinyAssertions.assertSelection(editor, [ 0, 2 ], 1, [ 0, 2 ], 1);
     });
-    it('TINY-13108: CET element after link', () => {
+
+    it('TINY-13108: CET element after link', async () => {
       const editor = hook.editor();
       editor.setContent('<p><a href="Link">Link</a><span data-keep-span="YES">Content</span></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      await pAssertLinkPresence(editor, { a: 0 });
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
     });
 
-    it('TINY-13108: CEF element after link', () => {
+    it('TINY-13108: CEF element after link', async () => {
       const editor = hook.editor();
       editor.setContent('<p><a href="Link">Link</a><span data-keep-span="YES" contenteditable="false">Content</span></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      await pAssertLinkPresence(editor, { a: 0 });
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
     });
 
-    it('TINY-13108: CEF NBSP element after link', () => {
+    it('TINY-13108: CEF NBSP element after link', async () => {
       const editor = hook.editor();
       editor.setContent('<p><a href="Link">Link</a><span data-keep-span="YES" contenteditable="false">&nbsp;</span></p>');
       TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
+      await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
-      TinyAssertions.assertContentPresence(editor, { a: 0 });
+      await pAssertLinkPresence(editor, { a: 0 });
       TinyAssertions.assertSelection(editor, [ 0, 0 ], 1, [ 0, 0 ], 1);
     });
   });

--- a/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
+++ b/modules/tinymce/src/plugins/link/test/ts/browser/RemoveLinkTest.ts
@@ -60,6 +60,7 @@ describe('browser.tinymce.plugins.link.RemoveLinkTest', () => {
       const editor = hook.editor();
       editor.setContent('<p><span data-keep-span="YES">Content</span><a href="Link">Link</a></p>');
       TinySelections.setCursor(editor, [ 0, 1, 0 ], 1);
+      await TinyUiActions.pWaitForUi(editor, '[data-mce-name="unlink"][aria-disabled="false"]');
       TinyUiActions.clickOnUi(editor, 'button[data-mce-name="unlink"]');
       await pAssertLinkPresence(editor, { a: 0 });
       TinyAssertions.assertSelection(editor, [ 0, 1 ], 1, [ 0, 1 ], 1);

--- a/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/NoneditableRootTest.ts
@@ -1,5 +1,5 @@
 import { Keys, UiFinder } from '@ephox/agar';
-import { context, describe, it } from '@ephox/bedrock-client';
+import { afterEach, context, describe, it } from '@ephox/bedrock-client';
 import { Obj, Optional } from '@ephox/katamari';
 import { SugarBody } from '@ephox/sugar';
 import { TinyHooks, TinySelections, TinyState, TinyUiActions } from '@ephox/wrap-mcagar';
@@ -84,6 +84,14 @@ describe('browser.tinymce.plugins.table.NoneditableRootTest', () => {
     },
     base_url: '/project/tinymce/js/tinymce'
   }, [ Plugin ], true);
+
+  // Several tests here populate the process-wide FakeClipboard singleton, which persists
+  // across every test file in the bundle. Clear it so a leftover row/column does not alter
+  // paste-button state in later files sharing the realm.
+  afterEach(() => {
+    FakeClipboard.clearRows();
+    FakeClipboard.clearColumns();
+  });
 
   context('Noneditable root buttons', () => {
     const testDisableButtonOnNoneditable = (title: string, ariaDisabled = true) => () => {

--- a/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/settings/TableToolbarTest.ts
@@ -1,14 +1,24 @@
 import { UiFinder, Waiter } from '@ephox/agar';
-import { before, describe, it } from '@ephox/bedrock-client';
+import { before, beforeEach, describe, it } from '@ephox/bedrock-client';
 import { SugarBody } from '@ephox/sugar';
 import { McEditor, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
+import * as FakeClipboard from 'tinymce/plugins/table/api/Clipboard';
 import Plugin from 'tinymce/plugins/table/Plugin';
 
 describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
   before(() => {
     Plugin();
+  });
+
+  beforeEach(() => {
+    // The paste row/column toolbar buttons derive their disabled state from a
+    // process-wide FakeClipboard singleton that persists across the whole bundle.
+    // Clear it so the disabled-state assertions below hold regardless of whether an
+    // earlier test in the realm copied a row or column.
+    FakeClipboard.clearRows();
+    FakeClipboard.clearColumns();
   });
 
   const tableHtml = '<table><tbody><tr><td>x</td></tr></tbody></table>';
@@ -34,7 +44,7 @@ describe('browser.tinymce.plugins.table.TableToolbarTest', () => {
     const editor = await pCreateEditor('tablecopyrow tablepasterowafter tablepasterowbefore');
     editor.focus();
     editor.setContent(tableWithCaptionHtml);
-    TinySelections.setSelection(editor, [ 0, 0, 0 ], 1, [ 0, 0, 0 ], 1);
+    TinySelections.setCursor(editor, [ 0, 0, 0 ], 1);
     // Ensure the copy/paste row buttons are disabled
     await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-name="tablecopyrow"]');
     await TinyUiActions.pWaitForUi(editor, '.tox-pop .tox-tbtn--disabled[data-mce-name="tablepasterowbefore"]');


### PR DESCRIPTION
Related Ticket: TINYMCE-14682

Description of Changes:

- Fix a few of the commont test flakes

The main non-test change I did have to make it export a `_clearCache` from Schema.ts. This is internal only and not included in the public API so is safe

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of image paste/drop by waiting for pasted images to fully load before asserting.
  - Stabilized link removal verification by waiting for unlink UI to become enabled and for link content changes to appear.
  - Ensured editor focus and layout stability before outline, resize, and visual assertions.

- **Tests**
  - Improved isolation by clearing schema cache and resetting FakeClipboard state between tests.
  - Made CSS and DOM assertions more deterministic via key-based filtering and data-driven blob ID checks.
  - Updated annotation styling, schema, resize, and related tests to match the new focus/layout and timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->