### PR TITLE
TINYMCE-9142: Apply format to editable children when non-editable is selected

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-9142-2026-07-20.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-9142-2026-07-20.yaml
@@ -1,7 +1,7 @@
 project: tinymce
 kind: Fixed
-body: Format could not be applied to editable child elements when noneditable element
-  is selected.
+body: Formatting could not be applied to and removed from editable child elements when a noneditable element
+  was selected.
 time: 2026-07-20T13:39:21.803395+10:00
 custom:
   Issue: TINYMCE-9142

--- a/.changes/unreleased/tinymce-TINYMCE-9142-2026-07-20.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-9142-2026-07-20.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Format could not be applied to editable child elements when noneditable element
+  is selected.
+time: 2026-07-20T13:39:21.803395+10:00
+custom:
+  Issue: TINYMCE-9142

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -91,6 +91,6 @@ newlines:
 envPrefix: CHANGIE_
 custom:
   - key: Issue
-    label: Issue (TINY-XXXX+)
+    label: Issue (TINYMCE-XXXX+)
     type: string
-    minLength: 7
+    minLength: 10

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -1,4 +1,4 @@
-import { Arr, Fun, Obj, Type } from '@ephox/katamari';
+import { Arr, Fun, Obj, Optional, Type } from '@ephox/katamari';
 import { PredicateExists, SugarElement, SugarElements } from '@ephox/sugar';
 
 import type DOMUtils from '../api/dom/DOMUtils';
@@ -317,12 +317,12 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
           ApplyElementFormat.setElementFormat(ed, elm, format, vars, node);
         }
       }
-    } else if (Arr.exists(formatList, FormatUtils.isSelectorFormat)) {
-      const parentMatch = dom.getParent(node, (candidate) =>
-        Arr.exists(formatList, (fmt) => FormatUtils.isSelectorFormat(fmt) && dom.is(candidate, fmt.selector)));
-      if (dom.isEditable(parentMatch)) {
-        applyNodeStyle(formatList, parentMatch);
-      }
+    } else {
+      const selectorFormats = Arr.filter(formatList, FormatUtils.isSelectorFormat);
+      Optional.from(dom.getParent(node, (candidate) =>
+        Arr.exists(selectorFormats, (fmt) => dom.is(candidate, fmt.selector))))
+        .filter(dom.isEditable)
+        .each((parent) => applyNodeStyle(formatList, parent));
     }
     Events.fireFormatApply(ed, name, node, vars);
     return;

--- a/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/ApplyFormat.ts
@@ -291,14 +291,23 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
     });
   };
 
-  // TODO: TINY-9142: Remove this to make nested noneditable formatting work
   const targetNode = FormatUtils.isNode(node) ? node : selection.getNode();
   if (dom.getContentEditable(targetNode) === 'false' && !FormatUtils.isWrappableNoneditable(ed, targetNode)) {
     // node variable is used by other functions above in the same scope so need to set it here
     node = targetNode;
     applyNodeStyle(formatList, node);
-    if (FormatUtils.isBlockFormat(format) && !dom.isBlock(targetNode)) {
-      const parentBlock = dom.getParent(targetNode, dom.isBlock);
+
+    if (FormatUtils.hasEditableDescendants(dom, node)) {
+      Arr.each(FormatUtils.getEditableDescendants(dom, node), (island) => {
+        const rng = dom.createRng();
+        rng.selectNodeContents(island);
+        applyRngStyle(dom, rng, true);
+      });
+      return;
+    }
+
+    if (FormatUtils.isBlockFormat(format) && !dom.isBlock(node)) {
+      const parentBlock = dom.getParent(node, dom.isBlock);
       if (dom.isEditable(parentBlock)) {
         const wrapperElementName = format.block;
         if (parentBlock.nodeName.toLowerCase() === wrapperElementName.toLowerCase()) {
@@ -307,6 +316,12 @@ const applyFormatAction = (ed: Editor, name: string, vars?: FormatVars, node?: N
           const elm = dom.rename(parentBlock, wrapperElementName);
           ApplyElementFormat.setElementFormat(ed, elm, format, vars, node);
         }
+      }
+    } else if (Arr.exists(formatList, FormatUtils.isSelectorFormat)) {
+      const parentMatch = dom.getParent(node, (candidate) =>
+        Arr.exists(formatList, (fmt) => FormatUtils.isSelectorFormat(fmt) && dom.is(candidate, fmt.selector)));
+      if (dom.isEditable(parentMatch)) {
+        applyNodeStyle(formatList, parentMatch);
       }
     }
     Events.fireFormatApply(ed, name, node, vars);
@@ -363,4 +378,3 @@ export const applyFormat = (editor: Editor, name: string, vars?: FormatVars, nod
     applyFormatAction(editor, name, vars, node);
   }
 };
-

--- a/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/FormatUtils.ts
@@ -149,6 +149,16 @@ const isWrapNoneditableTarget = (editor: Editor, node: Node): boolean => {
   return Selectors.is(SugarElement.fromDom(node), selector);
 };
 
+const hasEditableDescendants = (dom: DOMUtils, node: Node): boolean =>
+  dom.select('[contenteditable="true"]', node).length > 0;
+
+const getEditableDescendants = (dom: DOMUtils, parent: Node): Node[] => Arr.foldl(Arr.from(parent.childNodes), (editableDescendants, child) => [
+  ...editableDescendants,
+  ...(NodeType.isElement(child) && dom.getContentEditable(child) === 'true'
+    ? [ child ]
+    : getEditableDescendants(dom, child))
+], [] as Node[]);
+
 // A noneditable element is wrappable if it:
 // - is valid target (has data-mce-cef-wrappable attribute or matches selector from option)
 // - has no editable descendants - removing formats in the editable region can result in the wrapped noneditable being split which is undesirable
@@ -159,7 +169,7 @@ const isWrappableNoneditable = (editor: Editor, node: Node): boolean => {
     isElementNode(node) &&
     dom.getContentEditable(node) === 'false' &&
     isWrapNoneditableTarget(editor, node) &&
-    dom.select('[contenteditable="true"]', node).length === 0
+    !hasEditableDescendants(dom, node)
   );
 };
 
@@ -347,6 +357,8 @@ export {
   isWhiteSpaceNode,
   isEmptyTextNode,
   isWrappableNoneditable,
+  hasEditableDescendants,
+  getEditableDescendants,
   replaceVars,
   isEq,
   normalizeStyleValue,

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -140,28 +140,28 @@ const matchNode = (ed: Editor, node: Node | null, name: string, vars?: FormatVar
   return undefined;
 };
 
-const containsFormat = (editor: Editor, root: Node, name: string, vars?: FormatVars, similar?: boolean): boolean =>
+const containsFormatDeep = (editor: Editor, root: Node, name: string, vars?: FormatVars, similar?: boolean): boolean =>
   Type.isNonNullable(matchNode(editor, root, name, vars, similar)) ||
-  Arr.exists(Arr.from(root.childNodes), (child) => containsFormat(editor, child, name, vars, similar));
+  Arr.exists(Arr.from(root.childNodes), (child) => containsFormatDeep(editor, child, name, vars, similar));
 
-const matchDescendants = (editor: Editor, node: Node, name: string, vars?: FormatVars, similar?: boolean): boolean => {
+const matchEditableDescendants = (editor: Editor, node: Node, name: string, vars?: FormatVars, similar?: boolean): boolean => {
   const dom = editor.dom;
   if (!NodeType.isElement(node) || dom.getContentEditable(node) !== 'false' || FormatUtils.isWrappableNoneditable(editor, node)) {
     return false;
   }
 
-  return Arr.exists(FormatUtils.getEditableDescendants(dom, node), (descendant) => containsFormat(editor, descendant, name, vars, similar));
+  return Arr.exists(FormatUtils.getEditableDescendants(dom, node), (descendant) => containsFormatDeep(editor, descendant, name, vars, similar));
 };
 
 const match = (editor: Editor, name: string, vars?: FormatVars, node?: Node, similar?: boolean): boolean => {
   // Check specified node
   if (node) {
-    return matchParents(editor, node, name, vars, similar) || matchDescendants(editor, node, name, vars, similar);
+    return matchParents(editor, node, name, vars, similar) || matchEditableDescendants(editor, node, name, vars, similar);
   }
 
   // Check selected node
   node = editor.selection.getNode();
-  if (matchParents(editor, node, name, vars, similar) || matchDescendants(editor, node, name, vars, similar)) {
+  if (matchParents(editor, node, name, vars, similar) || matchEditableDescendants(editor, node, name, vars, similar)) {
     return true;
   }
 

--- a/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/MatchFormat.ts
@@ -140,15 +140,28 @@ const matchNode = (ed: Editor, node: Node | null, name: string, vars?: FormatVar
   return undefined;
 };
 
+const containsFormat = (editor: Editor, root: Node, name: string, vars?: FormatVars, similar?: boolean): boolean =>
+  Type.isNonNullable(matchNode(editor, root, name, vars, similar)) ||
+  Arr.exists(Arr.from(root.childNodes), (child) => containsFormat(editor, child, name, vars, similar));
+
+const matchDescendants = (editor: Editor, node: Node, name: string, vars?: FormatVars, similar?: boolean): boolean => {
+  const dom = editor.dom;
+  if (!NodeType.isElement(node) || dom.getContentEditable(node) !== 'false' || FormatUtils.isWrappableNoneditable(editor, node)) {
+    return false;
+  }
+
+  return Arr.exists(FormatUtils.getEditableDescendants(dom, node), (descendant) => containsFormat(editor, descendant, name, vars, similar));
+};
+
 const match = (editor: Editor, name: string, vars?: FormatVars, node?: Node, similar?: boolean): boolean => {
   // Check specified node
   if (node) {
-    return matchParents(editor, node, name, vars, similar);
+    return matchParents(editor, node, name, vars, similar) || matchDescendants(editor, node, name, vars, similar);
   }
 
   // Check selected node
   node = editor.selection.getNode();
-  if (matchParents(editor, node, name, vars, similar)) {
+  if (matchParents(editor, node, name, vars, similar) || matchDescendants(editor, node, name, vars, similar)) {
     return true;
   }
 

--- a/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/FormatNoneditableTest.ts
@@ -324,7 +324,7 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
               await pTest(editor, [
                 {
                   select: selectNoneditableSpan,
-                  expectedHtml: initialHtml,
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
                   pAssertAfter: async () => {
                     await pAssertToolbar(false)(editor);
                     TinyAssertions.assertContentPresence(editor, { 'span[contenteditable="false"][data-mce-selected]': 1 });
@@ -379,8 +379,8 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
                 },
                 {
                   select: selectNoneditableSpan,
-                  // Should remain the same
-                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true"><${format.html}>editable</${format.tag}></span>${noneditableAfterHtml} third</p>`,
+                  // Should toggle off
+                  expectedHtml: `<p>first ${noneditableBeforeHtml}<span contenteditable="true">editable</span>${noneditableAfterHtml} third</p>`,
                   pAssertAfter: pAssertToolbar(false)
                 },
               ]);
@@ -743,13 +743,20 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
     });
 
     context('noneditable inline elements with selector formats', () => {
-      // TODO: TINY-9142 Reenable when Jira is done
-      it.skip('TINY-8687: should apply selector format to matching parent block when a noneditable inline element is selected', () => {
+      it('TINY-8687: should apply selector format to matching parent block when a noneditable inline element is selected', () => {
         const editor = hook.editor();
         editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
         TinySelections.select(editor, 'span', []);
         editor.formatter.apply('alignright');
         TinyAssertions.assertContent(editor, `<p style="text-align: right;">a<span contenteditable="false">CEF</span>b</p>`);
+      });
+
+      it('TINY-9142: should not apply selector format to an editable ancestor outside a doubly-nested noneditable region', () => {
+        const editor = hook.editor();
+        editor.setContent(`<div contenteditable="false"><p>a<span contenteditable="false">CEF</span>b</p></div>`);
+        TinySelections.select(editor, 'div[contenteditable="false"] span', []);
+        editor.formatter.apply('alignright');
+        TinyAssertions.assertContent(editor, `<div contenteditable="false">\n<p>a<span contenteditable="false">CEF</span>b</p>\n</div>`);
       });
 
       it('TINY-8687: should apply selector format to matching parent block when selection is within a nested noneditable inline element', () => {
@@ -816,6 +823,66 @@ describe('browser.tinymce.core.fmt.FormatNoneditableTest', () => {
         TinySelections.select(editor, 'span[contenteditable="false"]', []);
         editor.formatter.apply('h1');
         TinyAssertions.assertContent(editor, `<h1>a<span contenteditable="false">CEF</span>b</h1>`);
+      });
+    });
+
+    context('noneditable inline elements with nested editable islands and inline formats', () => {
+      it('TINY-9142: should apply an inline format to a nested editable island once, from its outermost editable node', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>a<span contenteditable="false">CEF-<span contenteditable="true">bold <em>me</em> please</span>-text</span>b</p>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('bold');
+        TinyAssertions.assertContent(
+          editor,
+          `<p>a<span contenteditable="false">CEF-<span contenteditable="true"><strong>bold <em>me</em> please</strong></span>-text</span>b</p>`
+        );
+      });
+
+      it('TINY-9142: should leave a noneditable element untouched when it has no editable descendants', () => {
+        const editor = hook.editor();
+        editor.setContent(`<p>a<span contenteditable="false">CEF</span>b</p>`);
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.apply('bold');
+        TinyAssertions.assertContent(editor, `<p>a<span contenteditable="false">CEF</span>b</p>`);
+      });
+
+      it('TINY-9142: should not apply an inline format past an outer noneditable boundary when the island is doubly nested', () => {
+        const editor = hook.editor();
+        editor.setContent(`<div contenteditable="false"><p>a<span contenteditable="false">CEF-<span contenteditable="true">you can't bold me</span>-text</span>b</p></div>`);
+        TinySelections.select(editor, 'div[contenteditable="false"] span[contenteditable="false"]', []);
+        editor.formatter.apply('bold');
+        TinyAssertions.assertContent(
+          editor,
+          `<div contenteditable="false">\n<p>a<span contenteditable="false">CEF-<span contenteditable="true">you can't bold me</span>-text</span>b</p>\n</div>`
+        );
+      });
+    });
+
+    context('toggling formats on a noneditable target with an already-formatted editable island', () => {
+      it('TINY-9142: should toggle an inline format off when the nested editable island already has it applied', () => {
+        const editor = hook.editor();
+        editor.setContent(
+          `<p>a<span contenteditable="false">CEF-<span contenteditable="true"><strong>bold me</strong></span>-text</span>b</p>`
+        );
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.toggle('bold');
+        TinyAssertions.assertContent(
+          editor,
+          `<p>a<span contenteditable="false">CEF-<span contenteditable="true">bold me</span>-text</span>b</p>`
+        );
+      });
+
+      it('TINY-9142: should toggle an inline format on when the nested editable island does not have it applied', () => {
+        const editor = hook.editor();
+        editor.setContent(
+          `<p>a<span contenteditable="false">CEF-<span contenteditable="true">bold me</span>-text</span>b</p>`
+        );
+        TinySelections.select(editor, 'span[contenteditable="false"]', []);
+        editor.formatter.toggle('bold');
+        TinyAssertions.assertContent(
+          editor,
+          `<p>a<span contenteditable="false">CEF-<span contenteditable="true"><strong>bold me</strong></span>-text</span>b</p>`
+        );
       });
     });
   });

--- a/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/fmt/RemoveFormatTest.ts
@@ -263,6 +263,47 @@ describe('browser.tinymce.core.fmt.RemoveFormatTest', () => {
     });
   });
 
+  context('Remove format with noneditable content', () => {
+    it('TINY-9142: should remove an inline format from a nested editable island, once, from its outermost editable node', () => {
+      const editor = hook.editor();
+      editor.setContent(
+        `<p>a<span contenteditable="false">CEF-<span contenteditable="true"><strong>bold</strong> <em>me</em> please</span>-text</span>b</p>`
+      );
+      TinySelections.select(editor, 'span[contenteditable="false"]', []);
+      editor.formatter.remove('bold');
+      TinyAssertions.assertContent(
+        editor,
+        `<p>a<span contenteditable="false">CEF-<span contenteditable="true">bold <em>me</em> please</span>-text</span>b</p>`
+      );
+    });
+
+    it('TINY-9142: should leave a noneditable element untouched when removing an inline format and it has no editable descendants', () => {
+      const editor = hook.editor();
+      const initialContent = `<p>a<span contenteditable="false"><strong>CEF</strong></span>b</p>`;
+      editor.setContent(initialContent);
+      TinySelections.select(editor, 'span[contenteditable="false"]', []);
+      editor.formatter.remove('bold');
+      TinyAssertions.assertContent(editor, initialContent);
+    });
+
+    it('TINY-8687: should remove a selector format from the matching parent block when a noneditable inline element is selected', () => {
+      const editor = hook.editor();
+      editor.setContent(`<p style="text-align: right;">a<span contenteditable="false">CEF</span>b</p>`);
+      TinySelections.select(editor, 'span[contenteditable="false"]', []);
+      editor.formatter.remove('alignright');
+      TinyAssertions.assertContent(editor, `<p>a<span contenteditable="false">CEF</span>b</p>`);
+    });
+
+    it('TINY-9142: should not remove a selector format from an editable ancestor outside a doubly-nested noneditable region', () => {
+      const editor = hook.editor();
+      const initialContent = `<div contenteditable="false"><p style="text-align: right;">a<span contenteditable="false">CEF</span>b</p></div>`;
+      editor.setContent(initialContent);
+      TinySelections.select(editor, 'div[contenteditable="false"] span[contenteditable="false"]', []);
+      editor.formatter.remove('alignright');
+      TinyAssertions.assertContent(editor, initialContent);
+    });
+  });
+
   it('TINY-9678: Should be a noop if selection is not in an editable context', () => {
     TinyState.withNoneditableRootEditor(hook.editor(), (editor) => {
       const initialContent = '<p><strong>test</strong></p><p contenteditable="true"><strong>editable</strong></p>';


### PR DESCRIPTION
Related Ticket: TINYMCE-9142

Description of Changes:
* Format can now be applied to editable children when noneditable element is selected

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
