### PR TITLE
TINYMCE-14682: Update flaky webdriver tests

### DIFF
--- a/modules/agar/src/test/ts/webdriver/RealEffectsTest.ts
+++ b/modules/agar/src/test/ts/webdriver/RealEffectsTest.ts
@@ -1,109 +1,108 @@
-import { UnitTest } from '@ephox/bedrock-client';
+import { after, Assert, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import { PlatformDetection } from '@ephox/sand';
-import { Class, Css, Html, Insert, Remove, SugarElement } from '@ephox/sugar';
+import { Class, Css, Focus, Html, Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
 
-import * as Assertions from 'ephox/agar/api/Assertions';
-import { Chain } from 'ephox/agar/api/Chain';
-import * as Guard from 'ephox/agar/api/Guard';
-import { Pipeline } from 'ephox/agar/api/Pipeline';
 import * as RealClipboard from 'ephox/agar/api/RealClipboard';
 import { RealKeys } from 'ephox/agar/api/RealKeys';
 import * as RealMouse from 'ephox/agar/api/RealMouse';
-import { Step } from 'ephox/agar/api/Step';
 import * as UiControls from 'ephox/agar/api/UiControls';
-import * as UiFinder from 'ephox/agar/api/UiFinder';
 import * as Waiter from 'ephox/agar/api/Waiter';
 
-UnitTest.asynctest('Real Effects Test', (success, failure) => {
+describe('webdriver.RealEffectsTest', () => {
   const platform = PlatformDetection.detect();
+  const selectAllModifier = platform.os.isMacOS() ? { metaKey: true } : { ctrlKey: true };
 
-  const head = SugarElement.fromDom(document.head);
-  const body = SugarElement.fromDom(document.body);
+  let container: SugarElement<HTMLDivElement>;
+  let input: SugarElement<HTMLInputElement>;
+  let button: SugarElement<HTMLButtonElement>;
+  let style: SugarElement<HTMLStyleElement>;
 
-  const container = SugarElement.fromTag('div');
+  // Poll the real post-condition rather than assert once after a fixed sleep: real
+  // input has variable round-trip latency, so a single eager assert races it.
+  const pAssertInputValue = (label: string, expected: string): Promise<void> =>
+    Waiter.pTryUntil(label, () => Assert.eq(label, expected, UiControls.getValue(input)));
 
-  const sCreateWorld = Step.sync(() => {
-    const input = SugarElement.fromTag('input');
+  const pAssertButtonBorder = (label: string, expected: string): Promise<void> =>
+    Waiter.pTryUntil(label, () => {
+      const prop = platform.browser.isFirefox() ? 'border-right-color' : 'border-color';
+      Assert.eq(label, expected, Css.get(button, prop));
+    });
+
+  before(() => {
+    container = SugarElement.fromTag('div');
+
+    input = SugarElement.fromTag('input');
     Insert.append(container, input);
 
-    const css = SugarElement.fromTag('style');
-    Html.set(css, 'button { border: 1px solid black; }\nbutton.test:hover { border: 1px solid white }');
-    Insert.append(head, css);
+    style = SugarElement.fromTag('style');
+    Html.set(style, 'button { border: 1px solid black; }\nbutton.test:hover { border: 1px solid white }');
+    Insert.append(SugarElement.fromDom(document.head), style);
 
-    const button = SugarElement.fromTag('button');
+    button = SugarElement.fromTag('button');
     Class.add(button, 'test');
     Html.set(button, 'Mouse over me');
     Insert.append(container, button);
-    Insert.append(body, container);
+
+    Insert.append(SugarBody.body(), container);
   });
 
-  const sCheckInput = (label, expected) =>
-    Chain.asStep(body, [
-      Chain.control(
-        UiFinder.cFindIn('input'),
-        Guard.addLogging(label + '\nlooking for input to check expected')
-      ),
-      UiControls.cGetValue,
-      Assertions.cAssertEq(label + '\nChecking the input value', expected)
-    ]);
+  after(() => {
+    if (container) {
+      Remove.remove(container);
+    }
+    if (style) {
+      Remove.remove(style);
+    }
+  });
 
-  const sCheckButtonBorder = (label, expected) =>
-    Chain.asStep(body, [
-      UiFinder.cFindIn('button.test'),
-      Chain.mapper((button) => {
-        const prop = platform.browser.isFirefox() ? 'border-right-color' : 'border-color';
-        return Css.get(button, prop);
-      }),
-      Assertions.cAssertEq(label + '\nChecking color of button border', expected)
-    ]);
+  context('real keyboard and clipboard input', () => {
+    // Each test starts from a known, focused, empty input so it does not depend on
+    // whatever a previous test left behind.
+    beforeEach(() => {
+      UiControls.setValue(input, '');
+      Focus.focus(input);
+    });
 
-  Pipeline.async({}, [
-    sCreateWorld,
-    Step.wait(200),
-    RealKeys.sSendKeysOn('input', [
-      RealKeys.text('I am typing thos')
-    ]),
-    sCheckInput('Initial typing', 'I am typing thos'),
-    Step.wait(50),
-    RealKeys.sSendKeysOn('input', [
-      RealKeys.backspace(),
-      RealKeys.backspace()
-    ]),
-    sCheckInput('After backspacing incorrect letters', 'I am typing th'),
-    Step.wait(50),
-    RealKeys.sSendKeysOn('input', [
-      RealKeys.text('is')
-    ]),
-    sCheckInput('After correcting "this"', 'I am typing this'),
-    Step.wait(50),
-    RealKeys.sSendKeysOn('input', [
-      RealKeys.combo(platform.os.isMacOS() ? { metaKey: true } : { ctrlKey: true }, 'a')
-    ]),
-    Step.wait(50),
-    RealClipboard.sCopy('input'),
-    sCheckInput('After triggering copy', 'I am typing this'),
+    it('enters text with real key presses', async () => {
+      await RealKeys.pSendKeysOn('input', [ RealKeys.text('I am typing this') ]);
+      await pAssertInputValue('After typing', 'I am typing this');
+    });
 
-    Step.wait(50),
-    RealKeys.sSendKeysOn('input', [
-      RealKeys.backspace()
-    ]),
-    sCheckInput('After pressing Backspace on Select All', ''),
-    Step.wait(50),
-    RealClipboard.sPaste('input'),
-    sCheckInput('Post paste', 'I am typing this'),
-    Step.wait(100),
-    RealMouse.sMoveToOn('input'),
-    sCheckButtonBorder('Checking initial state of button border', 'rgb(0, 0, 0)'),
-    RealMouse.sMoveToOn('button.test'),
-    // Safari resets the mouse immediately after the move action so we can't do the assertion
-    ...(platform.browser.isSafari() ? [] : [
-      Waiter.sTryUntil(
-        'Waiting for hovered state',
-        sCheckButtonBorder('Checking hovered state of button border', 'rgb(255, 255, 255)')
-      )
-    ])
-  ], () => {
-    Remove.remove(container);
-    success();
-  }, failure);
+    it('removes characters with real backspace', async () => {
+      await RealKeys.pSendKeysOn('input', [ RealKeys.text('I am typing thisXX') ]);
+      await pAssertInputValue('After typing', 'I am typing thisXX');
+
+      await RealKeys.pSendKeysOn('input', [ RealKeys.backspace(), RealKeys.backspace() ]);
+      await pAssertInputValue('After backspacing the two extra characters', 'I am typing this');
+    });
+
+    it('copies and pastes text through the real clipboard', async () => {
+      await RealKeys.pSendKeysOn('input', [ RealKeys.text('I am typing this') ]);
+      await pAssertInputValue('After typing', 'I am typing this');
+
+      // Select all, copy, then delete the selection — an empty value confirms select-all worked.
+      await RealKeys.pSendKeysOn('input', [ RealKeys.combo(selectAllModifier, 'a') ]);
+      await RealClipboard.pCopy('input');
+      await RealKeys.pSendKeysOn('input', [ RealKeys.backspace() ]);
+      await pAssertInputValue('After deleting the selected-all content', '');
+
+      await RealClipboard.pPaste('input');
+      await pAssertInputValue('After pasting the copied text back', 'I am typing this');
+    });
+  });
+
+  context('real mouse hover', () => {
+    it('shows the default border when the button is not hovered', async () => {
+      await RealMouse.pMoveToOn('input');
+      await pAssertButtonBorder('Initial, non-hovered border', 'rgb(0, 0, 0)');
+    });
+
+    it('shows the hover border when the button is hovered', async () => {
+      await RealMouse.pMoveToOn('button.test');
+      // Safari resets the mouse immediately after the move, so the hovered state can't be asserted.
+      if (!platform.browser.isSafari()) {
+        await pAssertButtonBorder('Hovered border', 'rgb(255, 255, 255)');
+      }
+    });
+  });
 });

--- a/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionBackspaceDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/browser/AccordionBackspaceDeleteTest.ts
@@ -1,8 +1,7 @@
-import { RealKeys } from '@ephox/agar';
+import { Keys } from '@ephox/agar';
 import { context, describe, it } from '@ephox/bedrock-client';
-import { Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
-import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { TinyAssertions, TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
 
@@ -17,12 +16,7 @@ interface AccordionSpec {
   body?: string;
 }
 
-interface BackspaceDeleteModifier {
-  ctrlKey?: boolean;
-  altKey?: boolean;
-}
-
-describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () => {
+describe('browser.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () => {
   const settings = {
     plugins: 'accordion',
     base_url: '/project/tinymce/js/tinymce',
@@ -32,15 +26,17 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
 
   const platform = PlatformDetection.detect();
   const isFirefox = platform.browser.isFirefox();
-  const isSafari = platform.browser.isSafari();
-  const isMacOS = platform.os.isMacOS();
-  const isWindows = platform.os.isWindows();
 
-  const pDoBackspaceDelete = async (key: DeletionKey, modifier?: BackspaceDeleteModifier): Promise<void> => {
-    await RealKeys.pSendKeysOn('iframe => body', [ Type.isUndefined(modifier) ? RealKeys.text(key) : RealKeys.combo(modifier, key) ]);
+  // Synthetic keydown drives TinyMCE's own Backspace/Delete overrides (the accordion
+  // delete handling under test), the same way the core browser delete tests do. Native
+  // Ctrl/Alt word-deletion is NOT handled by TinyMCE, so those cases stay in the
+  // webdriver AccordionCtrlWordDeleteTest.
+  const pDoBackspaceDelete = (key: DeletionKey): Promise<void> => {
+    TinyContentActions.keystroke(hook.editor(), key === 'Backspace' ? Keys.backspace() : Keys.delete());
+    return Promise.resolve();
   };
-  const pDoBackspace = (modifier?: BackspaceDeleteModifier) => pDoBackspaceDelete('Backspace', modifier);
-  const pDoDelete = (modifier?: BackspaceDeleteModifier) => pDoBackspaceDelete('Delete', modifier);
+  const pDoBackspace = () => pDoBackspaceDelete('Backspace');
+  const pDoDelete = () => pDoBackspaceDelete('Delete');
 
   const getAccordionContent = ({ summary, body }: AccordionSpec = { summary: 'summary', body: '<p>body</p>' }): string =>
     `${AccordionUtils.createAccordion({ summary, body })}`;
@@ -386,55 +382,6 @@ describe('webdriver.tinymce.plugins.accordion.AccordionBackspaceDeleteTest', () 
 
       it('TINY-9951: Can select content from end in body and delete it using Backspace', testDeleteSelectionFromEndInBody('Backspace'));
       it('TINY-9951: Can select content from end in body and delete it using Delete', testDeleteSelectionFromEndInBody('Delete'));
-    });
-
-    context('Using ranged deletion keyboard shortcuts', () => {
-      const pDoCtrlBackspaceDelete = (deletionKey: DeletionKey) => pDoBackspaceDelete(deletionKey, isMacOS ? { altKey: true } : { ctrlKey: true });
-
-      const testCtrlDeletion = (deletionKey: DeletionKey, location: ContentLocation) => async () => {
-        const editor = hook.editor();
-        const isBackspace = deletionKey === 'Backspace';
-        const isSummary = location === 'summary';
-        const initialContent = 'word1 word2';
-        const getSummarySpec = (content: string): AccordionSpec => isSummary ? { summary: content, body: '<p>body</p>' } : { summary: 'summary', body: `<p>${content}</p>` };
-        createAccordion(editor, getSummarySpec(initialContent));
-        TinySelections.setCursor(editor, isSummary ? [ 0, 0, 0 ] : [ 0, 1, 0, 0 ], isBackspace ? 'word1 wo'.length : 'wo'.length);
-        await pDoCtrlBackspaceDelete(deletionKey);
-
-        let expectedContent: string;
-        if (isBackspace) {
-          expectedContent = 'word1 rd2';
-        } else if (isWindows) {
-          // Difference in native behavior for Ctrl + Delete on Windows
-          expectedContent = 'woword2';
-        } else {
-          expectedContent = 'wo word2';
-        }
-        assertAccordionContent(editor, getSummarySpec(expectedContent));
-
-        if (isSafari) {
-          // Safari positions selection around format caret
-          const expectedPath = isSummary ? [ 0, 0, 0 ] : [ 0, 1, 0, 0 ];
-          const expectedOffset = isBackspace ? 6 : 2;
-
-          TinyAssertions.assertCursor(editor, expectedPath, expectedOffset);
-        } else {
-          // 0 offset as selection positioned within format caret
-          const expectedPath = isSummary ? [ 0, 0, 1, 0 ] : [ 0, 1, 0, 1, 0 ];
-          const expectedOffset = 0;
-
-          TinyAssertions.assertCursor(editor, expectedPath, expectedOffset);
-        }
-
-      };
-
-      const testCtrlDeletionInSummary = (deletionKey: DeletionKey) => testCtrlDeletion(deletionKey, 'summary');
-      it('TINY-9951: Can delete summary using Ctrl+Backspace', testCtrlDeletionInSummary('Backspace'));
-      it('TINY-9951: Can delete summary using Ctrl+Delete', testCtrlDeletionInSummary('Delete'));
-
-      const testCtrlDeletionInBody = (deletionKey: DeletionKey) => testCtrlDeletion(deletionKey, 'body');
-      it('TINY-9951: Can delete body using Ctrl+Backspace', testCtrlDeletionInBody('Backspace'));
-      it('TINY-9951: Can delete body using Ctrl+Delete', testCtrlDeletionInBody('Delete'));
     });
   });
 

--- a/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionCtrlWordDeleteTest.ts
+++ b/modules/tinymce/src/plugins/accordion/test/ts/webdriver/AccordionCtrlWordDeleteTest.ts
@@ -1,0 +1,93 @@
+import { RealKeys } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { PlatformDetection } from '@ephox/sand';
+import { TinyAssertions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+import AccordionPlugin from '../../../main/ts/Plugin';
+import * as AccordionUtils from '../module/AccordionUtils';
+
+type DeletionKey = 'Backspace' | 'Delete';
+type ContentLocation = 'summary' | 'body';
+
+interface AccordionSpec {
+  summary?: string;
+  body?: string;
+}
+
+// Ctrl/Alt word-deletion is performed natively by the browser, not by TinyMCE, and the
+// result differs per OS/browser — so these cases require real webdriver keystrokes and
+// cannot move to the synthetic browser AccordionBackspaceDeleteTest. See
+// webdriver_conversion.md for the split rationale.
+describe('webdriver.tinymce.plugins.accordion.AccordionCtrlWordDeleteTest', () => {
+  const settings = {
+    plugins: 'accordion',
+    base_url: '/project/tinymce/js/tinymce',
+    indent: false
+  };
+  const hook = TinyHooks.bddSetup<Editor>(settings, [ AccordionPlugin ], true);
+
+  const platform = PlatformDetection.detect();
+  const isSafari = platform.browser.isSafari();
+  const isMacOS = platform.os.isMacOS();
+  const isWindows = platform.os.isWindows();
+
+  const getAccordionContent = ({ summary, body }: AccordionSpec = { summary: 'summary', body: '<p>body</p>' }): string =>
+    `${AccordionUtils.createAccordion({ summary, body })}`;
+  const assertAccordionContent = (editor: Editor, spec?: AccordionSpec) =>
+    TinyAssertions.assertContent(editor, getAccordionContent(spec));
+  const createAccordion = (editor: Editor, spec?: AccordionSpec) => {
+    const content = getAccordionContent(spec);
+    editor.setContent(content);
+    return content;
+  };
+
+  const pDoCtrlBackspaceDelete = async (deletionKey: DeletionKey): Promise<void> => {
+    await RealKeys.pSendKeysOn('iframe => body', [ RealKeys.combo(isMacOS ? { altKey: true } : { ctrlKey: true }, deletionKey) ]);
+  };
+
+  const testCtrlDeletion = (deletionKey: DeletionKey, location: ContentLocation) => async () => {
+    const editor = hook.editor();
+    const isBackspace = deletionKey === 'Backspace';
+    const isSummary = location === 'summary';
+    const initialContent = 'word1 word2';
+    const getSummarySpec = (content: string): AccordionSpec => isSummary ? { summary: content, body: '<p>body</p>' } : { summary: 'summary', body: `<p>${content}</p>` };
+    createAccordion(editor, getSummarySpec(initialContent));
+    TinySelections.setCursor(editor, isSummary ? [ 0, 0, 0 ] : [ 0, 1, 0, 0 ], isBackspace ? 'word1 wo'.length : 'wo'.length);
+    await pDoCtrlBackspaceDelete(deletionKey);
+
+    let expectedContent: string;
+    if (isBackspace) {
+      expectedContent = 'word1 rd2';
+    } else if (isWindows) {
+      // Difference in native behavior for Ctrl + Delete on Windows
+      expectedContent = 'woword2';
+    } else {
+      expectedContent = 'wo word2';
+    }
+    assertAccordionContent(editor, getSummarySpec(expectedContent));
+
+    if (isSafari) {
+      // Safari positions selection around format caret
+      const expectedPath = isSummary ? [ 0, 0, 0 ] : [ 0, 1, 0, 0 ];
+      const expectedOffset = isBackspace ? 6 : 2;
+
+      TinyAssertions.assertCursor(editor, expectedPath, expectedOffset);
+    } else {
+      // 0 offset as selection positioned within format caret
+      const expectedPath = isSummary ? [ 0, 0, 1, 0 ] : [ 0, 1, 0, 1, 0 ];
+      const expectedOffset = 0;
+
+      TinyAssertions.assertCursor(editor, expectedPath, expectedOffset);
+    }
+  };
+
+  const testCtrlDeletionInSummary = (deletionKey: DeletionKey) => testCtrlDeletion(deletionKey, 'summary');
+  it('TINY-9951: Can delete summary using Ctrl+Backspace', testCtrlDeletionInSummary('Backspace'));
+  it('TINY-9951: Can delete summary using Ctrl+Delete', testCtrlDeletionInSummary('Delete'));
+
+  const testCtrlDeletionInBody = (deletionKey: DeletionKey) => testCtrlDeletion(deletionKey, 'body');
+  it('TINY-9951: Can delete body using Ctrl+Backspace', testCtrlDeletionInBody('Backspace'));
+  it('TINY-9951: Can delete body using Ctrl+Delete', testCtrlDeletionInBody('Delete'));
+});


### PR DESCRIPTION
Related Ticket:

Description of Changes:

- Migrated `RealEffectsTest` from the legacy `UnitTest.asynctest` / `Pipeline` / `Chain` / `Step` API to the modern `describe`/`it` async style, splitting the single monolithic test into focused, isolated cases with `before`/`after`/`beforeEach` lifecycle hooks.
- Replaced fixed `Step.wait` sleeps with `Waiter.pTryUntil` polling assertions to avoid races against real input round-trip latency.
- Moved `AccordionBackspaceDeleteTest` from the `webdriver` suite to the `browser` suite, replacing `RealKeys` with synthetic `TinyContentActions.keystroke` / `Keys` calls since TinyMCE's own Backspace/Delete overrides are exercised by synthetic keystrokes.
- Extracted the Ctrl/Alt word-deletion cases (which require native browser behaviour and therefore real keystrokes) into a new dedicated webdriver test file `AccordionCtrlWordDeleteTest`, keeping the rationale documented in comments.

Pre-checks:

- [x] Changelog entry added
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [ ] Milestone set
- [x] Docs ticket created (if applicable)

GitHub issues (if applicable):