### PR TITLE
TINYMCE-14701: Update DomPurify to 3.4.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -345,7 +345,7 @@
     },
     "modules/tinymce": {
       "name": "tinymce",
-      "version": "8.7.0",
+      "version": "8.8.1",
       "dependencies": {
         "@ephox/acid": "^8.0.0",
         "@ephox/agar": "^10.0.0",
@@ -356,7 +356,7 @@
         "@tinymce/oxide-icons-default": "^4.0.0",
         "@tinymce/persona": "^1.0.0",
         "@types/prismjs": "^1.16.6",
-        "dompurify": "3.4.11",
+        "dompurify": "3.4.12",
         "prismjs": "^1.27.0",
       },
       "devDependencies": {
@@ -1798,7 +1798,7 @@
 
     "domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
 
-    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
 

--- a/modules/tinymce/package.json
+++ b/modules/tinymce/package.json
@@ -36,7 +36,7 @@
     "@tinymce/oxide-icons-default": "^4.0.0",
     "@tinymce/persona": "^1.0.0",
     "@types/prismjs": "^1.16.6",
-    "dompurify": "3.4.11",
+    "dompurify": "3.4.12",
     "prismjs": "^1.27.0"
   },
   "devDependencies": {

--- a/modules/tinymce/src/core/main/ts/html/Sanitization.ts
+++ b/modules/tinymce/src/core/main/ts/html/Sanitization.ts
@@ -77,18 +77,9 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, sc
   const bogus = Attribute.get(element, 'data-mce-bogus');
   if (!isInternalElement && Type.isString(bogus)) {
     if (bogus === 'all') {
-      // Empty before removing so a detached raw-text element (e.g. script/style) can't carry
-      // markup-like content into DOMPurify's unsafe-node check, which would then throw trying
-      // to _forceRemove the now-parentless node.
-      Remove.empty(element);
       Remove.remove(element);
     } else {
       Remove.unwrap(element);
-    }
-    // We detach the element above; DOMPurify throws if it then tries to _forceRemove the
-    // now-parentless node, so mark the tag allowed to stop that second removal.
-    if (Type.isNonNullable(evt)) {
-      evt.allowedTags[lcTagName] = true;
     }
     return;
   }
@@ -96,23 +87,11 @@ const processNode = (node: Node, settings: DomParserSettings, schema: Schema, sc
   // Determine if the schema allows the element and either add it or remove it
   const rule = schema.getElementRule(lcTagName);
   if (validate && !rule) {
-    // Don't detach invalid special / non-HTML-namespace elements: DOMPurify throws if it later
-    // _forceRemoves a parentless node (its unsafe-content and namespace checks do this regardless
-    // of allowedTags). Empty and leave attached instead, so DOMPurify removes it without hoisting content.
-    if (settings.sanitize && (Obj.has(specialElements, lcTagName) || scope !== 'html')) {
-      Remove.empty(element);
+    // If a special element is invalid, then remove the entire element instead of unwrapping
+    if (Obj.has(specialElements, lcTagName)) {
+      Remove.remove(element);
     } else {
-      // No DOMPurify to remove it (sanitize disabled), or a plain invalid HTML element: detach it ourselves.
-      if (Obj.has(specialElements, lcTagName)) {
-        Remove.remove(element);
-      } else {
-        Remove.unwrap(element);
-      }
-      // The element is now detached; mark the tag allowed so DOMPurify won't _forceRemove the
-      // parentless node and throw. Safe here: it's empty and HTML-namespaced, so no earlier check fires.
-      if (Type.isNonNullable(evt)) {
-        evt.allowedTags[lcTagName] = true;
-      }
+      Remove.unwrap(element);
     }
     return;
   } else {
@@ -321,9 +300,7 @@ const sanitizeMathmlElement = (node: Element, settings: DomParserSettings) => {
       evt.allowedTags[lcTagName] = keepElement;
       if (!keepElement && settings.sanitize) {
         if (NodeType.isElement(node)) {
-          // Empty the node and leave it attached so DOMPurify removes it (allowedTags is false).
-          // Detaching it would make DOMPurify throw when it _forceRemoves the parentless node.
-          Remove.empty(SugarElement.fromDom(node));
+          node.remove();
         }
       }
     });

--- a/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/html/DomParserTest.ts
@@ -535,6 +535,12 @@ describe('browser.tinymce.core.html.DomParserTest', () => {
         );
       });
 
+      it('TINYMCE-14701: Remove broken elements', () => {
+        const parser = DomParser(scenario.settings, Schema());
+        const root = parser.parse('<p>ab<c</p><p>ab<bc</p>');
+        assert.equal(serializer.serialize(root), '<p>ab</p><p>ab</p>', 'Remove broken element');
+      });
+
       it('Self closing list elements', () => {
         const schema = Schema();
 


### PR DESCRIPTION
Related Ticket: TINYMCE-14701

Description of Changes:
* Malformed HTML would throw an error in 8.8 due to the update to DomPurify 3.4.11
* Updating DomPurify to 3.4.12
* Reverting workaround code

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
