### PR TITLE
TINYMCE-14415: fix caret position with scroll and context toolbar

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-14415-2026-07-17.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-14415-2026-07-17.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The caret could be positioned incorrectly in some cases when scrolling while a context toolbar was open.
+time: 2026-07-17T14:12:52.679079558+02:00
+custom:
+  Issue: TINYMCE-14415

--- a/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
+++ b/modules/alloy/src/main/ts/ephox/alloy/positioning/mode/SelectionAnchor.ts
@@ -43,10 +43,12 @@ const placement = (component: AlloyComponent, anchorInfo: SelectionAnchor, origi
     if (isSimRange(sel)) {
       const optRect = WindowSelection.getBounds(win, SimSelection.exactFromRange(sel)).orThunk(() => {
         const zeroWidth = SugarElement.fromText(Unicode.zeroWidth);
+        const beforeMutation = WindowSelection.getExact(win);
         Insert.before(sel.start, zeroWidth);
         // Certain things like <p><br/></p> with (p, 0) or <br>) as collapsed selection do not return a client rectangle
         const rect = WindowSelection.getFirstRect(win, SimSelection.exact(zeroWidth, 0, zeroWidth, 1));
         Remove.remove(zeroWidth);
+        beforeMutation.each((range) => WindowSelection.setExact(win, range.start, range.soffset, range.finish, range.foffset));
         return rect;
       });
 


### PR DESCRIPTION
Related Ticket: TINYMCE-14415

Description of Changes:
**Requirements to reproduce the bug:**
- a scrollable context with an image in it
- a context toolbar that is showed when the caret is on an empty line

**Steps to reproduce the bug:**
- place the caret after the image
- press enter
- press backspace
Current -> the caret is before the image
Expected -> the caret should be after the image

the is caused by an edge case in Chrome that adding an empty element and then removing it in a specific case causes that bug

**NOTE:** I couldn't simulate the real behaviour in the tests so I couldn't test it

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the caret could be positioned incorrectly after scrolling with a context toolbar open.
  * Preserved the user’s text selection while determining caret positioning, preventing unexpected selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->