### PR TITLE
TINYMCE-13829: useKeyboardShortcuts hook

### DIFF
--- a/modules/oxide-components/src/main/ts/main.ts
+++ b/modules/oxide-components/src/main/ts/main.ts
@@ -27,6 +27,7 @@ import { UniverseProvider } from './contexts/UniverseContext/UniverseProvider';
 import type { UniverseResources } from './contexts/UniverseContext/UniverseTypes';
 import * as KeyboardNavigationTypes from './keynav/keyboard/NavigationTypes';
 import * as KeyboardNavigationHooks from './keynav/KeyboardNavigationHooks';
+import * as KeyboardShortcuts from './shortcuts/UseKeyboardShortcuts';
 import * as Bem from './utils/Bem';
 import * as ContentUiBem from './utils/ContentUiBem';
 import * as FocusHelpers from './utils/FocusHelpers';
@@ -51,6 +52,7 @@ export {
   IconButton,
   KeyboardNavigationHooks,
   KeyboardNavigationTypes,
+  KeyboardShortcuts,
   Menu,
   MenuRenderer,
   Spinner,

--- a/modules/oxide-components/src/main/ts/shortcuts/UseKeyboardShortcuts.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/UseKeyboardShortcuts.ts
@@ -1,0 +1,72 @@
+import { Fun } from '@ephox/katamari';
+import { useEffect, type RefObject } from 'react';
+
+import { attachShortcutListener, type AttachOptions, type KeyboardShortcut } from './internals/AttachShortcutListener';
+
+// TODO: TINY-13828 Support shift shortcuts
+
+/**
+ * Attaches `keydown` listeners to a container element and invokes handlers when a matching shortcut
+ * is pressed. On match, the event is consumed (`stopPropagation` + `preventDefault`).
+ *
+ * **Pattern syntax**
+ *
+ * Patterns are strings composed of tokens joined by `+`. Each pattern must contain exactly one key
+ * and any number of modifiers.
+ *
+ * Modifiers:
+ *   - `ctrl`  — Requires Ctrl key
+ *   - `alt`   — Requires Alt key
+ *   - `shift` — Requires Shift key
+ *   - `meta`  — Requires Cmd on macOS, maps to Ctrl on other platforms
+ *
+ * Keys: any `event.key` value in lowercase, plus the special token `space` for the spacebar.
+ *
+ * Examples:
+ *   "ctrl+s"          → Ctrl + S
+ *   "meta+shift+z"    → Cmd+Shift+Z (macOS) / Ctrl+Shift+Z (other)
+ *   "alt+arrowdown"   → Alt + ↓
+ *   "meta+space"      → Cmd+Space (macOS) / Ctrl+Space (other)
+ *
+ * Matching is case-insensitive — both the pattern and `event.key` are lowercased before comparison.
+ *
+ * For letter/digit keys, when `event.key` does not match, matching falls back to `event.code`
+ * (e.g. `KeyS`, `Digit5`, `Numpad5`). This handles Mac Option-key transforms (e.g. Option+S
+ * produces `event.key='ß'`) and makes shortcuts layout-independent. As a side effect, digit
+ * shortcuts like `ctrl+alt+1` match both the main keyboard 1 and the numeric keypad 1.
+ *
+ * **Options**
+ *
+ * Pass `{ capture: true }` when the shortcut's focused target sits inside a component that
+ * intercepts the same key in its own bubble-phase handler. Example: `useFlowKeyNavigation`
+ * swallows arrow keys for toolbar focus management, so a bubble-phase arrow-key shortcut
+ * attached on a wrapping container never fires.
+ *
+ * **Limitations**
+ *
+ * Shift + non-letter keys are unreliable. Matching uses `event.key`, which reflects the character
+ * produced after Shift is applied. For example, `shift+1` produces `"!"` on a US layout but a
+ * different character on other layouts. `shift+letter` works correctly (e.g. `shift+a`) because
+ * both sides are lowercased. Shift combinations with digits or symbols should be avoided until
+ * this is addressed. See TINY-13828
+ */
+const useKeyboardShortcuts = (
+  containerRef: RefObject<HTMLElement>,
+  shortcuts: KeyboardShortcut[],
+  options?: AttachOptions
+): void => {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return Fun.noop;
+    }
+    const binder = attachShortcutListener(container, shortcuts, options);
+    return () => binder.unbind();
+  }, [ containerRef, shortcuts, options ]);
+};
+
+export {
+  attachShortcutListener,
+  useKeyboardShortcuts
+};
+export type { KeyboardShortcut, AttachOptions };

--- a/modules/oxide-components/src/main/ts/shortcuts/internals/AttachShortcutListener.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/internals/AttachShortcutListener.ts
@@ -1,0 +1,48 @@
+import { Arr } from '@ephox/katamari';
+import { PlatformDetection } from '@ephox/sand';
+import { DomEvent, SugarElement, type EventUnbinder } from '@ephox/sugar';
+
+import * as PatternCompiler from './PatternCompiler';
+
+export interface KeyboardShortcut {
+  readonly pattern: string;
+  readonly handler: () => void;
+}
+
+export interface AttachOptions {
+  readonly capture?: boolean;
+}
+
+/**
+ * Attaches a `keydown` listener to `target` that invokes the matching shortcut's handler.
+ * On match, the event is consumed (`stopPropagation` + `preventDefault`).
+ *
+ * Set `options.capture` to `true` when the focused element sits inside a component that
+ * intercepts the same key in its own bubble-phase handler (e.g. `useFlowKeyNavigation`
+ * swallows arrow keys for toolbar focus management).
+ *
+ * Returns an unbinder; call `unbinder.unbind()` to detach.
+ */
+export const attachShortcutListener = (
+  target: Node,
+  shortcuts: KeyboardShortcut[],
+  options: AttachOptions = {}
+): EventUnbinder => {
+  const platform = PlatformDetection.detect();
+  const isMac = platform.os.isiOS() || platform.os.isMacOS();
+  const compiled = Arr.map(shortcuts, ({ pattern, handler }) => ({
+    test: PatternCompiler.compile(pattern, isMac),
+    handler
+  }));
+
+  const onKeyDown = (e: { raw: KeyboardEvent; stop: () => void; prevent: () => void }) => {
+    Arr.find(compiled, (s) => s.test(e.raw)).each((s) => {
+      e.stop();
+      e.prevent();
+      s.handler();
+    });
+  };
+
+  const bindFn = options.capture ? DomEvent.capture : DomEvent.bind;
+  return bindFn<KeyboardEvent>(SugarElement.fromDom(target), 'keydown', onKeyDown);
+};

--- a/modules/oxide-components/src/main/ts/shortcuts/internals/KeyboardModifiers.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/internals/KeyboardModifiers.ts
@@ -1,0 +1,4 @@
+export const CONTROL = 'ctrl';
+export const ALT = 'alt';
+export const SHIFT = 'shift';
+export const META = 'meta';

--- a/modules/oxide-components/src/main/ts/shortcuts/internals/Keys.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/internals/Keys.ts
@@ -1,0 +1,1 @@
+export const SPACE = 'space';

--- a/modules/oxide-components/src/main/ts/shortcuts/internals/PatternCompiler.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/internals/PatternCompiler.ts
@@ -1,0 +1,91 @@
+import { Arr, Fun } from '@ephox/katamari';
+
+import * as KeyboardModifiers from './KeyboardModifiers';
+import * as Keys from './Keys';
+import * as Utils from './Utils';
+
+const PATTERN_DELIMITER = '+';
+
+type ShortcutPredicate = (event: KeyboardEvent) => boolean;
+
+interface Shortcut {
+  readonly key: Array<string>;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  metaKey: boolean;
+};
+
+const compile = (pattern: string, isMac = false): ShortcutPredicate => {
+  const parts = Arr.map(Utils.explode(pattern, PATTERN_DELIMITER), Utils.lowercase);
+  const decodedShortcut = decodeShortcut(parts, isMac);
+
+  if (decodedShortcut.key.length !== 1) {
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid shortcut pattern "${pattern}": valid pattern includes one key and zero or more modifiers`);
+    return Fun.never;
+  }
+  const [ decodedShortcutKey ] = decodedShortcut.key;
+
+  return (event: KeyboardEvent) => {
+    if (event.ctrlKey !== decodedShortcut.ctrlKey) {
+      return false;
+    }
+    if (event.altKey !== decodedShortcut.altKey) {
+      return false;
+    }
+    if (event.shiftKey !== decodedShortcut.shiftKey) {
+      return false;
+    }
+    if (event.metaKey !== decodedShortcut.metaKey) {
+      return false;
+    }
+
+    if (Utils.lowercase(event.key) === decodedShortcutKey) {
+      return true;
+    }
+
+    if (/^[a-z]$/.test(decodedShortcutKey)) {
+      return event.code === `Key${decodedShortcutKey.toUpperCase()}`;
+    }
+    if (/^[0-9]$/.test(decodedShortcutKey)) {
+      return event.code === `Digit${decodedShortcutKey}` || event.code === `Numpad${decodedShortcutKey}`;
+    }
+
+    return false;
+  };
+};
+
+const decodeShortcut = (parts: string[], isMac: boolean): Shortcut => {
+  const shortcut: Shortcut = {
+    key: [],
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false
+  };
+
+  Arr.each(parts, (part) => {
+    if (part === KeyboardModifiers.CONTROL) {
+      shortcut.ctrlKey = true;
+    } else if (part === KeyboardModifiers.ALT) {
+      shortcut.altKey = true;
+    } else if (part === KeyboardModifiers.SHIFT) {
+      shortcut.shiftKey = true;
+    } else if (part === KeyboardModifiers.META && isMac) {
+      shortcut.metaKey = true;
+    } else if (part === KeyboardModifiers.META && !isMac) {
+      shortcut.ctrlKey = true;
+    } else if (part === Keys.SPACE) {
+      shortcut.key.push(' ');
+    } else {
+      shortcut.key.push(part);
+    }
+  });
+
+  return shortcut;
+};
+
+export {
+  compile
+};

--- a/modules/oxide-components/src/main/ts/shortcuts/internals/PatternCompiler.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/internals/PatternCompiler.ts
@@ -20,7 +20,7 @@ const compile = (pattern: string, isMac = false): ShortcutPredicate => {
   const parts = Arr.map(Utils.explode(pattern, PATTERN_DELIMITER), Utils.lowercase);
   const decodedShortcut = decodeShortcut(parts, isMac);
 
-  if (decodedShortcut.key.length !== 1) {
+  if (decodedShortcut.key.length !== 1 || decodedShortcut.key[0] === '') {
     // eslint-disable-next-line no-console
     console.warn(`Invalid shortcut pattern "${pattern}": valid pattern includes one key and zero or more modifiers`);
     return Fun.never;

--- a/modules/oxide-components/src/main/ts/shortcuts/internals/Utils.ts
+++ b/modules/oxide-components/src/main/ts/shortcuts/internals/Utils.ts
@@ -1,0 +1,11 @@
+import { Arr } from '@ephox/katamari';
+
+const lowercase = (s: string): string => s.toLowerCase();
+
+// Splits a string but removes the whitespace before and after each value.
+const explode = (s: string, delimeter: string): string[] => Arr.map(s.split(delimeter), (p) => p.trim());
+
+export {
+  lowercase,
+  explode
+};

--- a/modules/oxide-components/src/test/ts/browser/shortcuts/PatternCompiler.spec.ts
+++ b/modules/oxide-components/src/test/ts/browser/shortcuts/PatternCompiler.spec.ts
@@ -1,0 +1,190 @@
+import { Fun } from '@ephox/katamari';
+import * as PatternCompiler from 'oxide-components/shortcuts/internals/PatternCompiler';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+export interface FakeKeyboardEventConfig {
+  readonly key: string;
+  readonly code?: string;
+  readonly ctrlKey?: boolean;
+  readonly metaKey?: boolean;
+  readonly shiftKey?: boolean;
+  readonly altKey?: boolean;
+}
+
+const createFakeKeydownEvent = (config: FakeKeyboardEventConfig): KeyboardEvent => {
+  return new KeyboardEvent('keydown', {
+    key: config.key,
+    code: config.code ?? '',
+    ctrlKey: config.ctrlKey ?? false,
+    metaKey: config.metaKey ?? false,
+    shiftKey: config.shiftKey ?? false,
+    altKey: config.altKey ?? false,
+    bubbles: true
+  });
+};
+
+const testPattern = (pattern: string, eventConfig: FakeKeyboardEventConfig, environment: 'mac' | 'other' = 'other') => {
+  const matcher = PatternCompiler.compile(pattern, environment === 'mac');
+  expect(matcher(createFakeKeydownEvent(eventConfig))).toBe(true);
+};
+
+const testPatternFalse = (pattern: string, eventConfig: FakeKeyboardEventConfig, environment: 'mac' | 'other' = 'other') => {
+  const matcher = PatternCompiler.compile(pattern, environment === 'mac');
+  expect(matcher(createFakeKeydownEvent(eventConfig))).toBe(false);
+};
+
+const invalidPatternWarning = (pattern: string) =>
+  `Invalid shortcut pattern "${pattern}": valid pattern includes one key and zero or more modifiers`;
+
+describe('browser.shortcuts.PatternCompilerTest', () => {
+  describe('Single key shortcuts', () => {
+    it('should match Enter key', () => testPattern('Enter', { key: 'Enter' }));
+    it('should match Escape key', () => testPattern('Escape', { key: 'Escape' }));
+    it('should match Space key', () => testPattern('Space', { key: ' ' }));
+    it('should match Tab key', () => testPattern('Tab', { key: 'Tab' }));
+    it('should match Backspace key', () => testPattern('Backspace', { key: 'Backspace' }));
+
+    it('should match Enter key insensitive', () => testPattern('enter', { key: 'Enter' }));
+    it('should match Escape key insensitive', () => testPattern('escape', { key: 'Escape' }));
+    it('should match Space key insensitive', () => testPattern('space', { key: ' ' }));
+    it('should match Tab key insensitive', () => testPattern('tab', { key: 'Tab' }));
+    it('should match Backspace key insensitive', () => testPattern('backspace', { key: 'Backspace' }));
+
+    describe('Should match arrow keys', () => {
+      it('should match arrow up', () => testPattern('ArrowUp', { key: 'ArrowUp' }));
+      it('should match arrow down', () => testPattern('ArrowDown', { key: 'ArrowDown' }));
+      it('should match arrow left', () => testPattern('ArrowLeft', { key: 'ArrowLeft' }));
+      it('should match arrow right', () => testPattern('ArrowRight', { key: 'ArrowRight' }));
+      it('should match arrow up key insensitive', () => testPattern('arrowup', { key: 'ArrowUp' }));
+    });
+
+    describe('Should match letter keys', () => {
+      it('should match a letter', () => testPattern('a', { key: 'a' }));
+      it('should match b letter', () => testPattern('b', { key: 'b' }));
+    });
+
+    describe('Should match function keys', () => {
+      it('should match f1', () => testPattern('F1', { key: 'F1' }));
+      it('should match f12', () => testPattern('F12', { key: 'F12' }));
+      it('should match f1 key insensitive', () => testPattern('f1', { key: 'F1' }));
+    });
+  });
+
+  describe('Single modifier', () => {
+    it('should match Ctrl+J', () => testPattern('Ctrl+J', { key: 'j', ctrlKey: true }));
+    it('should match Meta+J on mac', () => testPattern('Meta+J', { key: 'j', metaKey: true }, 'mac'));
+    it('should match Meta+J on non-mac', () => testPattern('Meta+J', { key: 'j', ctrlKey: true }, 'other'));
+    it('should match Alt+J', () => testPattern('Alt+J', { key: 'j', altKey: true }));
+    it('should match Shift+J', () => testPattern('Shift+J', { key: 'J', shiftKey: true }));
+
+    it('should match Ctrl+Enter', () => testPattern('Ctrl+Enter', { key: 'Enter', ctrlKey: true }));
+    it('should match Meta+Enter on mac', () => testPattern('Meta+Enter', { key: 'Enter', metaKey: true }, 'mac'));
+    it('should match Meta+Enter on non-mac', () => testPattern('Meta+Enter', { key: 'Enter', ctrlKey: true }, 'other'));
+
+    it('should match ctrl+j case insensitive', () => testPattern('ctrl+j', { key: 'j', ctrlKey: true }));
+    it('should match meta+j case insensitive on mac', () => testPattern('meta+j', { key: 'j', metaKey: true }, 'mac'));
+    it('should match meta+j case insensitive on non-mac', () => testPattern('meta+j', { key: 'j', ctrlKey: true }, 'other'));
+    it('should match alt+j case insensitive', () => testPattern('alt+j', { key: 'j', altKey: true }));
+    it('should match shift+j case insensitive', () => testPattern('shift+j', { key: 'J', shiftKey: true }));
+  });
+
+  describe('Two modifiers', () => {
+    it('should match Ctrl+Alt+K', () => testPattern('Ctrl+Alt+K', { key: 'k', ctrlKey: true, altKey: true }));
+    it('should match Ctrl+Shift+L', () => testPattern('Ctrl+Shift+L', { key: 'L', ctrlKey: true, shiftKey: true }));
+  });
+
+  describe('event.code fallback for letter/digit keys', () => {
+    // On macOS, Option+letter produces a transformed character (e.g. Option+S → 'ß').
+    // The compiler should fall back to event.code when event.key doesn't match the pattern.
+    it('Ctrl+Alt+S should match on mac when event.key is Option-transformed', () =>
+      testPattern('Ctrl+Alt+S', { key: 'ß', code: 'KeyS', ctrlKey: true, altKey: true }, 'mac'));
+
+    it('Ctrl+Alt+K should match when event.key is Option-transformed', () =>
+      testPattern('Ctrl+Alt+K', { key: '˚', code: 'KeyK', ctrlKey: true, altKey: true }, 'mac'));
+
+    it('Alt+J should match when event.key is Option-transformed', () =>
+      testPattern('Alt+J', { key: '∆', code: 'KeyJ', altKey: true }, 'mac'));
+
+    it('letter shortcuts should match physical key on non-QWERTY layouts', () =>
+      testPattern('Ctrl+S', { key: 'o', code: 'KeyS', ctrlKey: true }));
+
+    it('digit shortcut should match Digit code', () =>
+      testPattern('Ctrl+Alt+1', { key: '¡', code: 'Digit1', ctrlKey: true, altKey: true }, 'mac'));
+
+    it('digit shortcut should also match Numpad code', () =>
+      testPattern('Ctrl+Alt+1', { key: '¡', code: 'Numpad1', ctrlKey: true, altKey: true }, 'mac'));
+
+    it('should not match when modifiers differ even if event.code matches', () =>
+      testPatternFalse('Ctrl+Alt+S', { key: 'ß', code: 'KeyS', altKey: true }, 'mac'));
+
+    it('should not fall back for non-letter/digit keys', () =>
+      testPatternFalse('Enter', { key: 'X', code: 'Enter' }));
+  });
+
+  describe('Strict shortcut matching', () => {
+    it('should not match Shift+J when Ctrl is also pressed', () => {
+      testPattern('Shift+J', { key: 'J', shiftKey: true });
+      testPatternFalse('Shift+J', { key: 'J', shiftKey: true, ctrlKey: true });
+    });
+
+    it('should not match Enter when Meta is pressed', () => {
+      testPattern('Enter', { key: 'Enter' });
+      testPatternFalse('Enter', { key: 'Enter', metaKey: true });
+    });
+  });
+
+  describe('Meta key mappings', () => {
+    describe('Meta key should be CMD on Mac', () => {
+      it('Meta+K should match CMD+K on mac', () => testPattern('Meta+K', { key: 'k', metaKey: true }, 'mac'));
+      it('Meta+K should not match CTRL+K on mac', () => testPatternFalse('Meta+K', { key: 'k', ctrlKey: true }, 'mac'));
+      it('Ctrl + Meta + K should be Control + CMD + K on mac', () => testPattern('Ctrl + Meta + K', { key: 'k', ctrlKey: true, metaKey: true }, 'mac'));
+      it('Ctrl + Meta + K should not be squashed into CMD + K on mac', () => testPatternFalse('Ctrl + Meta + K', { key: 'k', metaKey: true }, 'mac'));
+    });
+
+    describe('Meta key should be CTRL on non-mac', () => {
+      it('Meta+K should not match Win+K on non-mac', () => testPatternFalse('Meta+K', { key: 'k', metaKey: true }, 'other'));
+      it('Meta+K should match CTRL+K on non-mac', () => testPattern('Meta+K', { key: 'k', ctrlKey: true }, 'other'));
+      it('Ctrl + Meta + K should not be Control + Win + K on non-mac', () => testPatternFalse('Ctrl + Meta + K', { key: 'k', ctrlKey: true, metaKey: true }, 'other'));
+      it('Ctrl + Meta + K should be squashed into Ctrl + K on non-mac', () => testPattern('Ctrl + Meta + K', { key: 'k', ctrlKey: true }, 'other'));
+    });
+  });
+
+  describe('Invalid patterns', () => {
+    let warnSpy: MockInstance;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(Fun.noop);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const testInvalidPattern = (pattern: string, eventConfig: FakeKeyboardEventConfig) => {
+      const matcher = PatternCompiler.compile(pattern);
+      expect(warnSpy).toHaveBeenCalledExactlyOnceWith(invalidPatternWarning(pattern));
+      expect(matcher(createFakeKeydownEvent(eventConfig))).toBe(false);
+    };
+
+    it('should warn and return never-matching function for Ctrl only', () =>
+      testInvalidPattern('Ctrl', { key: 'Control', ctrlKey: true }));
+
+    it('should warn and return never-matching function for Meta only', () =>
+      testInvalidPattern('Meta', { key: 'Meta', metaKey: true }));
+
+    it('should warn and return never-matching function for Alt only', () =>
+      testInvalidPattern('Alt', { key: 'Alt', altKey: true }));
+
+    it('should warn and return never-matching function for Shift only', () =>
+      testInvalidPattern('Shift', { key: 'Shift', shiftKey: true }));
+
+    it('should warn and return never-matching function for Alt+Ctrl only', () =>
+      testInvalidPattern('Alt+Ctrl', { key: 'Control', ctrlKey: true, altKey: true }));
+
+    it('should warn and return never-matching function for "J+K" (two keys)', () =>
+      testInvalidPattern('J+K', { key: 'j' }));
+
+    it('should warn and return never-matching function for "Space+Enter" (two keys)', () =>
+      testInvalidPattern('Space+Enter', { key: ' ' }));
+  });
+});

--- a/modules/oxide-components/src/test/ts/browser/shortcuts/PatternCompiler.spec.ts
+++ b/modules/oxide-components/src/test/ts/browser/shortcuts/PatternCompiler.spec.ts
@@ -186,5 +186,14 @@ describe('browser.shortcuts.PatternCompilerTest', () => {
 
     it('should warn and return never-matching function for "Space+Enter" (two keys)', () =>
       testInvalidPattern('Space+Enter', { key: ' ' }));
+
+    it('should warn and return never-matching function for empty pattern', () =>
+      testInvalidPattern('', { key: '' }));
+
+    it('should warn and return never-matching function for "Ctrl+" (trailing delimiter)', () =>
+      testInvalidPattern('Ctrl+', { key: '', ctrlKey: true }));
+
+    it('should warn and return never-matching function for "Ctrl+ " (trailing delimiter and whitespace)', () =>
+      testInvalidPattern('Ctrl+ ', { key: '', ctrlKey: true }));
   });
 });

--- a/modules/oxide-components/src/test/ts/browser/shortcuts/UseKeyboardShortcuts.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/shortcuts/UseKeyboardShortcuts.spec.tsx
@@ -1,0 +1,112 @@
+import { Fun } from '@ephox/katamari';
+import { useKeyboardShortcuts, type KeyboardShortcut } from 'oxide-components/shortcuts/UseKeyboardShortcuts';
+import { createRef, useRef, type RefObject } from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+const TestWrapper = ({ shortcuts, inputRef }: {
+  shortcuts: KeyboardShortcut[];
+  inputRef: RefObject<HTMLInputElement>;
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useKeyboardShortcuts(containerRef, shortcuts);
+  return (
+    <div ref={containerRef}>
+      <input type="text" ref={inputRef} />
+    </div>
+  );
+};
+
+const createCtrlKEvent = (): KeyboardEvent =>
+  new KeyboardEvent('keydown', {
+    key: 'k',
+    ctrlKey: true,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    bubbles: true
+  });
+
+const renderTestWrapper = (shortcuts: KeyboardShortcut[]) => {
+  const inputRef = createRef<HTMLInputElement>();
+  const screen = render(<TestWrapper shortcuts={shortcuts} inputRef={inputRef} />);
+
+  return {
+    screen,
+    getInput: () => {
+      if (inputRef.current === null) {
+        throw new Error('inputRef was not populated after render');
+      }
+      return inputRef.current;
+    },
+    rerenderWithShortcuts: (nextShortcuts: KeyboardShortcut[]) =>
+      screen.rerender(<TestWrapper shortcuts={nextShortcuts} inputRef={inputRef} />)
+  };
+};
+
+describe('browser.shortcuts.UseKeyboardShortcutsTest', () => {
+  it('should fire handler on matching keydown event', () => {
+    let callCount = 0;
+    const shortcuts: KeyboardShortcut[] = [
+      { pattern: 'Ctrl + K', handler: () => callCount++ }
+    ];
+
+    const { getInput } = renderTestWrapper(shortcuts);
+    getInput().dispatchEvent(createCtrlKEvent());
+
+    expect(callCount, 'Handler should have been called once').toBe(1);
+  });
+
+  it('should only fire the first matching shortcut handler', () => {
+    let firstCallCount = 0;
+    let secondCallCount = 0;
+    const shortcuts: KeyboardShortcut[] = [
+      { pattern: 'Ctrl + K', handler: () => firstCallCount++ },
+      { pattern: 'Ctrl + K', handler: () => secondCallCount++ }
+    ];
+
+    const { getInput } = renderTestWrapper(shortcuts);
+    getInput().dispatchEvent(createCtrlKEvent());
+
+    expect(firstCallCount, 'First handler should have been called once').toBe(1);
+    expect(secondCallCount, 'Second handler should not have been called').toBe(0);
+  });
+
+  it('should remove event listener on effect cleanup', () => {
+    let firstCallCount = 0;
+    let secondCallCount = 0;
+
+    const { getInput, rerenderWithShortcuts } = renderTestWrapper([
+      { pattern: 'Ctrl+K', handler: () => firstCallCount++ }
+    ]);
+    // Passing a new shortcuts array to the effect should execute its cleanup function
+    rerenderWithShortcuts([
+      { pattern: 'Ctrl+K', handler: () => secondCallCount++ }
+    ]);
+    getInput().dispatchEvent(createCtrlKEvent());
+
+    expect(firstCallCount, 'First handler should not have been called').toBe(0);
+    expect(secondCallCount, 'Second handler should have been called once').toBe(1);
+  });
+
+  it('should call stopPropagation and preventDefault on matched event', () => {
+    const shortcuts: KeyboardShortcut[] = [
+      { pattern: 'Ctrl+K', handler: Fun.noop }
+    ];
+    let stopPropagationCalled = false;
+    let preventDefaultCalled = false;
+
+    const { getInput } = renderTestWrapper(shortcuts);
+    const event = createCtrlKEvent();
+    event.stopPropagation = () => {
+      stopPropagationCalled = true;
+    };
+    event.preventDefault = () => {
+      preventDefaultCalled = true;
+    };
+    getInput().dispatchEvent(event);
+
+    expect(stopPropagationCalled, 'stopPropagation should have been called').toBe(true);
+    expect(preventDefaultCalled, 'preventDefault should have been called').toBe(true);
+  });
+});


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Extracted the `useKeyboardShortcuts` hook and its supporting internals from plugin into `oxide-components`
* The implementation is a port of the original with only migration related:
  * `preact` -> `react`
  * `attachShortcutListener` and `AttachOptions` are exported alongside the hook
  * Migrated tests from `bedrock` to `vitest`
* Exposed via a new `KeyboardShortcuts` namespace export in `main.ts`

Pre-checks:
* [x] ~Changelog entry added~
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a React hook for registering keyboard shortcuts on a target container.
  * Introduced pattern-based shortcut matching with modifier support (Ctrl/Alt/Shift/Meta) and platform-specific behavior (including Mac).
  * Matching shortcuts now consume the event (stop propagation + prevent default) and only trigger the first match.
  * Exposed the new shortcut utilities via the component library.

* **Tests**
  * Added browser test coverage for shortcut matching, invalid patterns, listener cleanup, and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->