### PR TITLE
TINYMCE-14118: Fix Jenkins view resetting on pod failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -324,9 +324,6 @@ timestamps { notifyStatusChange(
           }
           parallel processes
         }
-      }
-
-      container('node') {
 
         stage('Deploy Storybook') {
           if (env.BRANCH_NAME == props.primaryBranch) {
@@ -338,7 +335,7 @@ timestamps { notifyStatusChange(
             echo "Skipping Storybook deployment as the pipeline is not running on the primary branch"
           }
         }
-      } // close container
+      }
     } // close pod
     } // close retry
   } // close outer timeout


### PR DESCRIPTION
Related Ticket: TINYMCE-14118

Description of Changes:
* Moved the storybook stage inside the test stage.
* I have confirmed this still waits for test to pass before deploying storybook; we won't know if this fixes the view reset issue until we get some more pod failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CI pipeline’s handling of test execution and the subsequent Storybook deployment stage.
  * Ensured pipeline stages close and transition correctly after parallel test processes complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->