### PR TITLE
TINYMCE-14527: add unit test for sidebar width during animation

### DIFF
--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -623,4 +623,60 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
       assert.equal(Width.get(pane), 440, 'The pane should follow the sidebar width instead of growing to its content width');
     });
   });
+
+  context('TINYMCE-14527: Sidebar content keeps its full width during the open animation', () => {
+    const resizeHandleWidth = 1;
+    const contentProbeClass = 'test-sidebar-content-probe';
+
+    const registerMeasuringSidebar = (editor: Editor, name: string): void => {
+      editor.ui.registry.addSidebar(name, {
+        tooltip: name,
+        icon: 'comment',
+        onShow: (api: Sidebar.SidebarInstanceApi) => {
+          const content = SugarElement.fromTag('div');
+          Class.add(content, contentProbeClass);
+          Css.setAll(content, { width: '100%', height: '100%' });
+          api.element().appendChild(content.dom);
+        },
+        resizable: true
+      });
+    };
+
+    const setupMeasuringHook = (settings: Record<string, unknown>) =>
+      TinyHooks.bddSetupLight<Editor>({
+        base_url: '/project/tinymce/js/tinymce',
+        toolbar: 'measuring',
+        setup: (editor: Editor) => registerMeasuringSidebar(editor, 'measuring'),
+        ...settings
+      }, []);
+
+    const assertContentWidthDuringGrow = (editor: Editor, expectedWidth: number, message: string): void => {
+      editor.execCommand('ToggleSidebar', false, 'measuring');
+      UiFinder.exists(SugarBody.body(), '.tox-sidebar--sliding-growing');
+      const contentProbe = UiFinder.findIn<HTMLElement>(SugarBody.body(), `.${contentProbeClass}`).getOrDie();
+      const contentWidth = Width.get(contentProbe);
+      const slider = UiFinder.findIn<HTMLElement>(SugarBody.body(), '.tox-sidebar__slider').getOrDie();
+      assert.equal(contentWidth, expectedWidth, message);
+      assert.isBelow(Width.get(slider), contentWidth, 'The animating slider should still be mid-animation and narrower than the content');
+    };
+
+    context('TINYMCE-14527: at the configured width', () => {
+      const sidebarWidth = 500;
+      const hook = setupMeasuringHook({ sidebar_width: sidebarWidth, width: 1200, sidebar_min_width: 200, sidebar_max_width: 600 });
+
+      it('TINYMCE-14527: should give the content the full configured width during the open animation', () => {
+        assertContentWidthDuringGrow(hook.editor(), sidebarWidth - resizeHandleWidth, 'The content should span the full configured sidebar width during the animation');
+      });
+    });
+
+    context('TINYMCE-14527: when the editing-area minimum-width clamp applies', () => {
+      const editorWidth = 1200;
+      const minEditingAreaWidth = 280;
+      const hook = setupMeasuringHook({ sidebar_width: 1000, width: editorWidth, sidebar_min_width: 200, sidebar_max_width: 5000 });
+
+      it('TINYMCE-14527: should give the content the resolved (clamped) width during the open animation', () => {
+        assertContentWidthDuringGrow(hook.editor(), editorWidth - editorBorderLeft - editorBorderRight - minEditingAreaWidth - resizeHandleWidth, 'The content should span the resolved (editing-area-clamped) width during the animation');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Related Ticket: TINYMCE-14527

Description of Changes:

- I'm only adding missing unit test in this PR
- Sidebar content has to receive its full configured with during open animation, otherwise it would inherit it's size from it's parent width even during animation. This means that the text inside the sidebar would wrap during animation etc. Sidebar content's parent has overflow: hidden, so even if the child is wider than a parent during animation it looks okay.
- Added tests to verify that sidebar content maintains its full configured width during the open (grow) animation
- Added a test case to verify that when the editing-area minimum-width clamp applies, the sidebar content receives the resolved (clamped) width during the open animation

Pre-checks:

~~- [ ] Changelog entry added~~
- [x] Tests have been added (if applicable)
- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~- [] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for sidebar sizing during the opening animation.
  - Verified content width remains consistent with the sidebar and available editing area constraints.
  - Confirmed the resize control remains narrower than the sidebar content while animating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->