### PR TITLE
TINYMCE-13738: Updated images apply new alt text

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-13738-2026-07-30.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-13738-2026-07-30.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Image with empty alt text would add role='presentation' instead of adding alt
+  text when updated.
+time: 2026-07-30T15:50:43.311611+10:00
+custom:
+  Issue: TINYMCE-13738

--- a/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/image/main/ts/ui/Dialog.ts
@@ -306,6 +306,7 @@ const submitHandler = (editor: Editor, info: ImageDialogInfo, helpers: Helpers) 
   // Since the style field was removed that process must be simulated on submit.
   const finalData = {
     ...data,
+    isDecorative: info.hasAccessibilityOptions && data.isDecorative,
     style: getStyleValue(helpers.normalizeCss, toImageData(data, false))
   };
 

--- a/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
+++ b/modules/tinymce/src/plugins/image/test/ts/browser/DialogUpdateTest.ts
@@ -81,6 +81,19 @@ describe('browser.tinymce.plugins.image.DialogUpdateTest', () => {
     editor.options.unset('image_caption');
   });
 
+  it('TINYMCE-13738: Typing a non-empty alt on an image previously saved with an empty alt should apply the alt, not role="presentation"', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p><img src="#1" alt="" /></p>');
+    TinySelections.setSelection(editor, [ 0 ], 0, [ 0 ], 1);
+    editor.execCommand('mceImage');
+    await TinyUiActions.pWaitForDialog(editor);
+    assertInputValue(generalTabLabels.src, '#1');
+    assertInputValue(generalTabLabels.alt, '');
+    setInputValue(generalTabLabels.alt, 'A cat');
+    TinyUiActions.submitDialog(editor);
+    assertCleanHtml('Checking output', editor, '<p><img src="#1" alt="A cat"></p>');
+  });
+
   it('TINY-11670: floating images should not lose the float if is not put in a caption', async () => {
     const editor = hook.editor();
     editor.setContent(`<p><img src="${image}" style="border: 2px solid red; float: left" width="200" height="200"/></p>`);


### PR DESCRIPTION
Related Ticket: TINYMCE-13738

Description of Changes:
* Images with empty alt text would add role='presentation' instead of adding alt text when updated

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
