### PR TITLE
TINYMCE-10480: expose `getKeyCodeFromKey`

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-10480-2-2026-08-06.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-10480-2-2026-08-06.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: Removed a Firefox-only CSS quirk (`img:-moz-broken`) that no longer had any effect, since Firefox has unshipped support for the non-standard `:-moz-broken` pseudo-class and `-moz-force-broken-image-icon` property
+time: 2026-08-06T00:00:00.000000+00:00
+custom:
+  Issue: TINYMCE-10480-2

--- a/modules/agar/src/main/ts/ephox/agar/api/Keyboard.ts
+++ b/modules/agar/src/main/ts/ephox/agar/api/Keyboard.ts
@@ -2,6 +2,7 @@ import { Arr } from '@ephox/katamari';
 import { Focus, type SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import { keyevent, type MixedKeyModifiers } from '../keyboard/FakeKeys';
+import { getKeyCodeFromKey } from '../keyboard/Keycodes';
 import * as TypeInEditable from '../keyboard/TypeInEditable';
 import * as TypeInInput from '../keyboard/TypeInInput';
 
@@ -68,6 +69,7 @@ export {
   keyup,
   keypress,
   keystroke,
+  getKeyCodeFromKey,
 
   activeKeydown,
   activeKeyup,

--- a/modules/agar/src/main/ts/ephox/agar/keyboard/Keycodes.ts
+++ b/modules/agar/src/main/ts/ephox/agar/keyboard/Keycodes.ts
@@ -1,4 +1,4 @@
-import { Arr, Type, type Optional } from '@ephox/katamari';
+import { Arr, type Optional, Type } from '@ephox/katamari';
 import { PlatformDetection } from '@ephox/sand';
 
 const isMac = PlatformDetection.detect().os.isMacOS();
@@ -233,3 +233,5 @@ export const getKeyEventFromKeyCode = (
 
 export const getKeyEventFromData = (view: typeof globalThis, event: string, data: string): Optional<KeyboardEvent> =>
   Arr.find(keys, (key) => key.data === data).map((key) => createKeyboardEvent(view, event, false, false, false, false, key));
+
+export const getKeyCodeFromKey = (key: string): number => Arr.find(keys, (k) => k.key === key).map((k) => k.keyCode).getOrDie(`key: ${key} doesn't have a mapped value`);

--- a/modules/tinymce/src/core/main/ts/util/Quirks.ts
+++ b/modules/tinymce/src/core/main/ts/util/Quirks.ts
@@ -531,19 +531,6 @@ const Quirks = (editor: Editor): Quirks => {
   };
 
   /**
-   * Forces Gecko to render a broken image icon if it fails to load an image.
-   */
-  const showBrokenImageIcon = () => {
-    editor.contentStyles.push(
-      'img:-moz-broken {' +
-      '-moz-force-broken-image-icon:1;' +
-      'min-width:24px;' +
-      'min-height:24px' +
-      '}'
-    );
-  };
-
-  /**
    * iOS has a bug where it's impossible to type if the document has a touchstart event
    * bound and the user touches the document while having the on screen keyboard visible.
    *
@@ -799,7 +786,6 @@ const Quirks = (editor: Editor): Quirks => {
     if (isGecko) {
       focusBody();
       setGeckoEditingOptions();
-      showBrokenImageIcon();
       blockCmdArrowNavigation();
     }
   };
@@ -848,7 +834,6 @@ const Quirks = (editor: Editor): Quirks => {
       removeStylesWhenDeletingAcrossBlockElements();
       setGeckoEditingOptions();
       addBrAfterLastLinks();
-      showBrokenImageIcon();
       blockCmdArrowNavigation();
       disableBackspaceIntoATable();
     }

--- a/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
@@ -1,4 +1,4 @@
-import { context, describe, it, before, afterEach, after } from '@ephox/bedrock-client';
+import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
 import { Arr } from '@ephox/katamari';
 import { Insert, Remove, Selectors, SugarBody, SugarElement } from '@ephox/sugar';
 import { assert } from 'chai';
@@ -9,7 +9,7 @@ import EditorManager from 'tinymce/core/api/EditorManager';
 import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
 // TODO TINY-10480: Investigate flaky tests
-describe.skip('browser.tinymce.core.EditorAutoFocusTest', () => {
+describe('browser.tinymce.core.EditorAutoFocusTest', () => {
   before(() => {
     Insert.append(SugarBody.body(), SugarElement.fromHtml(`<div id="abc">
       <div class="tinymce" id="mce_0">Editor_0</div>

--- a/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
@@ -8,8 +8,7 @@ import type Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
-// TODO TINY-10480: Investigate flaky tests
-describe('browser.tinymce.core.EditorAutoFocusTest', () => {
+describe.skip('browser.tinymce.core.EditorAutoFocusTest', () => {
   before(() => {
     Insert.append(SugarBody.body(), SugarElement.fromHtml(`<div id="abc">
       <div class="tinymce" id="mce_0">Editor_0</div>

--- a/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorAutoFocusTest.ts
@@ -8,7 +8,7 @@ import type Editor from 'tinymce/core/api/Editor';
 import EditorManager from 'tinymce/core/api/EditorManager';
 import type { RawEditorOptions } from 'tinymce/core/api/OptionTypes';
 
-describe.skip('browser.tinymce.core.EditorAutoFocusTest', () => {
+describe('browser.tinymce.core.EditorAutoFocusTest', () => {
   before(() => {
     Insert.append(SugarBody.body(), SugarElement.fromHtml(`<div id="abc">
       <div class="tinymce" id="mce_0">Editor_0</div>


### PR DESCRIPTION
Related Ticket: TINYMCE-10480

Description of Changes:
- exposed `getKeyCodeFromKey` from Sugar for a test in the premium repo
- removed quirk for `img:-moz-broken` since is no more needed (https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:-moz-broken)

Pre-checks:
* [x] Changelog entry added
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public keyboard utility for converting key names into key codes.

* **Bug Fixes**
  * Removed an obsolete Firefox broken-image icon workaround.

* **Tests**
  * Re-enabled automatic editor focus tests so they run normally.

* **Documentation**
  * Updated the unreleased changelog with the Firefox compatibility cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->