### PR TITLE
TINYMCE-14527: fix styling issue when the sidebar content has min-content wider then sidebar  

### DIFF
--- a/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
+++ b/modules/oxide/src/less/theme/components/sidebar/sidebar-container.less
@@ -104,7 +104,7 @@
   }
 
   .tox-sidebar-wrap--resizable .tox-sidebar__pane {
-    flex: 1; 
+    width: 100%;
   }
 
   .tox-sidebar__pane {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarResizeTest.ts
@@ -1,4 +1,4 @@
-import { Pointer, TestStore } from '@ephox/agar';
+import { Pointer, TestStore, UiFinder } from '@ephox/agar';
 import { afterEach, beforeEach, context, describe, it } from '@ephox/bedrock-client';
 import type { Sidebar } from '@ephox/bridge';
 import { Fun } from '@ephox/katamari';
@@ -67,7 +67,7 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
     const { setupElement, ...settings } = configOverrides;
     const config = {
       base_url: '/project/tinymce/js/tinymce',
-      toolbar: 'sidebarone sidebartwo resizable-unset resizable-false w800-resizable-false w1000-resizable-false',
+      toolbar: 'sidebarone sidebartwo resizable-unset resizable-false w800-resizable-false w1000-resizable-false wide-content',
       setup: (editor: Editor) => {
         registerResizable(editor, 'sidebarone', 'side bar one');
         registerResizable(editor, 'sidebartwo', 'side bar two');
@@ -85,6 +85,17 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
             api.element().appendChild(div.dom);
             return Fun.noop;
           }
+        });
+        editor.ui.registry.addSidebar('wide-content', {
+          tooltip: 'wide content',
+          icon: 'comment',
+          onSetup: (api: Sidebar.SidebarInstanceApi) => {
+            const div = SugarElement.fromTag('div');
+            Css.setAll(div, { 'width': '600px', 'min-width': '600px' });
+            api.element().appendChild(div.dom);
+            return Fun.noop;
+          },
+          resizable: true
         });
         editor.on('SidebarResizeStart', () => store.add(resizeStartEvent()));
         editor.on('SidebarResized', (e) => store.add(resizedEvent(e.width)));
@@ -599,6 +610,17 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarResizeTest', () => {
           );
         });
       });
+    });
+  });
+
+  context('TINYMCE-14527: Sidebar pane sizing', () => {
+    setupEditorHook({ sidebar_show: 'wide-content', sidebar_width: 440, sidebar_min_width: 300, sidebar_max_width: 800 });
+
+    it('TINYMCE-14527: should keep the shown pane at the sidebar width when its content is wider', () => {
+      const pane = UiFinder.findIn<HTMLElement>(SugarBody.body(), '.tox-sidebar__pane:not([aria-hidden="true"])').getOrDie();
+
+      assertSidebarWidth(440, 'The sidebar should render at its configured width');
+      assert.equal(Width.get(pane), 440, 'The pane should follow the sidebar width instead of growing to its content width');
     });
   });
 });


### PR DESCRIPTION
Related Ticket: TINYMCE-14527

Description of Changes:

- Fixed the sidebar pane width in resizable mode. With the previous approach, if the sidebar content had an element with min-width: 1000px, then the .tox-sidebar__pane could outgrow .tox-sidebar__pane-container - which is not expected. .tox-sidebar__pane should always mirror the width of tox-sidebar__pane-container.

Pre-checks:

~~\- [ ] Changelog entry added~~
- [x] Tests have been added (if applicable)

- [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:

- [x] Milestone set
~~\- [ ] Docs ticket created (if applicable)~~

GitHub issues (if applicable):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resizable sidebar layout behavior by ensuring the visible pane maintains its configured width, even when its content is wider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->