### PR TITLE
TINYMCE-14740: Fix three tests that depend on state left behind by other tests

### DIFF
--- a/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/webdriver/keyboard/IframeTabfocusTest.ts
@@ -1,6 +1,6 @@
-import { FocusTools, RealKeys, RealMouse } from '@ephox/agar';
+import { FocusTools, RealKeys, RealMouse, Waiter } from '@ephox/agar';
 import { after, afterEach, before, context, describe, it } from '@ephox/bedrock-client';
-import { Class, SugarDocument } from '@ephox/sugar';
+import { Class, Focus, SugarDocument } from '@ephox/sugar';
 import { TinyDom, TinyHooks } from '@ephox/wrap-mcagar';
 import { assert } from 'chai';
 
@@ -50,9 +50,14 @@ describe('webdriver.tinymce.core.keyboard.IframeTabfocusTest', () => {
       }
     }, []);
 
-    afterEach(() => {
-      // Un focus the editor
+    afterEach(async () => {
+      // Un focus the editor. window.focus() on its own is not enough: it does not
+      // reliably move focus out of the iframe, and FocusController removes the
+      // highlight in a deferred timeout on focusout, so the next test cannot assume
+      // the class is already gone.
+      Focus.active(SugarDocument.getDocument()).each(Focus.blur);
       window.focus();
+      await Waiter.pTryUntil('Editor highlight should be removed', () => assertIsNotHighlighted(hook.editor()));
     });
 
     it('TINY-9277: Focus on tab', async () => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/backstage/BackstageSinkTest.ts
@@ -25,15 +25,22 @@ describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () 
   //
   // NOTE: If this approach is causing problems, we can just load silver normally, and create a duplicate
   // backstage, but this approach removes the number of extraneous elements.
+  // The oxide skin is loaded into the shared page below. Remember how to remove it
+  // again: leaving it behind changes the layout for every later test that expects an
+  // unskinned page, which is how it broke webdriver DialogFocusTest.
+  let unloadSkin: () => void = Fun.noop;
+
   const hook = TinyHooks.bddSetupLight<Editor>({
     base_url: '/project/tinymce/js/tinymce',
     setup: (ed: Editor) => {
       Options.register(ed);
       ed.on('init', () => {
         const skinUrl = EditorManager.baseURL + '/skins/ui/oxide/skin.css';
+        const styleSheetLoader = ed.ui.styleSheetLoader;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        ed.ui.styleSheetLoader.load(skinUrl).then(
+        styleSheetLoader.load(skinUrl).then(
           () => {
+            unloadSkin = () => styleSheetLoader.unload(skinUrl);
             ed.dispatch('SkinLoaded');
           }
         );
@@ -69,6 +76,7 @@ describe('browser.tinymce.themes.silver.editor.backstage.BackstageSinkTest', () 
   after(() => {
     Attachment.detachSystem(mothership);
     mothership.destroy();
+    unloadSkin();
   });
 
   const buildAndAddColorInput = (backstage: Backstage.UiFactoryBackstage): AlloyComponent => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/skin/OxideColorSwatchMenuTest.ts
@@ -7,6 +7,7 @@ import { TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
 import type Editor from 'tinymce/core/api/Editor';
 import type { Menu } from 'tinymce/core/api/ui/Ui';
 import LocalStorage from 'tinymce/core/api/util/LocalStorage';
+import * as ColorCache from 'tinymce/themes/silver/ui/core/color/ColorCache';
 
 import * as GuiSetup from '../../module/GuiSetup';
 
@@ -141,6 +142,10 @@ describe('browser.tinymce.themes.silver.skin.OxideColorSwatchMenuTest', () => {
 
   beforeEach(() => {
     LocalStorage.clear();
+    // ColorCache memoises a cache per id in module scope, so clearing local
+    // storage alone leaves custom colors added by earlier tests in memory. They
+    // would show up as extra swatches and shift the structure asserted below.
+    ColorCache.clearStoredCaches();
   });
 
   it('Check structure of color swatch', async () => {


### PR DESCRIPTION
Related Ticket: [TINYMCE-14740](https://tiugotech.atlassian.net/browse/TINYMCE-14740)

Description of Changes:
* Fixes three tests that fail because of state left behind by earlier tests. Test-only, no production code is touched.
* `OxideColorSwatchMenuTest` – clear the module-scoped `ColorCache` next to the existing `LocalStorage.clear()`, the same way `ColorCacheTest` and `TextColorSanityTest` already do.
* `IframeTabfocusTest` – in teardown, blur the active element explicitly and wait for the `tox-edit-focus` highlight to disappear instead of relying on `window.focus()`.
* `BackstageSinkTest` – unload the oxide skin stylesheet the test injects into the shared page, in the existing `after` hook.

<details>
<summary><b>Root cause of each failure, with verification numbers</b></summary>

### 1. `OxideColorSwatchMenuTest` – a memoised cache in module scope

`ColorCache` memoises one cache per id in module scope and reads local storage only the first time an id is requested, so the existing `LocalStorage.clear()` in `beforeEach` cannot remove a custom color added by an earlier test in the same page load. The extra swatch shifts the asserted row by one, and the structure assertion then finds the "Remove color" `div` where it expects the picker `button`:

```
Incorrect node name for: <div class="tox-swatch tox-swatch--remove" aria-label="Remove color" ...>
Expected: "button"   Actual: "div"
```

| scope | before | after |
|---|---|---|
| `-d modules/tinymce/src/themes/silver/test/ts/browser` (1461 tests, one page load) | failed 4/4 runs | green 5/5 runs |
| `-d modules/tinymce/src` (~10k tests, chunked as CI runs them) | failed 2/2 runs | green 2/2 runs |
| the file in isolation | 20/20 pass | 20/20 pass |

### 2. `IframeTabfocusTest` – a CSS class removed in a deferred timeout

"TINY-9277: Focus on click" begins by asserting the editor is **not** highlighted, but the preceding "Focus on tab" leaves it highlighted and the `afterEach` only called `window.focus()`. That does not reliably move focus out of the iframe (it is frequently a no-op in headless), and `FocusController` removes `tox-edit-focus` inside `Delay.setEditorTimeout` on `focusout` – so the next test can start before the class is gone. This one fails even when the file runs alone.

Failed in every run before (in isolation, and in 10/10 runs of `-d modules/tinymce/src`); green 3/3 in isolation and 0/3 failures at module scope after.

### 3. `BackstageSinkTest` – an injected stylesheet that is never unloaded

`BackstageSinkTest` deliberately loads the full oxide skin into the shared page (`ed.ui.styleSheetLoader.load(.../oxide/skin.css)`) and never unloads it. Later tests written for an *unskinned* page then run with skin styles applied. That is how it broke webdriver `DialogFocusTest`, which adds its own minimal `[role="dialog"]` styles precisely because there is no skin: with the real skin present the dialog wrapper covers the page, so `RealMouse.pClickOn('body')` never reaches the body and the focus assertion times out after 3s.

Paired with `BackstageSinkTest` alone, `DialogFocusTest` failed 3/3 runs before this change and passes 3/3 after it, so the leak on its own is sufficient to break it.

Being precise about what this change does *not* claim: at module scope `DialogFocusTest` failed 10/10 runs before any of these changes, but it now passes 6/6 with change 3 reverted and change 2 applied. So at that scope the symptom is multi-causal and I cannot attribute it to a single carrier. Change 3 stands on its own as hygiene – a test that injects a stylesheet into the shared page should remove it – and on the pair result above, not on the module-scope numbers.

### Environment used for the numbers

Linux container, Chromium 151 with a matching chromedriver, `bedrock-auto --retries=0`, tests invoked directly rather than through `grunt`, to keep the option handling out of the picture.

</details>

<details>
<summary><b>Two findings that may matter more than the fixes</b></summary>

1. **This class of failure is invisible in CI reporting.** When a test fails and then passes on retry, `Controller.ts` overwrites the failed attempt with the passing one, so nothing reaches the JUnit report. All three tests above were found only because a transient failure flashed in bedrock's console HUD, or because retries were switched off locally. A "flaky: N" counter per build would surface the rest – the server already receives the failing attempt.
2. **Boolean bedrock options cannot be turned off from the command line.** In the root `Gruntfile.js`, `bedrockOpts` does `if (current) opts[opt] = current`. Grunt converts `"true"`/`"false"` to booleans, so `--stopOnFailure=false` and any `--no-<option>` form arrive as `false`, are discarded as falsy, and the Gruntfile default silently stands. Verified by printing the generated bedrock config: `--stopOnFailure=false` and `--no-delayExit` are absent from it. (`--retries=0` is unaffected – grunt does not convert numbers, so it arrives as the truthy string `"0"` and is forwarded.)

</details>

<details>
<summary><b>Resolved: change 3 does not destabilise the sticky-header and tooltip tests</b></summary>

Worth recording because it was the reason this stayed a draft. `StickyHeaderTopTest` / `StickyHeaderBottomTest` ("TINY-7337: Checking toolbar_sticky_offset"), `HtmlPanelTooltipTest` ("TINY-9641") and `TooltipTest` ("TINY-10453") failed in **2 of 8** module-scope runs with change 3 applied, and in **1 of 6** runs with change 3 reverted. A different test failed on each occasion.

So they fail either way and they are not tied to the stylesheet: they look like ambient flakiness in style- and timing-sensitive tests. They are not touched here, and they are worth a separate look – with retries on, none of them appear in any CI report either.

</details>

Pre-checks:
* [ ] Changelog entry added – n/a, test-only changes (#11194 added none either)
* [x] Tests have been added (if applicable) – n/a, these repair existing tests
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set – needs a Tiny reviewer
* [ ] Docs ticket created (if applicable) – n/a

GitHub issues (if applicable): none

---

The branch lives in `tinymce/tinymce`, so the Jenkins multibranch job picks it up and this gets a real CI run. It replaces #11222, which came from a fork and therefore could not be built (the job discovers branches only – there are no `PR-*` jobs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved editor focus testing by ensuring focus state is reset consistently between tests.
  * Added cleanup for temporary skin stylesheets after test execution.
  * Reset color data between swatch tests to prevent results from being affected by earlier tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[TINYMCE-14740]: https://tiugotech.atlassian.net/browse/TINYMCE-14740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ