### PR TITLE
TINYMCE-14611: Add deleted media overlay styles and media diff treatments to content CSS

### DIFF
--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -89,7 +89,6 @@ body.tox-tinymceai-preview--selectable {
     background-color: fade(@color-error, 20%);
     box-shadow: @tinymceai-selected-box-shadow;
 
-    // Nested media under a selected removed block (classes on the wrapper).
     img:not(.tox-tinymceai__annotation--removed__paired),
     video,
     iframe {
@@ -142,13 +141,15 @@ body.tox-tinymceai-preview--selectable {
       border-color: @media-modified-background-color;
       .diff-media-selected-outline();
     }
+  }
 
-    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected:not(.tox-tinymceai__annotation--removed__paired) {
-      .diff-media-removed();
-      border-color: @media-removed-background-color;
-      display: inline;
-      .diff-media-selected-outline();
-    }
+  img.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected:not(.tox-tinymceai__annotation--removed__paired),
+  video.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected,
+  iframe.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+    .diff-media-removed();
+    border-color: @media-removed-background-color;
+    display: inline-block;
+    .diff-media-selected-outline();
   }
 }
 

--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -88,6 +88,15 @@ body.tox-tinymceai-preview--selectable {
     background-image: none;
     background-color: fade(@color-error, 20%);
     box-shadow: @tinymceai-selected-box-shadow;
+
+    // Nested media under a selected removed block (classes on the wrapper).
+    img:not(.tox-tinymceai__annotation--removed__paired),
+    video,
+    iframe {
+      .diff-media-removed();
+      border-color: @media-removed-background-color;
+      .diff-media-selected-outline();
+    }
   }
 
   // ins/del elements only contain text and inline formatting, so they can safely use
@@ -138,17 +147,6 @@ body.tox-tinymceai-preview--selectable {
       .diff-media-removed();
       border-color: @media-removed-background-color;
       display: inline;
-      .diff-media-selected-outline();
-    }
-  }
-
-  // Nested media under a selected removed block (classes on the wrapper).
-  .tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
-    img:not(.tox-tinymceai__annotation--removed__paired),
-    video,
-    iframe {
-      .diff-media-removed();
-      border-color: @media-removed-background-color;
       .diff-media-selected-outline();
     }
   }

--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -121,20 +121,22 @@ body.tox-tinymceai-preview--selectable {
   }
 
   img, video, iframe {
-    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected,
-    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected {
       background-image: none;
       border: 0.25em solid fade(@color-tint, 20%);
       outline: 0.125em solid @color-tint;
       padding: 0;
     }
 
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
+      .diff-media-modified();
+      outline: 2px solid @tinymceai-selected-outline-color;
+    }
+
     &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+      .diff-media-removed();
       display: inline;
-      background-image: none;
-      border: 0.25em solid fade(@color-error, 20%);
-      outline: 0.125em solid @color-error;
-      padding: 0;
+      outline: 2px solid @tinymceai-selected-outline-color;
     }
   }
 }
@@ -151,9 +153,9 @@ body.tox-tinymceai-preview--selectable {
   position: absolute;
   left: 0;
   top: 0;
-  right: 0;
   overflow: hidden;
   pointer-events: none;
+  z-index: 10;
 }
 
 .tox-tinymceai__diff-focus-overlay-dim {

--- a/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/content/ai-preview/ai-preview.less
@@ -57,11 +57,12 @@ span[tinymceai-data-pending-diff="true"] {
 }
 
 img, video, iframe {
-  &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight,
+  &.tox-tinymceai__annotation--added.tox-tinymceai__annotation--preview-highlight {
+    .diff-media-added();
+  }
+
   &.tox-tinymceai__annotation--modified.tox-tinymceai__annotation--preview-highlight {
-    background-image: none;
-    outline: 0.25em solid fade(@color-tint, 20%);
-    padding: 0.25em;
+    .diff-media-modified();
   }
 }
 
@@ -122,21 +123,33 @@ body.tox-tinymceai-preview--selectable {
 
   img, video, iframe {
     &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--added__selected {
-      background-image: none;
-      border: 0.25em solid fade(@color-tint, 20%);
-      outline: 0.125em solid @color-tint;
-      padding: 0;
+      .diff-media-added();
+      border-color: @media-added-background-color;
+      .diff-media-selected-outline();
     }
 
     &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--modified__selected {
       .diff-media-modified();
-      outline: 2px solid @tinymceai-selected-outline-color;
+      border-color: @media-modified-background-color;
+      .diff-media-selected-outline();
     }
 
-    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+    &.tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected:not(.tox-tinymceai__annotation--removed__paired) {
       .diff-media-removed();
+      border-color: @media-removed-background-color;
       display: inline;
-      outline: 2px solid @tinymceai-selected-outline-color;
+      .diff-media-selected-outline();
+    }
+  }
+
+  // Nested media under a selected removed block (classes on the wrapper).
+  .tox-tinymceai__annotation--preview-highlight.tox-tinymceai__annotation--removed__selected {
+    img:not(.tox-tinymceai__annotation--removed__paired),
+    video,
+    iframe {
+      .diff-media-removed();
+      border-color: @media-removed-background-color;
+      .diff-media-selected-outline();
     }
   }
 }

--- a/modules/oxide/src/less/theme/content/diff/diff.less
+++ b/modules/oxide/src/less/theme/content/diff/diff.less
@@ -5,22 +5,22 @@
 @media-added-background-color: mix(@background-color, @color-success, 80%);
 @media-removed-background-color: mix(@background-color, @color-error, 80%);
 @media-modified-background-color: mix(@background-color, @color-tint, 80%);
-// Selection ring around media; distinct from @color-tint (#006ce7) used for modified borders.
-@media-selected-outline-color: #233477;
+@media-selected-outline-color: @color-tint;
 
 .diff-media-added() {
   background-color: @media-added-background-color;
   background-image: none;
   border: 2px solid @color-success;
   padding: 0;
+  vertical-align: top;
 }
 
 .diff-media-removed() {
   background-color: @media-removed-background-color;
   background-image: none;
   border: 2px solid @color-error;
-  opacity: 0.6;
   padding: 0;
+  vertical-align: top;
 }
 
 .diff-media-modified() {
@@ -28,6 +28,7 @@
   background-image: none;
   border: 2px solid @color-tint;
   padding: 0;
+  vertical-align: top;
 }
 
 .diff-media-selected-outline() {
@@ -88,6 +89,35 @@
     background-image: none;
     background-color: @removed-bg;
     box-shadow: @selected-box-shadow;
+  }
+
+  // Avoid baseline gap under inline media inside annotation chrome.
+  img,
+  video,
+  iframe,
+  .mce-object,
+  .mce-preview-object {
+    &.tox-@{pluginName}__annotation--added,
+    &.tox-@{pluginName}__annotation--modified,
+    &.tox-@{pluginName}__annotation--removed {
+      padding-block: 0;
+      vertical-align: top;
+    }
+  }
+
+  .tox-@{pluginName}__annotation--added:has(img, video, iframe, .mce-object, .mce-preview-object),
+  .tox-@{pluginName}__annotation--modified:has(img, video, iframe, .mce-object, .mce-preview-object),
+  .tox-@{pluginName}__annotation--removed:has(img, video, iframe, .mce-object, .mce-preview-object) {
+    padding-block: 0;
+    line-height: 0;
+
+    img,
+    video,
+    iframe,
+    .mce-object,
+    .mce-preview-object {
+      vertical-align: top;
+    }
   }
 
   // ins/del elements only contain text and inline formatting, so they can safely use
@@ -158,8 +188,7 @@
     }
   }
 
-  // Paired remove = old half of a replacement: images get the X only (no washout).
-  // Also style media nested under a removed block (typical <!-- removed --> path).
+  // Replaced images: X only (no wash). Video/iframe keep wash even when paired.
   img.tox-@{pluginName}__annotation--removed__highlight:not(.tox-@{pluginName}__annotation--removed__paired),
   img.tox-@{pluginName}__annotation--removed__selected:not(.tox-@{pluginName}__annotation--removed__paired),
   .tox-@{pluginName}__annotation--removed__highlight img:not(.tox-@{pluginName}__annotation--removed__paired),
@@ -214,6 +243,11 @@
     position: absolute;
     top: 0;
     z-index: 11;
+  }
+
+  .tox-@{pluginName}__deleted-media-wash {
+    fill: @background-color;
+    fill-opacity: 0.4;
   }
 
   .tox-@{pluginName}__deleted-media-mark {

--- a/modules/oxide/src/less/theme/content/diff/diff.less
+++ b/modules/oxide/src/less/theme/content/diff/diff.less
@@ -2,6 +2,24 @@
 @modified-background-color: fade(@color-tint, 20%);
 @removed-background-color: fade(@color-error, 20%);
 
+@media-removed-background-color: mix(@background-color, @color-error, 80%);
+@media-modified-background-color: mix(@background-color, @color-tint, 80%);
+
+.diff-media-removed() {
+  background-color: @media-removed-background-color;
+  background-image: none;
+  border: 2px solid @color-error;
+  opacity: 0.6;
+  padding: 0;
+}
+
+.diff-media-modified() {
+  background-color: @media-modified-background-color;
+  background-image: none;
+  border: 2px solid @color-tint;
+  padding: 0;
+}
+
 @selected-outline-color: @color-tint;
 @selected-box-shadow: 0 2px 0 0 @selected-outline-color, 0 -2px 0 0 @selected-outline-color;
 
@@ -118,31 +136,31 @@
       background-image: none;
     }
 
-    &.tox-@{pluginName}__annotation--modified__highlight {
-      outline: 0.25em solid @modified-bg;
-      padding: 0.25em;
-      background-image: none;
-    }
-
+    &.tox-@{pluginName}__annotation--modified__highlight,
     &.tox-@{pluginName}__annotation--modified__selected {
-      border: 0.25em solid @modified-bg;
-      outline: 0.125em solid @selected-outline-color;
-      padding: 0em;
-      background-image: none;
+      .diff-media-modified();
     }
 
-    &.tox-@{pluginName}__annotation--removed__highlight {
-      outline: 0.25em solid @removed-bg;
-      padding: 0.25em;
-      background-image: none;
-    }
-
+    &.tox-@{pluginName}__annotation--modified__selected,
     &.tox-@{pluginName}__annotation--removed__selected {
-      border: 0.25em solid @removed-bg;
-      outline: 0.125em solid @selected-outline-color;
-      padding: 0em;
-      background-image: none;
+      outline: 2px solid @selected-outline-color;
     }
+  }
+
+  // A paired remove is the old half of a replacement: replaced images show the X mark
+  // only, while deleted images and all removed videos/iframes are also washed out.
+  img.tox-@{pluginName}__annotation--removed__highlight:not(.tox-@{pluginName}__annotation--removed__paired),
+  img.tox-@{pluginName}__annotation--removed__selected:not(.tox-@{pluginName}__annotation--removed__paired),
+  video.tox-@{pluginName}__annotation--removed__highlight,
+  video.tox-@{pluginName}__annotation--removed__selected,
+  iframe.tox-@{pluginName}__annotation--removed__highlight,
+  iframe.tox-@{pluginName}__annotation--removed__selected {
+    .diff-media-removed();
+  }
+
+  img.tox-@{pluginName}__annotation--removed__paired {
+    background-image: none;
+    padding: 0;
   }
 
   div.tox-@{pluginName}__annotation:has(> hr) {
@@ -156,6 +174,24 @@
 
   div.tox-@{pluginName}__annotation--added__highlight > hr {
     border-color: darken(@added-bg, 50%);
+  }
+
+  // One above the diff focus overlay so marks always paint over the dim layer.
+  .tox-@{pluginName}__deleted-media-overlay {
+    left: 0;
+    overflow: hidden;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    z-index: 11;
+  }
+
+  .tox-@{pluginName}__deleted-media-mark {
+    stroke: @color-error;
+  }
+
+  .tox-@{pluginName}__deleted-media-halo {
+    stroke: @color-white;
   }
 
   .mce-pagebreak {

--- a/modules/oxide/src/less/theme/content/diff/diff.less
+++ b/modules/oxide/src/less/theme/content/diff/diff.less
@@ -2,8 +2,18 @@
 @modified-background-color: fade(@color-tint, 20%);
 @removed-background-color: fade(@color-error, 20%);
 
+@media-added-background-color: mix(@background-color, @color-success, 80%);
 @media-removed-background-color: mix(@background-color, @color-error, 80%);
 @media-modified-background-color: mix(@background-color, @color-tint, 80%);
+// Selection ring around media; distinct from @color-tint (#006ce7) used for modified borders.
+@media-selected-outline-color: #233477;
+
+.diff-media-added() {
+  background-color: @media-added-background-color;
+  background-image: none;
+  border: 2px solid @color-success;
+  padding: 0;
+}
 
 .diff-media-removed() {
   background-color: @media-removed-background-color;
@@ -18,6 +28,10 @@
   background-image: none;
   border: 2px solid @color-tint;
   padding: 0;
+}
+
+.diff-media-selected-outline() {
+  outline: 2px solid @media-selected-outline-color;
 }
 
 @selected-outline-color: @color-tint;
@@ -124,43 +138,60 @@
   video,
   iframe {
     &.tox-@{pluginName}__annotation--added__highlight {
-      outline: 0.25em solid @added-bg;
-      padding: 0.25em;
-      background-image: none;
+      .diff-media-added();
     }
 
     &.tox-@{pluginName}__annotation--added__selected {
-      border: 0.25em solid @added-bg;
-      outline: 0.125em solid @selected-outline-color;
-      padding: 0em;
-      background-image: none;
+      .diff-media-added();
+      border-color: @media-added-background-color;
+      .diff-media-selected-outline();
     }
 
-    &.tox-@{pluginName}__annotation--modified__highlight,
-    &.tox-@{pluginName}__annotation--modified__selected {
+    &.tox-@{pluginName}__annotation--modified__highlight {
       .diff-media-modified();
     }
 
-    &.tox-@{pluginName}__annotation--modified__selected,
-    &.tox-@{pluginName}__annotation--removed__selected {
-      outline: 2px solid @selected-outline-color;
+    &.tox-@{pluginName}__annotation--modified__selected {
+      .diff-media-modified();
+      border-color: @media-modified-background-color;
+      .diff-media-selected-outline();
     }
   }
 
-  // A paired remove is the old half of a replacement: replaced images show the X mark
-  // only, while deleted images and all removed videos/iframes are also washed out.
+  // Paired remove = old half of a replacement: images get the X only (no washout).
+  // Also style media nested under a removed block (typical <!-- removed --> path).
   img.tox-@{pluginName}__annotation--removed__highlight:not(.tox-@{pluginName}__annotation--removed__paired),
   img.tox-@{pluginName}__annotation--removed__selected:not(.tox-@{pluginName}__annotation--removed__paired),
+  .tox-@{pluginName}__annotation--removed__highlight img:not(.tox-@{pluginName}__annotation--removed__paired),
+  .tox-@{pluginName}__annotation--removed__selected img:not(.tox-@{pluginName}__annotation--removed__paired),
   video.tox-@{pluginName}__annotation--removed__highlight,
   video.tox-@{pluginName}__annotation--removed__selected,
+  .tox-@{pluginName}__annotation--removed__highlight video,
+  .tox-@{pluginName}__annotation--removed__selected video,
   iframe.tox-@{pluginName}__annotation--removed__highlight,
-  iframe.tox-@{pluginName}__annotation--removed__selected {
+  iframe.tox-@{pluginName}__annotation--removed__selected,
+  .tox-@{pluginName}__annotation--removed__highlight iframe,
+  .tox-@{pluginName}__annotation--removed__selected iframe {
     .diff-media-removed();
+  }
+
+  img.tox-@{pluginName}__annotation--removed__selected:not(.tox-@{pluginName}__annotation--removed__paired),
+  .tox-@{pluginName}__annotation--removed__selected img:not(.tox-@{pluginName}__annotation--removed__paired),
+  video.tox-@{pluginName}__annotation--removed__selected,
+  .tox-@{pluginName}__annotation--removed__selected video,
+  iframe.tox-@{pluginName}__annotation--removed__selected,
+  .tox-@{pluginName}__annotation--removed__selected iframe {
+    border-color: @media-removed-background-color;
+    .diff-media-selected-outline();
   }
 
   img.tox-@{pluginName}__annotation--removed__paired {
     background-image: none;
     padding: 0;
+  }
+
+  img.tox-@{pluginName}__annotation--removed__paired.tox-@{pluginName}__annotation--removed__selected {
+    .diff-media-selected-outline();
   }
 
   div.tox-@{pluginName}__annotation:has(> hr) {
@@ -176,7 +207,6 @@
     border-color: darken(@added-bg, 50%);
   }
 
-  // One above the diff focus overlay so marks always paint over the dim layer.
   .tox-@{pluginName}__deleted-media-overlay {
     left: 0;
     overflow: hidden;


### PR DESCRIPTION
Related Ticket: TINYMCE-14611

Description of Changes:
* Added, modified, and removed images, videos, and iframes get a 2px border in the state color. The background is `mix(@background-color, @color-*, 80%)` and thus follows the skin. Selected media gets a 2px `@color-tint` outline.
* A replaced image has the `--removed__paired` class and does not get the washed-out treatment. A replaced video or iframe keeps it.
* New classes style the SVG overlay: `__deleted-media-overlay` (z-index 11, above the diff-focus overlay), `__deleted-media-wash`, `__deleted-media-mark`, and `__deleted-media-halo`.
* `:has()` rules apply the treatments to media in removed blocks.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):
