### PR TITLE
TINYMCE-14506: fix tooltip on `Esc` behavior

### DIFF
--- a/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
@@ -1,4 +1,3 @@
-import { Global } from '@ephox/katamari';
 import { createContext, useContext } from 'react';
 
 export interface TooltipContext {
@@ -24,16 +23,4 @@ export const useTooltip = (): TooltipContext => {
   return context;
 };
 
-// Some plugins bundle their own independent copy of oxide-components (core plugin bundle vs. lazily-loaded sidebar bundle),
-// so a bare module-level singleton would not be shared between them.
-// Keying off `window` ensures every bundle copy resolves to the same
-// EventTarget so CloseActiveTooltips coordination works across bundle boundaries.
-const TOOLTIPS_EVENT_TARGET_KEY = '__tinymceOxideTooltipsEventTarget__';
-
-const getTooltipsEventTarget = (): EventTarget => {
-  if (!Global[TOOLTIPS_EVENT_TARGET_KEY]) {
-    Global[TOOLTIPS_EVENT_TARGET_KEY] = new window.EventTarget();
-  }
-  return Global[TOOLTIPS_EVENT_TARGET_KEY];
-};
-export const tooltipsEventTarget = getTooltipsEventTarget();
+export const tooltipsEventTarget: EventTarget = document;

--- a/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
+++ b/modules/oxide-components/src/main/ts/components/tooltip/internals/Context.tsx
@@ -1,3 +1,4 @@
+import { Global } from '@ephox/katamari';
 import { createContext, useContext } from 'react';
 
 export interface TooltipContext {
@@ -23,5 +24,16 @@ export const useTooltip = (): TooltipContext => {
   return context;
 };
 
-export const tooltipsEventTarget = new window.EventTarget();
+// Some plugins bundle their own independent copy of oxide-components (core plugin bundle vs. lazily-loaded sidebar bundle),
+// so a bare module-level singleton would not be shared between them.
+// Keying off `window` ensures every bundle copy resolves to the same
+// EventTarget so CloseActiveTooltips coordination works across bundle boundaries.
+const TOOLTIPS_EVENT_TARGET_KEY = '__tinymceOxideTooltipsEventTarget__';
 
+const getTooltipsEventTarget = (): EventTarget => {
+  if (!Global[TOOLTIPS_EVENT_TARGET_KEY]) {
+    Global[TOOLTIPS_EVENT_TARGET_KEY] = new window.EventTarget();
+  }
+  return Global[TOOLTIPS_EVENT_TARGET_KEY];
+};
+export const tooltipsEventTarget = getTooltipsEventTarget();


### PR DESCRIPTION
Related Ticket: TINYMCE-14506

Description of Changes:
the previous solution wasn't working bundling the plugins, it worked on running it on dev, this fix it

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~Tests have been added (if applicable)~
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] ~Docs ticket created (if applicable)~

GitHub issues (if applicable):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip coordination when multiple independently bundled copies of the components are used together.
  * Ensured tooltip behavior remains consistent across separate application bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->