### PR TITLE
TINYMCE-14723: Add Card.Expansion component

### DIFF
--- a/modules/oxide-components/src/main/ts/components/card/Card.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.stories.tsx
@@ -61,9 +61,15 @@ The component uses a compound component pattern with these parts:
 - \`Card.HeaderActions\`: Right-side header action buttons with visibility modes (\`hover\` default, \`focus\`, \`always\`)
 - \`Card.Body\`: Main content area
 - \`Card.Actions\`: Bottom button container
-- \`Card.Expansion\`: Expandable section for nested content (feedback threads, comment replies)
-- \`Card.ExpansionTrigger\`: Button that toggles the expansion (Enter/Space)
-- \`Card.ExpansionContent\`: Animated collapsible content region
+
+## Feedback/Comment Threads
+
+For feedback and comment threads, click the card to reveal the thread content:
+1. **Click card** → Shows divider + existing replies + textarea
+2. **Focus textarea** → Shows Cancel/Save buttons
+3. **Click Cancel** → Hides buttons, keeps textarea visible
+
+The feedback count is shown in the \`Profile.Subheading\` with an icon.
 
 ## Integration
 
@@ -71,8 +77,15 @@ Works seamlessly with other oxide-components:
 - **Button** / **IconButton**: For action buttons
 - **Profile**: For user info in HeaderContent
 - **ExpandableBox**: For long content
-- **AutoResizingTextarea**: For feedback/comment editors inside Expansion
+- **AutoResizingTextarea**: For feedback/comment editors
 - **Icon**: For status indicators
+
+## Advanced: Card.Expansion
+
+For custom expandable sections, use the \`Card.Expansion\` compound components:
+- \`Card.Expansion\`: Expandable section wrapper (controlled)
+- \`Card.ExpansionTrigger\`: Button that toggles the expansion
+- \`Card.ExpansionContent\`: Animated collapsible content region
         `
       }
     }
@@ -685,24 +698,30 @@ export const ExpansionProvideFeedback: Story = {
     docs: {
       description: {
         story: `
-**Card.Expansion — Provide Feedback (Suggested Edits)**
+**Card — Provide Feedback (Suggested Edits)**
 
-Mirrors the Suggested Edits pattern: clicking **Provide feedback** expands an editor
-inside the card. Cancel collapses the expansion.
+Click the card to reveal the feedback composer. Focus the textarea to show action buttons.
 
-**Try it:** Click or press Enter on Provide feedback.
+**Try it:** Click the card → focus textarea → Cancel hides buttons, keeps textarea visible.
         `
       }
     }
   },
   render: () => {
     const [ selected, setSelected ] = useState(true);
-    const [ open, setOpen ] = useState(false);
+    const [ threadOpen, setThreadOpen ] = useState(false);
+    const [ actionsVisible, setActionsVisible ] = useState(false);
     const [ feedback, setFeedback ] = useState('');
 
     return (
       <div style={{ width: '316px' }}>
-        <Card.Root selected={selected} onSelect={() => setSelected(!selected)}>
+        <Card.Root 
+          selected={selected} 
+          onSelect={() => {
+            setSelected(!selected);
+            setThreadOpen(!threadOpen);
+          }}
+        >
           <Card.Header>
             <Card.HeaderContent>
               <Profile.Root>
@@ -721,43 +740,46 @@ inside the card. Cancel collapses the expansion.
           <Card.Body>
             <p style={{ margin: 0 }}>Modified text</p>
           </Card.Body>
-          <Card.Expansion open={open} onOpenChange={setOpen}>
-            {!open && (
-              <Card.ExpansionTrigger>
-                <Button variant="outlined" className="tox-button--stretch">
-                  Provide feedback
-                </Button>
-              </Card.ExpansionTrigger>
-            )}
-            <Card.ExpansionContent ariaLabel="Feedback editor">
-              <AutoResizingTextarea
-                value={feedback}
-                onChange={setFeedback}
-                placeholder="Provide feedback..."
-              />
-              <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-                <Button
-                  variant="outlined"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setFeedback('');
-                    setOpen(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setOpen(false);
-                  }}
-                >
-                  Save
-                </Button>
+          {threadOpen && (
+            <>
+              <Card.Divider />
+              <div 
+                style={{ paddingBottom: '16px' }}
+                onFocusCapture={() => setActionsVisible(true)}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <AutoResizingTextarea
+                  value={feedback}
+                  onChange={setFeedback}
+                  placeholder="Provide feedback..."
+                />
+                {actionsVisible && (
+                  <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', marginTop: '8px' }}>
+                    <Button
+                      variant="outlined"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setFeedback('');
+                        setActionsVisible(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setFeedback('');
+                        setActionsVisible(false);
+                      }}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                )}
               </div>
-            </Card.ExpansionContent>
-          </Card.Expansion>
+            </>
+          )}
         </Card.Root>
       </div>
     );
@@ -769,25 +791,30 @@ export const ExpansionCommentReplies: Story = {
     docs: {
       description: {
         story: `
-**Card.Expansion — Comment Replies**
+**Card — Comment Thread (Comments)**
 
-Mirrors the Comments pattern: a replies trigger expands nested reply cards,
-with an **Add comment...** action that opens a reply editor.
+Click the card to reveal existing replies and a composer. Focus the textarea to show action buttons.
 
-**Try it:** Expand replies, then Add comment.
+**Try it:** Click card → see replies + composer → focus textarea → action buttons appear.
         `
       }
     }
   },
   render: () => {
     const [ selected, setSelected ] = useState(true);
-    const [ repliesOpen, setRepliesOpen ] = useState(false);
-    const [ replyOpen, setReplyOpen ] = useState(false);
+    const [ threadOpen, setThreadOpen ] = useState(false);
+    const [ actionsVisible, setActionsVisible ] = useState(false);
     const [ reply, setReply ] = useState('');
 
     return (
       <div style={{ width: '316px' }}>
-        <Card.Root selected={selected} onSelect={() => setSelected(!selected)}>
+        <Card.Root 
+          selected={selected} 
+          onSelect={() => {
+            setSelected(!selected);
+            setThreadOpen(!threadOpen);
+          }}
+        >
           <Card.Header>
             <Card.HeaderContent>
               <Profile.Root>
@@ -807,14 +834,14 @@ with an **Add comment...** action that opens a reply editor.
             </p>
           </Card.Body>
 
-          <Card.Expansion open={repliesOpen} onOpenChange={setRepliesOpen}>
-            <Card.ExpansionTrigger>
-              <Button variant="outlined" className="tox-button--stretch">
-                2 replies
-              </Button>
-            </Card.ExpansionTrigger>
-            <Card.ExpansionContent>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {threadOpen && (
+            <>
+              <Card.Divider />
+              <div 
+                style={{ paddingBottom: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}
+                onFocusCapture={() => setActionsVisible(true)}
+                onClick={(e) => e.stopPropagation()}
+              >
                 <div>
                   <Profile.Root>
                     <Profile.Image src={AVATAR_URL} alt="Alex Rivera" />
@@ -836,46 +863,38 @@ with an **Add comment...** action that opens a reply editor.
                   <p style={{ margin: '8px 0 0' }}>I can take a pass on a rewrite.</p>
                 </div>
 
-                <Card.Expansion open={replyOpen} onOpenChange={setReplyOpen}>
-                  {!replyOpen && (
-                    <Card.ExpansionTrigger>
-                      <Button variant="outlined" className="tox-button--stretch">
-                        Add comment...
-                      </Button>
-                    </Card.ExpansionTrigger>
-                  )}
-                  <Card.ExpansionContent ariaLabel="Comment editor">
-                    <AutoResizingTextarea
-                      value={reply}
-                      onChange={setReply}
-                      placeholder="Add comment..."
-                    />
-                    <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-                      <Button
-                        variant="outlined"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setReply('');
-                          setReplyOpen(false);
-                        }}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        variant="primary"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setReplyOpen(false);
-                        }}
-                      >
-                        Comment
-                      </Button>
-                    </div>
-                  </Card.ExpansionContent>
-                </Card.Expansion>
+                <AutoResizingTextarea
+                  value={reply}
+                  onChange={setReply}
+                  placeholder="Add comment..."
+                />
+                {actionsVisible && (
+                  <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                    <Button
+                      variant="outlined"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setReply('');
+                        setActionsVisible(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setReply('');
+                        setActionsVisible(false);
+                      }}
+                    >
+                      Comment
+                    </Button>
+                  </div>
+                )}
               </div>
-            </Card.ExpansionContent>
-          </Card.Expansion>
+            </>
+          )}
         </Card.Root>
       </div>
     );
@@ -887,25 +906,30 @@ export const ExpansionFeedbackReplies: Story = {
     docs: {
       description: {
         story: `
-**Card.Expansion — Feedback with Replies (Suggested Edits)**
+**Card — Feedback Thread (Suggested Edits)**
 
-Shows a feedback thread where the original feedback can expand to show nested replies,
-with a **Provide feedback** action to respond to the feedback.
+Click the card to reveal existing feedback and a composer. Focus the textarea to show action buttons.
 
-**Try it:** Expand feedback thread, then Provide feedback.
+**Try it:** Click card → see feedback + composer → focus textarea → action buttons appear.
         `
       }
     }
   },
   render: () => {
     const [ selected, setSelected ] = useState(true);
-    const [ feedbackOpen, setFeedbackOpen ] = useState(false);
-    const [ replyOpen, setReplyOpen ] = useState(false);
+    const [ threadOpen, setThreadOpen ] = useState(false);
+    const [ actionsVisible, setActionsVisible ] = useState(false);
     const [ reply, setReply ] = useState('');
 
     return (
       <div style={{ width: '316px' }}>
-        <Card.Root selected={selected} onSelect={() => setSelected(!selected)}>
+        <Card.Root 
+          selected={selected} 
+          onSelect={() => {
+            setSelected(!selected);
+            setThreadOpen(!threadOpen);
+          }}
+        >
           <Card.Header>
             <Card.HeaderContent>
               <Profile.Root>
@@ -927,14 +951,14 @@ with a **Provide feedback** action to respond to the feedback.
             <p style={{ margin: 0 }}>Modified text with suggested changes</p>
           </Card.Body>
 
-          <Card.Expansion open={feedbackOpen} onOpenChange={setFeedbackOpen}>
-            <Card.ExpansionTrigger>
-              <Button variant="outlined" className="tox-button--stretch">
-                View feedback (2)
-              </Button>
-            </Card.ExpansionTrigger>
-            <Card.ExpansionContent>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {threadOpen && (
+            <>
+              <Card.Divider />
+              <div 
+                style={{ paddingBottom: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}
+                onFocusCapture={() => setActionsVisible(true)}
+                onClick={(e) => e.stopPropagation()}
+              >
                 <div>
                   <Profile.Root>
                     <Profile.Image src={AVATAR_URL} alt="Sarah Chen" />
@@ -956,46 +980,38 @@ with a **Provide feedback** action to respond to the feedback.
                   <p style={{ margin: '8px 0 0' }}>Could we keep the original phrasing instead?</p>
                 </div>
 
-                <Card.Expansion open={replyOpen} onOpenChange={setReplyOpen}>
-                  {!replyOpen && (
-                    <Card.ExpansionTrigger>
-                      <Button variant="outlined" className="tox-button--stretch">
-                        Provide feedback
-                      </Button>
-                    </Card.ExpansionTrigger>
-                  )}
-                  <Card.ExpansionContent ariaLabel="Feedback editor">
-                    <AutoResizingTextarea
-                      value={reply}
-                      onChange={setReply}
-                      placeholder="Provide feedback..."
-                    />
-                    <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-                      <Button
-                        variant="outlined"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setReply('');
-                          setReplyOpen(false);
-                        }}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        variant="primary"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setReplyOpen(false);
-                        }}
-                      >
-                        Save
-                      </Button>
-                    </div>
-                  </Card.ExpansionContent>
-                </Card.Expansion>
+                <AutoResizingTextarea
+                  value={reply}
+                  onChange={setReply}
+                  placeholder="Provide feedback..."
+                />
+                {actionsVisible && (
+                  <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                    <Button
+                      variant="outlined"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setReply('');
+                        setActionsVisible(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setReply('');
+                        setActionsVisible(false);
+                      }}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                )}
               </div>
-            </Card.ExpansionContent>
-          </Card.Expansion>
+            </>
+          )}
         </Card.Root>
       </div>
     );

--- a/modules/oxide-components/src/main/ts/components/card/Card.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.stories.tsx
@@ -729,7 +729,7 @@ inside the card. Cancel collapses the expansion.
                 </Button>
               </Card.ExpansionTrigger>
             )}
-            <Card.ExpansionContent>
+            <Card.ExpansionContent ariaLabel="Feedback editor">
               <AutoResizingTextarea
                 value={feedback}
                 onChange={setFeedback}
@@ -844,7 +844,7 @@ with an **Add comment...** action that opens a reply editor.
                       </Button>
                     </Card.ExpansionTrigger>
                   )}
-                  <Card.ExpansionContent>
+                  <Card.ExpansionContent ariaLabel="Comment editor">
                     <AutoResizingTextarea
                       value={reply}
                       onChange={setReply}
@@ -890,7 +890,7 @@ export const ExpansionFeedbackReplies: Story = {
 **Card.Expansion — Feedback with Replies (Suggested Edits)**
 
 Shows a feedback thread where the original feedback can expand to show nested replies,
-with an **Provide feedback** action to respond to the feedback.
+with a **Provide feedback** action to respond to the feedback.
 
 **Try it:** Expand feedback thread, then Provide feedback.
         `
@@ -964,7 +964,7 @@ with an **Provide feedback** action to respond to the feedback.
                       </Button>
                     </Card.ExpansionTrigger>
                   )}
-                  <Card.ExpansionContent>
+                  <Card.ExpansionContent ariaLabel="Feedback editor">
                     <AutoResizingTextarea
                       value={reply}
                       onChange={setReply}

--- a/modules/oxide-components/src/main/ts/components/card/Card.stories.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { getAll as getAllIcons } from '@tinymce/oxide-icons-default';
 import { useEffect, useState } from 'react';
 
-import { Button, ExpandableBox, IconButton, UniverseProvider } from '../../main';
+import { Button, ExpandableBox, IconButton, AutoResizingTextarea, UniverseProvider } from '../../main';
 import * as Bem from '../../utils/Bem';
 import { Icon } from '../icon/Icon';
 import * as Profile from '../profile/Profile';
@@ -15,7 +15,8 @@ const icons: Record<string, string> = {
   'checkmark': allIcons.checkmark,
   'close': allIcons.close,
   'chevron-down': allIcons['chevron-down'],
-  'chevron-up': allIcons['chevron-up']
+  'chevron-up': allIcons['chevron-up'],
+  'feedback': allIcons.feedback
 };
 
 const mockUniverse = {
@@ -46,7 +47,7 @@ const meta = {
 The Card component is a reusable compound component for displaying content with actions.
 
 ## Features
-- **Compound Component Pattern**: Flexible composition with Root, Header, HeaderContent, HeaderActions, Body, and Actions
+- **Compound Component Pattern**: Flexible composition with Root, Header, HeaderContent, HeaderActions, Body, Actions, and Expansion
 - **State Management**: Supports selected and resolution states (accepted/rejected)
 - **Controlled Component**: Parent manages state via props
 - **Accessibility**: Proper ARIA attributes and keyboard support
@@ -60,6 +61,9 @@ The component uses a compound component pattern with these parts:
 - \`Card.HeaderActions\`: Right-side header action buttons with visibility modes (\`hover\` default, \`focus\`, \`always\`)
 - \`Card.Body\`: Main content area
 - \`Card.Actions\`: Bottom button container
+- \`Card.Expansion\`: Expandable section for nested content (feedback threads, comment replies)
+- \`Card.ExpansionTrigger\`: Button that toggles the expansion (Enter/Space)
+- \`Card.ExpansionContent\`: Animated collapsible content region
 
 ## Integration
 
@@ -67,6 +71,7 @@ Works seamlessly with other oxide-components:
 - **Button** / **IconButton**: For action buttons
 - **Profile**: For user info in HeaderContent
 - **ExpandableBox**: For long content
+- **AutoResizingTextarea**: For feedback/comment editors inside Expansion
 - **Icon**: For status indicators
         `
       }
@@ -669,6 +674,328 @@ This is useful for simple cards that only need action buttons without user info 
               More options
             </Button>
           </Card.Actions>
+        </Card.Root>
+      </div>
+    );
+  }
+};
+
+export const ExpansionProvideFeedback: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+**Card.Expansion — Provide Feedback (Suggested Edits)**
+
+Mirrors the Suggested Edits pattern: clicking **Provide feedback** expands an editor
+inside the card. Cancel collapses the expansion.
+
+**Try it:** Click or press Enter on Provide feedback.
+        `
+      }
+    }
+  },
+  render: () => {
+    const [ selected, setSelected ] = useState(true);
+    const [ open, setOpen ] = useState(false);
+    const [ feedback, setFeedback ] = useState('');
+
+    return (
+      <div style={{ width: '316px' }}>
+        <Card.Root selected={selected} onSelect={() => setSelected(!selected)}>
+          <Card.Header>
+            <Card.HeaderContent>
+              <Profile.Root>
+                <Profile.Image src={AVATAR_URL} alt="John Mac Giolla..." />
+                <Profile.Body>
+                  <Profile.Heading>John Mac Giolla...</Profile.Heading>
+                  <Profile.Subheading>May 18, 9:12 AM</Profile.Subheading>
+                </Profile.Body>
+              </Profile.Root>
+            </Card.HeaderContent>
+            <Card.HeaderActions visibilityMode="hover">
+              <IconButton variant="naked" icon="close" aria-label="Reject" />
+              <IconButton variant="naked" icon="checkmark" aria-label="Accept" />
+            </Card.HeaderActions>
+          </Card.Header>
+          <Card.Body>
+            <p style={{ margin: 0 }}>Modified text</p>
+          </Card.Body>
+          <Card.Expansion open={open} onOpenChange={setOpen}>
+            {!open && (
+              <Card.ExpansionTrigger>
+                <Button variant="outlined" className="tox-button--stretch">
+                  Provide feedback
+                </Button>
+              </Card.ExpansionTrigger>
+            )}
+            <Card.ExpansionContent>
+              <AutoResizingTextarea
+                value={feedback}
+                onChange={setFeedback}
+                placeholder="Provide feedback..."
+              />
+              <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                <Button
+                  variant="outlined"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setFeedback('');
+                    setOpen(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen(false);
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>
+      </div>
+    );
+  }
+};
+
+export const ExpansionCommentReplies: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+**Card.Expansion — Comment Replies**
+
+Mirrors the Comments pattern: a replies trigger expands nested reply cards,
+with an **Add comment...** action that opens a reply editor.
+
+**Try it:** Expand replies, then Add comment.
+        `
+      }
+    }
+  },
+  render: () => {
+    const [ selected, setSelected ] = useState(true);
+    const [ repliesOpen, setRepliesOpen ] = useState(false);
+    const [ replyOpen, setReplyOpen ] = useState(false);
+    const [ reply, setReply ] = useState('');
+
+    return (
+      <div style={{ width: '316px' }}>
+        <Card.Root selected={selected} onSelect={() => setSelected(!selected)}>
+          <Card.Header>
+            <Card.HeaderContent>
+              <Profile.Root>
+                <Profile.Image src={AVATAR_URL} alt="Jane Smith" />
+                <Profile.Body>
+                  <Profile.Heading>Jane Smith</Profile.Heading>
+                  <Profile.Subheading>
+                    May 19, 2:45 PM • 2 <Icon icon="feedback" aria-label="comments" />
+                  </Profile.Subheading>
+                </Profile.Body>
+              </Profile.Root>
+            </Card.HeaderContent>
+          </Card.Header>
+          <Card.Body>
+            <p style={{ margin: 0 }}>
+              Can we clarify this section before publishing?
+            </p>
+          </Card.Body>
+
+          <Card.Expansion open={repliesOpen} onOpenChange={setRepliesOpen}>
+            <Card.ExpansionTrigger>
+              <Button variant="outlined" className="tox-button--stretch">
+                2 replies
+              </Button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                <div>
+                  <Profile.Root>
+                    <Profile.Image src={AVATAR_URL} alt="Alex Rivera" />
+                    <Profile.Body>
+                      <Profile.Heading>Alex Rivera</Profile.Heading>
+                      <Profile.Subheading>May 19, 3:10 PM</Profile.Subheading>
+                    </Profile.Body>
+                  </Profile.Root>
+                  <p style={{ margin: '8px 0 0' }}>Agreed — the wording is ambiguous.</p>
+                </div>
+                <div>
+                  <Profile.Root>
+                    <Profile.Image src={AVATAR_URL} alt="Sam Lee" />
+                    <Profile.Body>
+                      <Profile.Heading>Sam Lee</Profile.Heading>
+                      <Profile.Subheading>May 19, 4:02 PM</Profile.Subheading>
+                    </Profile.Body>
+                  </Profile.Root>
+                  <p style={{ margin: '8px 0 0' }}>I can take a pass on a rewrite.</p>
+                </div>
+
+                <Card.Expansion open={replyOpen} onOpenChange={setReplyOpen}>
+                  {!replyOpen && (
+                    <Card.ExpansionTrigger>
+                      <Button variant="outlined" className="tox-button--stretch">
+                        Add comment...
+                      </Button>
+                    </Card.ExpansionTrigger>
+                  )}
+                  <Card.ExpansionContent>
+                    <AutoResizingTextarea
+                      value={reply}
+                      onChange={setReply}
+                      placeholder="Add comment..."
+                    />
+                    <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                      <Button
+                        variant="outlined"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setReply('');
+                          setReplyOpen(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="primary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setReplyOpen(false);
+                        }}
+                      >
+                        Comment
+                      </Button>
+                    </div>
+                  </Card.ExpansionContent>
+                </Card.Expansion>
+              </div>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>
+      </div>
+    );
+  }
+};
+
+export const ExpansionFeedbackReplies: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+**Card.Expansion — Feedback with Replies (Suggested Edits)**
+
+Shows a feedback thread where the original feedback can expand to show nested replies,
+with an **Provide feedback** action to respond to the feedback.
+
+**Try it:** Expand feedback thread, then Provide feedback.
+        `
+      }
+    }
+  },
+  render: () => {
+    const [ selected, setSelected ] = useState(true);
+    const [ feedbackOpen, setFeedbackOpen ] = useState(false);
+    const [ replyOpen, setReplyOpen ] = useState(false);
+    const [ reply, setReply ] = useState('');
+
+    return (
+      <div style={{ width: '316px' }}>
+        <Card.Root selected={selected} onSelect={() => setSelected(!selected)}>
+          <Card.Header>
+            <Card.HeaderContent>
+              <Profile.Root>
+                <Profile.Image src={AVATAR_URL} alt="John Mac Giolla..." />
+                <Profile.Body>
+                  <Profile.Heading>John Mac Giolla...</Profile.Heading>
+                  <Profile.Subheading>
+                    May 18, 9:12 AM • 2 <Icon icon="feedback" aria-label="feedback" />
+                  </Profile.Subheading>
+                </Profile.Body>
+              </Profile.Root>
+            </Card.HeaderContent>
+            <Card.HeaderActions visibilityMode="hover">
+              <IconButton variant="naked" icon="close" aria-label="Reject" />
+              <IconButton variant="naked" icon="checkmark" aria-label="Accept" />
+            </Card.HeaderActions>
+          </Card.Header>
+          <Card.Body>
+            <p style={{ margin: 0 }}>Modified text with suggested changes</p>
+          </Card.Body>
+
+          <Card.Expansion open={feedbackOpen} onOpenChange={setFeedbackOpen}>
+            <Card.ExpansionTrigger>
+              <Button variant="outlined" className="tox-button--stretch">
+                View feedback (2)
+              </Button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                <div>
+                  <Profile.Root>
+                    <Profile.Image src={AVATAR_URL} alt="Sarah Chen" />
+                    <Profile.Body>
+                      <Profile.Heading>Sarah Chen</Profile.Heading>
+                      <Profile.Subheading>May 18, 10:30 AM</Profile.Subheading>
+                    </Profile.Body>
+                  </Profile.Root>
+                  <p style={{ margin: '8px 0 0' }}>This change looks good to me.</p>
+                </div>
+                <div>
+                  <Profile.Root>
+                    <Profile.Image src={AVATAR_URL} alt="Mike Torres" />
+                    <Profile.Body>
+                      <Profile.Heading>Mike Torres</Profile.Heading>
+                      <Profile.Subheading>May 18, 11:15 AM</Profile.Subheading>
+                    </Profile.Body>
+                  </Profile.Root>
+                  <p style={{ margin: '8px 0 0' }}>Could we keep the original phrasing instead?</p>
+                </div>
+
+                <Card.Expansion open={replyOpen} onOpenChange={setReplyOpen}>
+                  {!replyOpen && (
+                    <Card.ExpansionTrigger>
+                      <Button variant="outlined" className="tox-button--stretch">
+                        Provide feedback
+                      </Button>
+                    </Card.ExpansionTrigger>
+                  )}
+                  <Card.ExpansionContent>
+                    <AutoResizingTextarea
+                      value={reply}
+                      onChange={setReply}
+                      placeholder="Provide feedback..."
+                    />
+                    <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                      <Button
+                        variant="outlined"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setReply('');
+                          setReplyOpen(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="primary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setReplyOpen(false);
+                        }}
+                      >
+                        Save
+                      </Button>
+                    </div>
+                  </Card.ExpansionContent>
+                </Card.Expansion>
+              </div>
+            </Card.ExpansionContent>
+          </Card.Expansion>
         </Card.Root>
       </div>
     );

--- a/modules/oxide-components/src/main/ts/components/card/Card.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.tsx
@@ -53,13 +53,7 @@ export interface CardExpansionProps extends PropsWithChildren {
    * Useful when multiple expansions exist in a list and parent needs stable identification.
    */
   readonly id?: string;
-  /**
-   * Open state (controlled).
-   */
   readonly open: boolean;
-  /**
-   * Called when the open state changes.
-   */
   readonly onOpenChange: (open: boolean) => void;
   readonly className?: string;
 }

--- a/modules/oxide-components/src/main/ts/components/card/Card.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.tsx
@@ -1,5 +1,5 @@
-import { Arr, Type } from '@ephox/katamari';
-import { useCallback, type FC, type PropsWithChildren } from 'react';
+import { Arr, Id, Type } from '@ephox/katamari';
+import { Children, cloneElement, createContext, isValidElement, useCallback, useContext, useEffect, useId, useMemo, useRef, useState, type FC, type MouseEvent as ReactMouseEvent, type PropsWithChildren, type ReactElement } from 'react';
 
 import * as Bem from '../../utils/Bem';
 
@@ -45,6 +45,44 @@ export interface CardActionsProps extends PropsWithChildren {
 
 export interface CardHighlightProps extends PropsWithChildren {
   readonly type: CardHighlightType;
+}
+
+export interface CardExpansionProps extends PropsWithChildren {
+  /**
+   * Optional unique identifier for this expansion.
+   * Useful when multiple expansions exist in a list and parent needs stable identification.
+   */
+  readonly id?: string;
+  /**
+   * Controlled open state. When provided, the expansion is controlled by the parent.
+   */
+  readonly open?: boolean;
+  /**
+   * Initial open state for uncontrolled mode.
+   * @default false
+   */
+  readonly defaultOpen?: boolean;
+  /**
+   * Called when the open state changes.
+   */
+  readonly onOpenChange?: (open: boolean) => void;
+  readonly className?: string;
+}
+
+export interface CardExpansionTriggerProps extends PropsWithChildren {
+  readonly className?: string;
+}
+
+export interface CardExpansionContentProps extends PropsWithChildren {
+  readonly className?: string;
+}
+
+interface CardExpansionContextValue {
+  readonly open: boolean;
+  readonly toggle: () => void;
+  readonly setOpen: (open: boolean) => void;
+  readonly contentId: string;
+  readonly triggerId: string;
 }
 
 const renderSkeletonLines = (lines: number) =>
@@ -203,6 +241,157 @@ const Highlight: FC<CardHighlightProps> = ({ children, type }) => {
   );
 };
 
+const CardExpansionContext = createContext<CardExpansionContextValue | null>(null);
+
+const useCardExpansion = (): CardExpansionContextValue => {
+  const context = useContext(CardExpansionContext);
+  if (context === null) {
+    throw new Error('Card Expansion components must be used within Card.Expansion');
+  }
+  return context;
+};
+
+const Expansion: FC<CardExpansionProps> = ({
+  children,
+  id,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  className
+}) => {
+  const [ uncontrolledOpen, setUncontrolledOpen ] = useState(defaultOpen);
+  const reactId = useId();
+  const fallbackId = useMemo(() => Id.generate('card-expansion'), []);
+
+  let baseId = fallbackId;
+  if (Type.isNonNullable(id)) {
+    baseId = id;
+  } else if (reactId.length > 0) {
+    baseId = reactId;
+  }
+
+  const isControlled = Type.isNonNullable(controlledOpen);
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  const setOpen = useCallback((nextOpen: boolean) => {
+    if (!isControlled) {
+      setUncontrolledOpen(nextOpen);
+    }
+    onOpenChange?.(nextOpen);
+  }, [ isControlled, onOpenChange ]);
+
+  const toggle = useCallback(() => {
+    setOpen(!open);
+  }, [ open, setOpen ]);
+
+  const contextValue = useMemo<CardExpansionContextValue>(() => ({
+    open,
+    toggle,
+    setOpen,
+    contentId: `${baseId}-content`,
+    triggerId: `${baseId}-trigger`
+  }), [ open, toggle, setOpen, baseId ]);
+
+  const expansionClassName = Bem.element('tox-card', 'expansion')
+    + (Type.isNonNullable(className) ? ` ${className}` : '');
+
+  return (
+    <CardExpansionContext.Provider value={contextValue}>
+      <div className={expansionClassName}>
+        {children}
+      </div>
+    </CardExpansionContext.Provider>
+  );
+};
+
+/**
+ * Trigger that toggles the expansion. Requires a single interactive child element.
+ *
+ * Enter and Space toggle via native button click behavior.
+ */
+const ExpansionTrigger: FC<CardExpansionTriggerProps> = ({ children, className }) => {
+  const { open, toggle, contentId, triggerId } = useCardExpansion();
+
+  const handleClick = useCallback((e: ReactMouseEvent) => {
+    e.stopPropagation();
+    toggle();
+  }, [ toggle ]);
+
+  const childArray = Children.toArray(children);
+  const singleChild = childArray.length === 1 ? childArray[0] : null;
+
+  if (!isValidElement(singleChild)) {
+    throw new Error('Card.ExpansionTrigger requires exactly one valid React element child');
+  }
+
+  const child = singleChild as ReactElement<{
+    'onClick'?: (e: ReactMouseEvent) => void;
+    'className'?: string;
+    'id'?: string;
+    'aria-expanded'?: boolean;
+    'aria-controls'?: string;
+  }>;
+
+  let mergedClassName = child.props.className;
+  if (Type.isNonNullable(className)) {
+    if (Type.isNonNullable(mergedClassName)) {
+      mergedClassName = `${mergedClassName} ${className}`;
+    } else {
+      mergedClassName = className;
+    }
+  }
+
+  return cloneElement(child, {
+    'id': child.props.id ?? triggerId,
+    'aria-expanded': open,
+    'aria-controls': contentId,
+    'className': mergedClassName,
+    'onClick': (e: ReactMouseEvent) => {
+      child.props.onClick?.(e);
+      if (!e.defaultPrevented) {
+        handleClick(e);
+      }
+    }
+  });
+};
+
+const ExpansionContent: FC<CardExpansionContentProps> = ({ children, className }) => {
+  const { open, contentId, triggerId } = useCardExpansion();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const element = contentRef.current;
+    if (Type.isNullable(element)) {
+      return;
+    }
+    if (open) {
+      element.removeAttribute('inert');
+    } else {
+      element.setAttribute('inert', '');
+    }
+  }, [ open ]);
+
+  const contentClassName = Bem.element('tox-card', 'expansion-content', {
+    expanded: open,
+    collapsed: !open
+  }) + (Type.isNonNullable(className) ? ` ${className}` : '');
+
+  return (
+    <div
+      ref={contentRef}
+      id={contentId}
+      role="region"
+      aria-labelledby={triggerId}
+      aria-hidden={!open}
+      className={contentClassName}
+    >
+      <div className={Bem.element('tox-card', 'expansion-content-inner')}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
 export {
   Root,
   Header,
@@ -210,7 +399,10 @@ export {
   HeaderActions,
   Body,
   Actions,
-  Highlight
+  Highlight,
+  Expansion,
+  ExpansionTrigger,
+  ExpansionContent
 };
 
 export { CardList, CardListController } from './CardList';

--- a/modules/oxide-components/src/main/ts/components/card/Card.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.tsx
@@ -47,6 +47,10 @@ export interface CardHighlightProps extends PropsWithChildren {
   readonly type: CardHighlightType;
 }
 
+export interface CardDividerProps {
+  readonly className?: string;
+}
+
 export interface CardExpansionProps extends PropsWithChildren {
   /**
    * Optional unique identifier for this expansion.
@@ -230,6 +234,13 @@ const Highlight: FC<CardHighlightProps> = ({ children, type }) => {
   );
 };
 
+const Divider: FC<CardDividerProps> = ({ className }) => {
+  const dividerClassName = Bem.element('tox-card', 'divider')
+    + (Type.isNonNullable(className) ? ` ${className}` : '');
+
+  return <hr className={dividerClassName} />;
+};
+
 const CardExpansionContext = createContext<CardExpansionContextValue | null>(null);
 
 const useCardExpansion = (): CardExpansionContextValue => {
@@ -380,6 +391,7 @@ export {
   Body,
   Actions,
   Highlight,
+  Divider,
   Expansion,
   ExpansionTrigger,
   ExpansionContent

--- a/modules/oxide-components/src/main/ts/components/card/Card.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.tsx
@@ -1,5 +1,5 @@
 import { Arr, Id, Type } from '@ephox/katamari';
-import { Children, cloneElement, createContext, isValidElement, useCallback, useContext, useEffect, useId, useMemo, useRef, useState, type FC, type MouseEvent as ReactMouseEvent, type PropsWithChildren, type ReactElement } from 'react';
+import { Children, cloneElement, createContext, isValidElement, useCallback, useContext, useEffect, useId, useMemo, useRef, type FC, type MouseEvent as ReactMouseEvent, type PropsWithChildren, type ReactElement } from 'react';
 
 import * as Bem from '../../utils/Bem';
 
@@ -54,18 +54,13 @@ export interface CardExpansionProps extends PropsWithChildren {
    */
   readonly id?: string;
   /**
-   * Controlled open state. When provided, the expansion is controlled by the parent.
+   * Open state (controlled).
    */
-  readonly open?: boolean;
-  /**
-   * Initial open state for uncontrolled mode.
-   * @default false
-   */
-  readonly defaultOpen?: boolean;
+  readonly open: boolean;
   /**
    * Called when the open state changes.
    */
-  readonly onOpenChange?: (open: boolean) => void;
+  readonly onOpenChange: (open: boolean) => void;
   readonly className?: string;
 }
 
@@ -80,7 +75,6 @@ export interface CardExpansionContentProps extends PropsWithChildren {
 interface CardExpansionContextValue {
   readonly open: boolean;
   readonly toggle: () => void;
-  readonly setOpen: (open: boolean) => void;
   readonly contentId: string;
   readonly triggerId: string;
 }
@@ -254,12 +248,10 @@ const useCardExpansion = (): CardExpansionContextValue => {
 const Expansion: FC<CardExpansionProps> = ({
   children,
   id,
-  open: controlledOpen,
-  defaultOpen = false,
+  open,
   onOpenChange,
   className
 }) => {
-  const [ uncontrolledOpen, setUncontrolledOpen ] = useState(defaultOpen);
   const reactId = useId();
   const fallbackId = useMemo(() => Id.generate('card-expansion'), []);
 
@@ -270,27 +262,16 @@ const Expansion: FC<CardExpansionProps> = ({
     baseId = reactId;
   }
 
-  const isControlled = Type.isNonNullable(controlledOpen);
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
-
-  const setOpen = useCallback((nextOpen: boolean) => {
-    if (!isControlled) {
-      setUncontrolledOpen(nextOpen);
-    }
-    onOpenChange?.(nextOpen);
-  }, [ isControlled, onOpenChange ]);
-
   const toggle = useCallback(() => {
-    setOpen(!open);
-  }, [ open, setOpen ]);
+    onOpenChange(!open);
+  }, [ open, onOpenChange ]);
 
   const contextValue = useMemo<CardExpansionContextValue>(() => ({
     open,
     toggle,
-    setOpen,
     contentId: `${baseId}-content`,
     triggerId: `${baseId}-trigger`
-  }), [ open, toggle, setOpen, baseId ]);
+  }), [ open, toggle, baseId ]);
 
   const expansionClassName = Bem.element('tox-card', 'expansion')
     + (Type.isNonNullable(className) ? ` ${className}` : '');

--- a/modules/oxide-components/src/main/ts/components/card/Card.tsx
+++ b/modules/oxide-components/src/main/ts/components/card/Card.tsx
@@ -70,6 +70,7 @@ export interface CardExpansionTriggerProps extends PropsWithChildren {
 
 export interface CardExpansionContentProps extends PropsWithChildren {
   readonly className?: string;
+  readonly ariaLabel?: string;
 }
 
 interface CardExpansionContextValue {
@@ -336,7 +337,7 @@ const ExpansionTrigger: FC<CardExpansionTriggerProps> = ({ children, className }
   });
 };
 
-const ExpansionContent: FC<CardExpansionContentProps> = ({ children, className }) => {
+const ExpansionContent: FC<CardExpansionContentProps> = ({ children, className, ariaLabel }) => {
   const { open, contentId, triggerId } = useCardExpansion();
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -357,12 +358,16 @@ const ExpansionContent: FC<CardExpansionContentProps> = ({ children, className }
     collapsed: !open
   }) + (Type.isNonNullable(className) ? ` ${className}` : '');
 
+  const labelProps = Type.isNonNullable(ariaLabel)
+    ? { 'aria-label': ariaLabel }
+    : { 'aria-labelledby': triggerId };
+
   return (
     <div
       ref={contentRef}
       id={contentId}
       role="region"
-      aria-labelledby={triggerId}
+      {...labelProps}
       aria-hidden={!open}
       className={contentClassName}
     >

--- a/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
@@ -1,6 +1,7 @@
 import * as Card from 'oxide-components/components/card/Card';
-import { Button, ExpandableBox, UniverseProvider } from 'oxide-components/main';
+import { AutoResizingTextarea, Button, ExpandableBox, UniverseProvider } from 'oxide-components/main';
 import * as Bem from 'oxide-components/utils/Bem';
+import { useState, type FC } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
@@ -837,6 +838,528 @@ describe('browser.components.CardTest', () => {
       expect(headerActions, 'HeaderActions element should exist').toBeTruthy();
       expect(headerContent, 'HeaderContent should not exist').toBeFalsy();
       expect(headerActions.querySelector('button'), 'HeaderActions button child should render').toBeTruthy();
+    });
+  });
+
+  describe('Expansion Tests', () => {
+    it('TINYMCE-14723: Should render Expansion with collapsed content by default', async () => {
+      const { container, getByRole } = render(
+        <Card.Root>
+          <Card.Body>Body</Card.Body>
+          <Card.Expansion>
+            <Card.ExpansionTrigger>
+              <button type="button">Provide feedback</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Feedback editor</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const expansion = container.querySelector(Bem.elementSelector('tox-card', 'expansion'));
+      const content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      const trigger = getByRole('button', { name: 'Provide feedback' });
+
+      expect(expansion, 'Expansion root should render').toBeTruthy();
+      expect(content, 'Expansion content should render').toBeTruthy();
+      expect(
+        content?.className,
+        'Content should have collapsed modifier by default'
+      ).toContain('tox-card__expansion-content--collapsed');
+      expect(trigger.element().getAttribute('aria-expanded'), 'Trigger should be collapsed').toBe('false');
+      expect(content?.getAttribute('aria-hidden'), 'Content should be aria-hidden when collapsed').toBe('true');
+    });
+
+    it('TINYMCE-14723: Should expand content when trigger is clicked', async () => {
+      const onOpenChange = vi.fn();
+      const { container, getByRole } = render(
+        <Card.Root>
+          <Card.Expansion onOpenChange={onOpenChange}>
+            <Card.ExpansionTrigger>
+              <button type="button">Provide feedback</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Feedback editor</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const trigger = getByRole('button', { name: 'Provide feedback' });
+      await userEvent.click(trigger);
+
+      const content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(trigger.element().getAttribute('aria-expanded'), 'Trigger should be expanded after click').toBe('true');
+      expect(
+        content?.className,
+        'Content should have expanded modifier after click'
+      ).toContain('tox-card__expansion-content--expanded');
+      expect(content?.getAttribute('aria-hidden'), 'Content should not be aria-hidden when expanded').toBe('false');
+      expect(onOpenChange, 'onOpenChange should be called with true').toHaveBeenCalledWith(true);
+    });
+
+    it('TINYMCE-14723: Should toggle expansion with Enter key', async () => {
+      const { container, getByRole } = render(
+        <Card.Root>
+          <Card.Expansion>
+            <Card.ExpansionTrigger>
+              <button type="button">Add comment...</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Reply editor</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const trigger = getByRole('button', { name: 'Add comment...' });
+      trigger.element().focus();
+      await userEvent.keyboard('{Enter}');
+
+      const content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(trigger.element().getAttribute('aria-expanded'), 'Enter should expand the trigger').toBe('true');
+      expect(
+        content?.className,
+        'Enter should apply expanded content class'
+      ).toContain('tox-card__expansion-content--expanded');
+    });
+
+    it('TINYMCE-14723: Should support controlled open state', async () => {
+      const onOpenChange = vi.fn();
+      const { container, rerender, getByRole } = render(
+        <Card.Root>
+          <Card.Expansion open={false} onOpenChange={onOpenChange}>
+            <Card.ExpansionTrigger>
+              <button type="button">2 replies</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Nested replies</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      let content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(content?.className, 'Controlled closed should be collapsed').toContain('tox-card__expansion-content--collapsed');
+
+      await userEvent.click(getByRole('button', { name: '2 replies' }));
+      expect(onOpenChange, 'Controlled mode should notify parent').toHaveBeenCalledWith(true);
+
+      rerender(
+        <Card.Root>
+          <Card.Expansion open={true} onOpenChange={onOpenChange}>
+            <Card.ExpansionTrigger>
+              <button type="button">2 replies</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Nested replies</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>
+      );
+
+      content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(content?.className, 'Controlled open should be expanded').toContain('tox-card__expansion-content--expanded');
+      expect(
+        getByRole('button', { name: '2 replies' }).element().getAttribute('aria-expanded'),
+        'Controlled open should set aria-expanded'
+      ).toBe('true');
+    });
+
+    it('TINYMCE-14723: Should wire aria-controls between trigger and content', async () => {
+      const { container, getByRole } = render(
+        <Card.Root>
+          <Card.Expansion>
+            <Card.ExpansionTrigger>
+              <button type="button">Provide feedback</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Feedback editor</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const trigger = getByRole('button', { name: 'Provide feedback' }).element();
+      const content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      const controlsId = trigger.getAttribute('aria-controls');
+
+      expect(controlsId, 'Trigger should have aria-controls').toBeTruthy();
+      expect(content?.id, 'Content id should match aria-controls').toBe(controlsId);
+      expect(content?.getAttribute('role'), 'Content should have role region').toBe('region');
+    });
+
+    it('TINYMCE-14723: Should support nested Expansion for comment reply composer', async () => {
+      const { getByRole, getByText } = render(
+        <Card.Root>
+          <Card.Expansion defaultOpen={true}>
+            <Card.ExpansionTrigger>
+              <button type="button">2 replies</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Existing reply</span>
+              <Card.Expansion>
+                <Card.ExpansionTrigger>
+                  <button type="button">Add comment...</button>
+                </Card.ExpansionTrigger>
+                <Card.ExpansionContent>
+                  <span>Nested reply editor</span>
+                </Card.ExpansionContent>
+              </Card.Expansion>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      expect(getByText('Existing reply').element(), 'Outer expansion content should be visible').toBeTruthy();
+
+      const addComment = getByRole('button', { name: 'Add comment...' });
+      expect(addComment.element().getAttribute('aria-expanded'), 'Nested trigger starts collapsed').toBe('false');
+
+      await userEvent.click(addComment);
+      expect(addComment.element().getAttribute('aria-expanded'), 'Nested trigger should expand').toBe('true');
+      expect(getByText('Nested reply editor').element(), 'Nested content should render').toBeTruthy();
+    });
+
+    it('TINYMCE-14723: Should not select card when Expansion trigger is activated', async () => {
+      const onSelect = vi.fn();
+      const { getByRole } = render(
+        <Card.CardList>
+          <Card.Root index={0} onSelect={onSelect}>
+            <Card.Expansion>
+              <Card.ExpansionTrigger>
+                <button type="button">Provide feedback</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Editor</span>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        </Card.CardList>,
+        { wrapper }
+      );
+
+      await userEvent.click(getByRole('button', { name: 'Provide feedback' }));
+      expect(onSelect, 'Card onSelect should not fire when clicking Expansion trigger').not.toHaveBeenCalled();
+    });
+
+    it('TINYMCE-14723: Should toggle expansion with Space key', async () => {
+      const { container, getByRole } = render(
+        <Card.Root>
+          <Card.Expansion>
+            <Card.ExpansionTrigger>
+              <button type="button">Provide feedback</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Feedback editor</span>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const trigger = getByRole('button', { name: 'Provide feedback' });
+      trigger.element().focus();
+      await userEvent.keyboard('{ }');
+
+      const content = container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(trigger.element().getAttribute('aria-expanded'), 'Space should expand the trigger').toBe('true');
+      expect(
+        content?.className,
+        'Space should apply expanded content class'
+      ).toContain('tox-card__expansion-content--expanded');
+    });
+
+    it('TINYMCE-14723: Provide feedback pattern should reveal textarea for typing', async () => {
+      const FeedbackComposer: FC = () => {
+        const [ open, setOpen ] = useState(false);
+        const [ feedback, setFeedback ] = useState('');
+
+        return (
+          <Card.Root>
+            <Card.Expansion open={open} onOpenChange={setOpen}>
+              {!open && (
+                <Card.ExpansionTrigger>
+                  <button type="button">Provide feedback</button>
+                </Card.ExpansionTrigger>
+              )}
+              <Card.ExpansionContent>
+                <AutoResizingTextarea
+                  value={feedback}
+                  onChange={setFeedback}
+                  placeholder="Provide feedback..."
+                />
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { getByRole, getByPlaceholder } = render(<FeedbackComposer />, { wrapper });
+
+      await userEvent.click(getByRole('button', { name: 'Provide feedback' }));
+
+      const textarea = getByPlaceholder('Provide feedback...');
+      expect(textarea.element(), 'Textarea should be available after Provide feedback').toBeTruthy();
+
+      await userEvent.type(textarea, 'Test feedback');
+      expect(
+        (textarea.element() as HTMLTextAreaElement).value,
+        'Typed feedback should appear in the textarea'
+      ).toBe('Test feedback');
+    });
+
+    it('TINYMCE-14723: Provide feedback pattern should hide trigger while composer is open', async () => {
+      const FeedbackComposer: FC = () => {
+        const [ open, setOpen ] = useState(false);
+
+        return (
+          <Card.Root>
+            <Card.Expansion open={open} onOpenChange={setOpen}>
+              {!open && (
+                <Card.ExpansionTrigger>
+                  <button type="button">Provide feedback</button>
+                </Card.ExpansionTrigger>
+              )}
+              <Card.ExpansionContent>
+                <span>Feedback editor</span>
+                <button type="button" onClick={() => setOpen(false)}>Cancel</button>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { getByRole, getByText, container } = render(<FeedbackComposer />, { wrapper });
+
+      await userEvent.click(getByRole('button', { name: 'Provide feedback' }));
+
+      expect(
+        container.querySelector('button[aria-expanded]'),
+        'Provide feedback trigger should be removed while composer is open'
+      ).toBeNull();
+      expect(getByText('Feedback editor').element(), 'Composer content should be visible').toBeTruthy();
+    });
+
+    it('TINYMCE-14723: Cancel should collapse the provide feedback composer', async () => {
+      const FeedbackComposer: FC = () => {
+        const [ open, setOpen ] = useState(false);
+        const [ feedback, setFeedback ] = useState('');
+
+        return (
+          <Card.Root>
+            <Card.Expansion open={open} onOpenChange={setOpen}>
+              {!open && (
+                <Card.ExpansionTrigger>
+                  <button type="button">Provide feedback</button>
+                </Card.ExpansionTrigger>
+              )}
+              <Card.ExpansionContent>
+                <AutoResizingTextarea
+                  value={feedback}
+                  onChange={setFeedback}
+                  placeholder="Provide feedback..."
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setFeedback('');
+                    setOpen(false);
+                  }}
+                >
+                  Cancel
+                </button>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { getByRole, getByPlaceholder, container } = render(<FeedbackComposer />, { wrapper });
+
+      await userEvent.click(getByRole('button', { name: 'Provide feedback' }));
+      await userEvent.type(getByPlaceholder('Provide feedback...'), 'Draft');
+      await userEvent.click(getByRole('button', { name: 'Cancel' }));
+
+      expect(
+        getByRole('button', { name: 'Provide feedback' }).element(),
+        'Provide feedback trigger should return after Cancel'
+      ).toBeTruthy();
+      expect(
+        container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'))?.className,
+        'Composer should be collapsed after Cancel'
+      ).toContain('tox-card__expansion-content--collapsed');
+      expect(
+        container.querySelector(Bem.elementSelector('tox-card', 'expansion-content'))?.getAttribute('aria-hidden'),
+        'Collapsed composer should be aria-hidden'
+      ).toBe('true');
+    });
+
+    it('TINYMCE-14723: Add comment pattern should open reply composer inside expanded replies', async () => {
+      const CommentThread: FC = () => {
+        const [ repliesOpen, setRepliesOpen ] = useState(true);
+        const [ replyOpen, setReplyOpen ] = useState(false);
+        const [ reply, setReply ] = useState('');
+
+        return (
+          <Card.Root>
+            <Card.Expansion open={repliesOpen} onOpenChange={setRepliesOpen}>
+              <Card.ExpansionTrigger>
+                <button type="button">2 replies</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Existing reply</span>
+                <Card.Expansion open={replyOpen} onOpenChange={setReplyOpen}>
+                  {!replyOpen && (
+                    <Card.ExpansionTrigger>
+                      <button type="button">Add comment...</button>
+                    </Card.ExpansionTrigger>
+                  )}
+                  <Card.ExpansionContent>
+                    <AutoResizingTextarea
+                      value={reply}
+                      onChange={setReply}
+                      placeholder="Add comment..."
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setReply('');
+                        setReplyOpen(false);
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </Card.ExpansionContent>
+                </Card.Expansion>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { getByRole, getByPlaceholder, getByText, container } = render(<CommentThread />, { wrapper });
+
+      expect(getByText('Existing reply').element(), 'Replies should be visible when outer expansion is open').toBeTruthy();
+      expect(
+        getByRole('button', { name: 'Add comment...' }).element(),
+        'Add comment trigger should be visible before opening composer'
+      ).toBeTruthy();
+
+      await userEvent.click(getByRole('button', { name: 'Add comment...' }));
+
+      expect(
+        Array.from(container.querySelectorAll('button')).some((button) => button.textContent === 'Add comment...'),
+        'Add comment trigger should be hidden while composer is open'
+      ).toBe(false);
+
+      const textarea = getByPlaceholder('Add comment...');
+      await userEvent.type(textarea, 'My reply');
+      expect(
+        (textarea.element() as HTMLTextAreaElement).value,
+        'Reply text should be typed into the composer'
+      ).toBe('My reply');
+    });
+
+    it('TINYMCE-14723: Cancel on nested comment composer should keep replies expansion open', async () => {
+      const CommentThread: FC = () => {
+        const [ repliesOpen, setRepliesOpen ] = useState(true);
+        const [ replyOpen, setReplyOpen ] = useState(false);
+
+        return (
+          <Card.Root>
+            <Card.Expansion open={repliesOpen} onOpenChange={setRepliesOpen}>
+              <Card.ExpansionTrigger>
+                <button type="button">2 replies</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Existing reply</span>
+                <Card.Expansion open={replyOpen} onOpenChange={setReplyOpen}>
+                  {!replyOpen && (
+                    <Card.ExpansionTrigger>
+                      <button type="button">Add comment...</button>
+                    </Card.ExpansionTrigger>
+                  )}
+                  <Card.ExpansionContent>
+                    <span>Reply editor</span>
+                    <button type="button" onClick={() => setReplyOpen(false)}>Cancel</button>
+                  </Card.ExpansionContent>
+                </Card.Expansion>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { getByRole, getByText, container } = render(<CommentThread />, { wrapper });
+
+      await userEvent.click(getByRole('button', { name: 'Add comment...' }));
+      await userEvent.click(getByRole('button', { name: 'Cancel' }));
+
+      expect(getByText('Existing reply').element(), 'Outer replies content should remain visible after Cancel').toBeTruthy();
+      expect(
+        getByRole('button', { name: 'Add comment...' }).element(),
+        'Add comment trigger should return after Cancel'
+      ).toBeTruthy();
+      expect(
+        getByRole('button', { name: '2 replies' }).element().getAttribute('aria-expanded'),
+        'Outer replies expansion should stay open after Cancel'
+      ).toBe('true');
+
+      const expansionContents = container.querySelectorAll(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(
+        expansionContents[0]?.className,
+        'Outer expansion content should remain expanded'
+      ).toContain('tox-card__expansion-content--expanded');
+      expect(
+        expansionContents[1]?.className,
+        'Inner composer should be collapsed after Cancel'
+      ).toContain('tox-card__expansion-content--collapsed');
+    });
+
+    it('TINYMCE-14723: Collapsed nested composer should stay aria-hidden while replies are expanded', async () => {
+      const { container, getByRole } = render(
+        <Card.Root>
+          <Card.Expansion defaultOpen={true}>
+            <Card.ExpansionTrigger>
+              <button type="button">2 replies</button>
+            </Card.ExpansionTrigger>
+            <Card.ExpansionContent>
+              <span>Existing reply</span>
+              <Card.Expansion>
+                <Card.ExpansionTrigger>
+                  <button type="button">Add comment...</button>
+                </Card.ExpansionTrigger>
+                <Card.ExpansionContent>
+                  <button type="button">Save reply</button>
+                </Card.ExpansionContent>
+              </Card.Expansion>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const expansionContents = container.querySelectorAll(Bem.elementSelector('tox-card', 'expansion-content'));
+      expect(
+        expansionContents[1]?.getAttribute('aria-hidden'),
+        'Nested composer should be aria-hidden while collapsed'
+      ).toBe('true');
+      expect(
+        expansionContents[1]?.hasAttribute('inert'),
+        'Nested composer should be inert while collapsed so it cannot be interacted with'
+      ).toBe(true);
+      expect(
+        getByRole('button', { name: 'Add comment...' }).element().getAttribute('aria-expanded'),
+        'Add comment trigger should report collapsed'
+      ).toBe('false');
     });
   });
 

--- a/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
@@ -1106,7 +1106,7 @@ describe('browser.components.CardTest', () => {
                   <button type="button">Provide feedback</button>
                 </Card.ExpansionTrigger>
               )}
-              <Card.ExpansionContent>
+              <Card.ExpansionContent ariaLabel="Feedback editor">
                 <AutoResizingTextarea
                   value={feedback}
                   onChange={setFeedback}
@@ -1144,7 +1144,7 @@ describe('browser.components.CardTest', () => {
                   <button type="button">Provide feedback</button>
                 </Card.ExpansionTrigger>
               )}
-              <Card.ExpansionContent>
+              <Card.ExpansionContent ariaLabel="Feedback editor">
                 <span>Feedback editor</span>
                 <button type="button" onClick={() => setOpen(false)}>Cancel</button>
               </Card.ExpansionContent>
@@ -1177,7 +1177,7 @@ describe('browser.components.CardTest', () => {
                   <button type="button">Provide feedback</button>
                 </Card.ExpansionTrigger>
               )}
-              <Card.ExpansionContent>
+              <Card.ExpansionContent ariaLabel="Feedback editor">
                 <AutoResizingTextarea
                   value={feedback}
                   onChange={setFeedback}
@@ -1238,7 +1238,7 @@ describe('browser.components.CardTest', () => {
                       <button type="button">Add comment...</button>
                     </Card.ExpansionTrigger>
                   )}
-                  <Card.ExpansionContent>
+                  <Card.ExpansionContent ariaLabel="Comment editor">
                     <AutoResizingTextarea
                       value={reply}
                       onChange={setReply}
@@ -1303,7 +1303,7 @@ describe('browser.components.CardTest', () => {
                       <button type="button">Add comment...</button>
                     </Card.ExpansionTrigger>
                   )}
-                  <Card.ExpansionContent>
+                  <Card.ExpansionContent ariaLabel="Comment editor">
                     <span>Reply editor</span>
                     <button type="button" onClick={() => setReplyOpen(false)}>Cancel</button>
                   </Card.ExpansionContent>

--- a/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
@@ -582,6 +582,36 @@ describe('browser.components.CardTest', () => {
     });
   });
 
+  describe('Divider Tests', () => {
+    it('TINYMCE-14723: Should render divider with correct class', async () => {
+      const { container } = render(
+        <Card.Root>
+          <Card.Body>Content above</Card.Body>
+          <Card.Divider />
+          <Card.Body>Content below</Card.Body>
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const divider = container.querySelector('.tox-card__divider');
+      expect(divider, 'Divider should render with correct class').toBeTruthy();
+      expect(divider?.tagName, 'Divider should be an hr element').toBe('HR');
+    });
+
+    it('TINYMCE-14723: Should support custom className', async () => {
+      const { container } = render(
+        <Card.Root>
+          <Card.Body>Content</Card.Body>
+          <Card.Divider className="custom-divider" />
+        </Card.Root>,
+        { wrapper }
+      );
+
+      const divider = container.querySelector('.tox-card__divider');
+      expect(divider?.className, 'Divider should include custom className').toContain('custom-divider');
+    });
+  });
+
   describe('Snapshot Tests', () => {
     it('TINY-13459: Should match snapshot for focused card in list', async () => {
       const { asFragment } = render(

--- a/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
@@ -1,3 +1,4 @@
+import { Fun } from '@ephox/katamari';
 import * as Card from 'oxide-components/components/card/Card';
 import { AutoResizingTextarea, Button, ExpandableBox, UniverseProvider } from 'oxide-components/main';
 import * as Bem from 'oxide-components/utils/Bem';
@@ -846,7 +847,7 @@ describe('browser.components.CardTest', () => {
       const { container, getByRole } = render(
         <Card.Root>
           <Card.Body>Body</Card.Body>
-          <Card.Expansion>
+          <Card.Expansion open={false} onOpenChange={Fun.noop}>
             <Card.ExpansionTrigger>
               <button type="button">Provide feedback</button>
             </Card.ExpansionTrigger>
@@ -876,7 +877,7 @@ describe('browser.components.CardTest', () => {
       const onOpenChange = vi.fn();
       const { container, getByRole } = render(
         <Card.Root>
-          <Card.Expansion onOpenChange={onOpenChange}>
+          <Card.Expansion open={false} onOpenChange={onOpenChange}>
             <Card.ExpansionTrigger>
               <button type="button">Provide feedback</button>
             </Card.ExpansionTrigger>
@@ -904,7 +905,7 @@ describe('browser.components.CardTest', () => {
     it('TINYMCE-14723: Should toggle expansion with Enter key', async () => {
       const { container, getByRole } = render(
         <Card.Root>
-          <Card.Expansion>
+          <Card.Expansion open={false} onOpenChange={Fun.noop}>
             <Card.ExpansionTrigger>
               <button type="button">Add comment...</button>
             </Card.ExpansionTrigger>
@@ -974,7 +975,7 @@ describe('browser.components.CardTest', () => {
     it('TINYMCE-14723: Should wire aria-controls between trigger and content', async () => {
       const { container, getByRole } = render(
         <Card.Root>
-          <Card.Expansion>
+          <Card.Expansion open={false} onOpenChange={Fun.noop}>
             <Card.ExpansionTrigger>
               <button type="button">Provide feedback</button>
             </Card.ExpansionTrigger>
@@ -998,13 +999,13 @@ describe('browser.components.CardTest', () => {
     it('TINYMCE-14723: Should support nested Expansion for comment reply composer', async () => {
       const { getByRole, getByText } = render(
         <Card.Root>
-          <Card.Expansion defaultOpen={true}>
+          <Card.Expansion open={true} onOpenChange={Fun.noop}>
             <Card.ExpansionTrigger>
               <button type="button">2 replies</button>
             </Card.ExpansionTrigger>
             <Card.ExpansionContent>
               <span>Existing reply</span>
-              <Card.Expansion>
+              <Card.Expansion open={false} onOpenChange={Fun.noop}>
                 <Card.ExpansionTrigger>
                   <button type="button">Add comment...</button>
                 </Card.ExpansionTrigger>
@@ -1033,7 +1034,7 @@ describe('browser.components.CardTest', () => {
       const { getByRole } = render(
         <Card.CardList>
           <Card.Root index={0} onSelect={onSelect}>
-            <Card.Expansion>
+            <Card.Expansion open={false} onOpenChange={Fun.noop}>
               <Card.ExpansionTrigger>
                 <button type="button">Provide feedback</button>
               </Card.ExpansionTrigger>
@@ -1053,7 +1054,7 @@ describe('browser.components.CardTest', () => {
     it('TINYMCE-14723: Should toggle expansion with Space key', async () => {
       const { container, getByRole } = render(
         <Card.Root>
-          <Card.Expansion>
+          <Card.Expansion open={false} onOpenChange={Fun.noop}>
             <Card.ExpansionTrigger>
               <button type="button">Provide feedback</button>
             </Card.ExpansionTrigger>
@@ -1327,13 +1328,13 @@ describe('browser.components.CardTest', () => {
     it('TINYMCE-14723: Collapsed nested composer should stay aria-hidden while replies are expanded', async () => {
       const { container, getByRole } = render(
         <Card.Root>
-          <Card.Expansion defaultOpen={true}>
+          <Card.Expansion open={true} onOpenChange={Fun.noop}>
             <Card.ExpansionTrigger>
               <button type="button">2 replies</button>
             </Card.ExpansionTrigger>
             <Card.ExpansionContent>
               <span>Existing reply</span>
-              <Card.Expansion>
+              <Card.Expansion open={false} onOpenChange={Fun.noop}>
                 <Card.ExpansionTrigger>
                   <button type="button">Add comment...</button>
                 </Card.ExpansionTrigger>

--- a/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.spec.tsx
@@ -874,20 +874,23 @@ describe('browser.components.CardTest', () => {
     });
 
     it('TINYMCE-14723: Should expand content when trigger is clicked', async () => {
-      const onOpenChange = vi.fn();
-      const { container, getByRole } = render(
-        <Card.Root>
-          <Card.Expansion open={false} onOpenChange={onOpenChange}>
-            <Card.ExpansionTrigger>
-              <button type="button">Provide feedback</button>
-            </Card.ExpansionTrigger>
-            <Card.ExpansionContent>
-              <span>Feedback editor</span>
-            </Card.ExpansionContent>
-          </Card.Expansion>
-        </Card.Root>,
-        { wrapper }
-      );
+      const TestComponent: FC = () => {
+        const [ open, setOpen ] = useState(false);
+        return (
+          <Card.Root>
+            <Card.Expansion open={open} onOpenChange={setOpen}>
+              <Card.ExpansionTrigger>
+                <button type="button">Provide feedback</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Feedback editor</span>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { container, getByRole } = render(<TestComponent />, { wrapper });
 
       const trigger = getByRole('button', { name: 'Provide feedback' });
       await userEvent.click(trigger);
@@ -899,23 +902,26 @@ describe('browser.components.CardTest', () => {
         'Content should have expanded modifier after click'
       ).toContain('tox-card__expansion-content--expanded');
       expect(content?.getAttribute('aria-hidden'), 'Content should not be aria-hidden when expanded').toBe('false');
-      expect(onOpenChange, 'onOpenChange should be called with true').toHaveBeenCalledWith(true);
     });
 
     it('TINYMCE-14723: Should toggle expansion with Enter key', async () => {
-      const { container, getByRole } = render(
-        <Card.Root>
-          <Card.Expansion open={false} onOpenChange={Fun.noop}>
-            <Card.ExpansionTrigger>
-              <button type="button">Add comment...</button>
-            </Card.ExpansionTrigger>
-            <Card.ExpansionContent>
-              <span>Reply editor</span>
-            </Card.ExpansionContent>
-          </Card.Expansion>
-        </Card.Root>,
-        { wrapper }
-      );
+      const TestComponent: FC = () => {
+        const [ open, setOpen ] = useState(false);
+        return (
+          <Card.Root>
+            <Card.Expansion open={open} onOpenChange={setOpen}>
+              <Card.ExpansionTrigger>
+                <button type="button">Add comment...</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Reply editor</span>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { container, getByRole } = render(<TestComponent />, { wrapper });
 
       const trigger = getByRole('button', { name: 'Add comment...' });
       trigger.element().focus();
@@ -997,27 +1003,32 @@ describe('browser.components.CardTest', () => {
     });
 
     it('TINYMCE-14723: Should support nested Expansion for comment reply composer', async () => {
-      const { getByRole, getByText } = render(
-        <Card.Root>
-          <Card.Expansion open={true} onOpenChange={Fun.noop}>
-            <Card.ExpansionTrigger>
-              <button type="button">2 replies</button>
-            </Card.ExpansionTrigger>
-            <Card.ExpansionContent>
-              <span>Existing reply</span>
-              <Card.Expansion open={false} onOpenChange={Fun.noop}>
-                <Card.ExpansionTrigger>
-                  <button type="button">Add comment...</button>
-                </Card.ExpansionTrigger>
-                <Card.ExpansionContent>
-                  <span>Nested reply editor</span>
-                </Card.ExpansionContent>
-              </Card.Expansion>
-            </Card.ExpansionContent>
-          </Card.Expansion>
-        </Card.Root>,
-        { wrapper }
-      );
+      const TestComponent: FC = () => {
+        const [ outerOpen, setOuterOpen ] = useState(true);
+        const [ innerOpen, setInnerOpen ] = useState(false);
+        return (
+          <Card.Root>
+            <Card.Expansion open={outerOpen} onOpenChange={setOuterOpen}>
+              <Card.ExpansionTrigger>
+                <button type="button">2 replies</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Existing reply</span>
+                <Card.Expansion open={innerOpen} onOpenChange={setInnerOpen}>
+                  <Card.ExpansionTrigger>
+                    <button type="button">Add comment...</button>
+                  </Card.ExpansionTrigger>
+                  <Card.ExpansionContent>
+                    <span>Nested reply editor</span>
+                  </Card.ExpansionContent>
+                </Card.Expansion>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { getByRole, getByText } = render(<TestComponent />, { wrapper });
 
       expect(getByText('Existing reply').element(), 'Outer expansion content should be visible').toBeTruthy();
 
@@ -1052,19 +1063,23 @@ describe('browser.components.CardTest', () => {
     });
 
     it('TINYMCE-14723: Should toggle expansion with Space key', async () => {
-      const { container, getByRole } = render(
-        <Card.Root>
-          <Card.Expansion open={false} onOpenChange={Fun.noop}>
-            <Card.ExpansionTrigger>
-              <button type="button">Provide feedback</button>
-            </Card.ExpansionTrigger>
-            <Card.ExpansionContent>
-              <span>Feedback editor</span>
-            </Card.ExpansionContent>
-          </Card.Expansion>
-        </Card.Root>,
-        { wrapper }
-      );
+      const TestComponent: FC = () => {
+        const [ open, setOpen ] = useState(false);
+        return (
+          <Card.Root>
+            <Card.Expansion open={open} onOpenChange={setOpen}>
+              <Card.ExpansionTrigger>
+                <button type="button">Provide feedback</button>
+              </Card.ExpansionTrigger>
+              <Card.ExpansionContent>
+                <span>Feedback editor</span>
+              </Card.ExpansionContent>
+            </Card.Expansion>
+          </Card.Root>
+        );
+      };
+
+      const { container, getByRole } = render(<TestComponent />, { wrapper });
 
       const trigger = getByRole('button', { name: 'Provide feedback' });
       trigger.element().focus();

--- a/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
@@ -161,7 +161,7 @@ describe('visual.CardTest', () => {
         <Card.Body>
           <p style={{ margin: 0 }}>Modified text</p>
         </Card.Body>
-        <Card.Expansion>
+        <Card.Expansion open={false} onOpenChange={Fun.noop}>
           <Card.ExpansionTrigger>
             <Button variant="outlined" className="tox-button--stretch">
               Provide feedback
@@ -201,7 +201,7 @@ describe('visual.CardTest', () => {
         <Card.Body>
           <p style={{ margin: 0 }}>Modified text</p>
         </Card.Body>
-        <Card.Expansion defaultOpen={true}>
+        <Card.Expansion open={true} onOpenChange={Fun.noop}>
           <Card.ExpansionTrigger>
             <Button variant="outlined" className="tox-button--stretch">
               Provide feedback
@@ -249,7 +249,7 @@ describe('visual.CardTest', () => {
           <Card.Body>
             <p style={{ margin: 0 }}>Modified text</p>
           </Card.Body>
-          <Card.Expansion open={open}>
+          <Card.Expansion open={open} onOpenChange={Fun.noop}>
             {!open && (
               <Card.ExpansionTrigger>
                 <Button variant="outlined" className="tox-button--stretch">
@@ -296,7 +296,7 @@ describe('visual.CardTest', () => {
         <Card.Body>
           <p style={{ margin: 0 }}>Can we clarify this section before publishing?</p>
         </Card.Body>
-        <Card.Expansion>
+        <Card.Expansion open={false} onOpenChange={Fun.noop}>
           <Card.ExpansionTrigger>
             <Button variant="outlined" className="tox-button--stretch">
               2 replies
@@ -314,7 +314,7 @@ describe('visual.CardTest', () => {
                 </Profile.Root>
                 <p style={{ margin: '8px 0 0' }}>Agreed — the wording is ambiguous.</p>
               </div>
-              <Card.Expansion>
+              <Card.Expansion open={false} onOpenChange={Fun.noop}>
                 <Card.ExpansionTrigger>
                   <Button variant="outlined" className="tox-button--stretch">
                     Add comment...
@@ -355,7 +355,7 @@ describe('visual.CardTest', () => {
         <Card.Body>
           <p style={{ margin: 0 }}>Can we clarify this section before publishing?</p>
         </Card.Body>
-        <Card.Expansion defaultOpen={true}>
+        <Card.Expansion open={true} onOpenChange={Fun.noop}>
           <Card.ExpansionTrigger>
             <Button variant="outlined" className="tox-button--stretch">
               2 replies
@@ -373,7 +373,7 @@ describe('visual.CardTest', () => {
                 </Profile.Root>
                 <p style={{ margin: '8px 0 0' }}>Agreed — the wording is ambiguous.</p>
               </div>
-              <Card.Expansion defaultOpen={true}>
+              <Card.Expansion open={true} onOpenChange={Fun.noop}>
                 <Card.ExpansionTrigger>
                   <Button variant="outlined" className="tox-button--stretch">
                     Add comment...
@@ -422,7 +422,7 @@ describe('visual.CardTest', () => {
         <Card.Body>
           <p style={{ margin: 0 }}>Modified text with suggested changes</p>
         </Card.Body>
-        <Card.Expansion defaultOpen={true}>
+        <Card.Expansion open={true} onOpenChange={Fun.noop}>
           <Card.ExpansionTrigger>
             <Button variant="outlined" className="tox-button--stretch">
               View feedback (2)
@@ -450,7 +450,7 @@ describe('visual.CardTest', () => {
                 </Profile.Root>
                 <p style={{ margin: '8px 0 0' }}>Could we keep the original phrasing instead?</p>
               </div>
-              <Card.Expansion>
+              <Card.Expansion open={false} onOpenChange={Fun.noop}>
                 <Card.ExpansionTrigger>
                   <Button variant="outlined" className="tox-button--stretch">
                     Provide feedback

--- a/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
@@ -1,10 +1,12 @@
-import { Obj } from '@ephox/katamari';
+import { Fun, Obj } from '@ephox/katamari';
+import { AutoResizingTextarea } from 'oxide-components/components/autoresizingtextarea/AutoResizingTextarea';
 import { Button } from 'oxide-components/components/button/Button';
 import * as Card from 'oxide-components/components/card/Card';
+import { Icon } from 'oxide-components/components/icon/Icon';
 import { IconButton } from 'oxide-components/components/iconbutton/IconButton';
 import * as Profile from 'oxide-components/components/profile/Profile';
 import { UniverseProvider } from 'oxide-components/contexts/UniverseContext/UniverseProvider';
-import type { ReactElement } from 'react';
+import { useState, type FC, type ReactElement } from 'react';
 import { describe, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
@@ -15,7 +17,8 @@ const AVATAR_URL = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"
 
 const icons: Record<string, string> = {
   close: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z"/></svg>',
-  checkmark: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.55 18L3.85 12.3L5.275 10.875L9.55 15.15L18.725 5.975L20.15 7.4L9.55 18Z"/></svg>'
+  checkmark: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.55 18L3.85 12.3L5.275 10.875L9.55 15.15L18.725 5.975L20.15 7.4L9.55 18Z"/></svg>',
+  feedback: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z"/></svg>'
 };
 
 const mockUniverse = {
@@ -135,5 +138,337 @@ describe('visual.CardTest', () => {
 
     await userEvent.hover(screen.getByRole('option'));
     await screen.expectScreenshot('card-header-actions-hover-revealed');
+  });
+
+  it('TINYMCE-14723: renders expansion collapsed by default', async () => {
+    const screen = renderCardVisual(
+      <Card.Root selected={true}>
+        <Card.Header>
+          <Card.HeaderContent>
+            <Profile.Root>
+              <Profile.Image src={AVATAR_URL} alt="John Mac Giolla" />
+              <Profile.Body>
+                <Profile.Heading>John Mac Giolla...</Profile.Heading>
+                <Profile.Subheading>May 18, 9:12 AM</Profile.Subheading>
+              </Profile.Body>
+            </Profile.Root>
+          </Card.HeaderContent>
+          <Card.HeaderActions visibilityMode="hover">
+            <IconButton variant="naked" icon="close" aria-label="Reject" />
+            <IconButton variant="naked" icon="checkmark" aria-label="Accept" />
+          </Card.HeaderActions>
+        </Card.Header>
+        <Card.Body>
+          <p style={{ margin: 0 }}>Modified text</p>
+        </Card.Body>
+        <Card.Expansion>
+          <Card.ExpansionTrigger>
+            <Button variant="outlined" className="tox-button--stretch">
+              Provide feedback
+            </Button>
+          </Card.ExpansionTrigger>
+          <Card.ExpansionContent>
+            <AutoResizingTextarea
+              value=""
+              onChange={Fun.noop}
+              placeholder="Provide feedback..."
+            />
+          </Card.ExpansionContent>
+        </Card.Expansion>
+      </Card.Root>
+    );
+    await screen.expectScreenshot('card-expansion-collapsed');
+  });
+
+  it('TINYMCE-14723: renders expansion expanded with textarea', async () => {
+    const screen = renderCardVisual(
+      <Card.Root selected={true}>
+        <Card.Header>
+          <Card.HeaderContent>
+            <Profile.Root>
+              <Profile.Image src={AVATAR_URL} alt="John Mac Giolla" />
+              <Profile.Body>
+                <Profile.Heading>John Mac Giolla...</Profile.Heading>
+                <Profile.Subheading>May 18, 9:12 AM</Profile.Subheading>
+              </Profile.Body>
+            </Profile.Root>
+          </Card.HeaderContent>
+          <Card.HeaderActions visibilityMode="hover">
+            <IconButton variant="naked" icon="close" aria-label="Reject" />
+            <IconButton variant="naked" icon="checkmark" aria-label="Accept" />
+          </Card.HeaderActions>
+        </Card.Header>
+        <Card.Body>
+          <p style={{ margin: 0 }}>Modified text</p>
+        </Card.Body>
+        <Card.Expansion defaultOpen={true}>
+          <Card.ExpansionTrigger>
+            <Button variant="outlined" className="tox-button--stretch">
+              Provide feedback
+            </Button>
+          </Card.ExpansionTrigger>
+          <Card.ExpansionContent>
+            <AutoResizingTextarea
+              value=""
+              onChange={Fun.noop}
+              placeholder="Provide feedback..."
+            />
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+              <Button variant="outlined">Cancel</Button>
+              <Button variant="primary">Save</Button>
+            </div>
+          </Card.ExpansionContent>
+        </Card.Expansion>
+      </Card.Root>
+    );
+    await screen.expectScreenshot('card-expansion-expanded');
+  });
+
+  it('TINYMCE-14723: renders expansion with trigger hidden when open', async () => {
+    const FeedbackComposer: FC = () => {
+      const [ open ] = useState(true);
+      const [ feedback ] = useState('');
+
+      return (
+        <Card.Root selected={true}>
+          <Card.Header>
+            <Card.HeaderContent>
+              <Profile.Root>
+                <Profile.Image src={AVATAR_URL} alt="John Mac Giolla" />
+                <Profile.Body>
+                  <Profile.Heading>John Mac Giolla...</Profile.Heading>
+                  <Profile.Subheading>May 18, 9:12 AM</Profile.Subheading>
+                </Profile.Body>
+              </Profile.Root>
+            </Card.HeaderContent>
+            <Card.HeaderActions visibilityMode="hover">
+              <IconButton variant="naked" icon="close" aria-label="Reject" />
+              <IconButton variant="naked" icon="checkmark" aria-label="Accept" />
+            </Card.HeaderActions>
+          </Card.Header>
+          <Card.Body>
+            <p style={{ margin: 0 }}>Modified text</p>
+          </Card.Body>
+          <Card.Expansion open={open}>
+            {!open && (
+              <Card.ExpansionTrigger>
+                <Button variant="outlined" className="tox-button--stretch">
+                  Provide feedback
+                </Button>
+              </Card.ExpansionTrigger>
+            )}
+            <Card.ExpansionContent>
+              <AutoResizingTextarea
+                value={feedback}
+                onChange={Fun.noop}
+                placeholder="Provide feedback..."
+              />
+              <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                <Button variant="outlined">Cancel</Button>
+                <Button variant="primary">Save</Button>
+              </div>
+            </Card.ExpansionContent>
+          </Card.Expansion>
+        </Card.Root>
+      );
+    };
+
+    const screen = renderCardVisual(<FeedbackComposer />);
+    await screen.expectScreenshot('card-expansion-trigger-hidden');
+  });
+
+  it('TINYMCE-14723: renders nested expansion for comment replies collapsed', async () => {
+    const screen = renderCardVisual(
+      <Card.Root selected={true}>
+        <Card.Header>
+          <Card.HeaderContent>
+            <Profile.Root>
+              <Profile.Image src={AVATAR_URL} alt="Jane Smith" />
+              <Profile.Body>
+                <Profile.Heading>Jane Smith</Profile.Heading>
+                <Profile.Subheading>
+                  May 19, 2:45 PM • 2 <Icon icon="feedback" aria-label="comments" />
+                </Profile.Subheading>
+              </Profile.Body>
+            </Profile.Root>
+          </Card.HeaderContent>
+        </Card.Header>
+        <Card.Body>
+          <p style={{ margin: 0 }}>Can we clarify this section before publishing?</p>
+        </Card.Body>
+        <Card.Expansion>
+          <Card.ExpansionTrigger>
+            <Button variant="outlined" className="tox-button--stretch">
+              2 replies
+            </Button>
+          </Card.ExpansionTrigger>
+          <Card.ExpansionContent>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div>
+                <Profile.Root>
+                  <Profile.Image src={AVATAR_URL} alt="Alex Rivera" />
+                  <Profile.Body>
+                    <Profile.Heading>Alex Rivera</Profile.Heading>
+                    <Profile.Subheading>May 19, 3:10 PM</Profile.Subheading>
+                  </Profile.Body>
+                </Profile.Root>
+                <p style={{ margin: '8px 0 0' }}>Agreed — the wording is ambiguous.</p>
+              </div>
+              <Card.Expansion>
+                <Card.ExpansionTrigger>
+                  <Button variant="outlined" className="tox-button--stretch">
+                    Add comment...
+                  </Button>
+                </Card.ExpansionTrigger>
+                <Card.ExpansionContent>
+                  <AutoResizingTextarea
+                    value=""
+                    onChange={Fun.noop}
+                    placeholder="Add comment..."
+                  />
+                </Card.ExpansionContent>
+              </Card.Expansion>
+            </div>
+          </Card.ExpansionContent>
+        </Card.Expansion>
+      </Card.Root>
+    );
+    await screen.expectScreenshot('card-expansion-nested-collapsed');
+  });
+
+  it('TINYMCE-14723: renders nested expansion for comment replies expanded', async () => {
+    const screen = renderCardVisual(
+      <Card.Root selected={true}>
+        <Card.Header>
+          <Card.HeaderContent>
+            <Profile.Root>
+              <Profile.Image src={AVATAR_URL} alt="Jane Smith" />
+              <Profile.Body>
+                <Profile.Heading>Jane Smith</Profile.Heading>
+                <Profile.Subheading>
+                  May 19, 2:45 PM • 2 <Icon icon="feedback" aria-label="comments" />
+                </Profile.Subheading>
+              </Profile.Body>
+            </Profile.Root>
+          </Card.HeaderContent>
+        </Card.Header>
+        <Card.Body>
+          <p style={{ margin: 0 }}>Can we clarify this section before publishing?</p>
+        </Card.Body>
+        <Card.Expansion defaultOpen={true}>
+          <Card.ExpansionTrigger>
+            <Button variant="outlined" className="tox-button--stretch">
+              2 replies
+            </Button>
+          </Card.ExpansionTrigger>
+          <Card.ExpansionContent>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div>
+                <Profile.Root>
+                  <Profile.Image src={AVATAR_URL} alt="Alex Rivera" />
+                  <Profile.Body>
+                    <Profile.Heading>Alex Rivera</Profile.Heading>
+                    <Profile.Subheading>May 19, 3:10 PM</Profile.Subheading>
+                  </Profile.Body>
+                </Profile.Root>
+                <p style={{ margin: '8px 0 0' }}>Agreed — the wording is ambiguous.</p>
+              </div>
+              <Card.Expansion defaultOpen={true}>
+                <Card.ExpansionTrigger>
+                  <Button variant="outlined" className="tox-button--stretch">
+                    Add comment...
+                  </Button>
+                </Card.ExpansionTrigger>
+                <Card.ExpansionContent>
+                  <AutoResizingTextarea
+                    value=""
+                    onChange={Fun.noop}
+                    placeholder="Add comment..."
+                  />
+                  <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                    <Button variant="outlined">Cancel</Button>
+                    <Button variant="primary">Comment</Button>
+                  </div>
+                </Card.ExpansionContent>
+              </Card.Expansion>
+            </div>
+          </Card.ExpansionContent>
+        </Card.Expansion>
+      </Card.Root>
+    );
+    await screen.expectScreenshot('card-expansion-nested-expanded');
+  });
+
+  it('TINYMCE-14723: renders feedback thread with nested replies', async () => {
+    const screen = renderCardVisual(
+      <Card.Root selected={true}>
+        <Card.Header>
+          <Card.HeaderContent>
+            <Profile.Root>
+              <Profile.Image src={AVATAR_URL} alt="John Mac Giolla" />
+              <Profile.Body>
+                <Profile.Heading>John Mac Giolla...</Profile.Heading>
+                <Profile.Subheading>
+                  May 18, 9:12 AM • 2 <Icon icon="feedback" aria-label="feedback" />
+                </Profile.Subheading>
+              </Profile.Body>
+            </Profile.Root>
+          </Card.HeaderContent>
+          <Card.HeaderActions visibilityMode="hover">
+            <IconButton variant="naked" icon="close" aria-label="Reject" />
+            <IconButton variant="naked" icon="checkmark" aria-label="Accept" />
+          </Card.HeaderActions>
+        </Card.Header>
+        <Card.Body>
+          <p style={{ margin: 0 }}>Modified text with suggested changes</p>
+        </Card.Body>
+        <Card.Expansion defaultOpen={true}>
+          <Card.ExpansionTrigger>
+            <Button variant="outlined" className="tox-button--stretch">
+              View feedback (2)
+            </Button>
+          </Card.ExpansionTrigger>
+          <Card.ExpansionContent>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div>
+                <Profile.Root>
+                  <Profile.Image src={AVATAR_URL} alt="Sarah Chen" />
+                  <Profile.Body>
+                    <Profile.Heading>Sarah Chen</Profile.Heading>
+                    <Profile.Subheading>May 18, 10:30 AM</Profile.Subheading>
+                  </Profile.Body>
+                </Profile.Root>
+                <p style={{ margin: '8px 0 0' }}>This change looks good to me.</p>
+              </div>
+              <div>
+                <Profile.Root>
+                  <Profile.Image src={AVATAR_URL} alt="Mike Torres" />
+                  <Profile.Body>
+                    <Profile.Heading>Mike Torres</Profile.Heading>
+                    <Profile.Subheading>May 18, 11:15 AM</Profile.Subheading>
+                  </Profile.Body>
+                </Profile.Root>
+                <p style={{ margin: '8px 0 0' }}>Could we keep the original phrasing instead?</p>
+              </div>
+              <Card.Expansion>
+                <Card.ExpansionTrigger>
+                  <Button variant="outlined" className="tox-button--stretch">
+                    Provide feedback
+                  </Button>
+                </Card.ExpansionTrigger>
+                <Card.ExpansionContent>
+                  <AutoResizingTextarea
+                    value=""
+                    onChange={Fun.noop}
+                    placeholder="Provide feedback..."
+                  />
+                </Card.ExpansionContent>
+              </Card.Expansion>
+            </div>
+          </Card.ExpansionContent>
+        </Card.Expansion>
+      </Card.Root>
+    );
+    await screen.expectScreenshot('card-expansion-feedback-thread');
   });
 });

--- a/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
@@ -259,7 +259,7 @@ describe('visual.CardTest', () => {
                 </Button>
               </Card.ExpansionTrigger>
             )}
-            <Card.ExpansionContent>
+            <Card.ExpansionContent ariaLabel="Feedback editor">
               <AutoResizingTextarea
                 value={feedback}
                 onChange={Fun.noop}

--- a/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
+++ b/modules/oxide-components/src/test/ts/browser/components/Card.visual.spec.tsx
@@ -1,4 +1,5 @@
 import { Fun, Obj } from '@ephox/katamari';
+import { getAll as getAllIcons } from '@tinymce/oxide-icons-default';
 import { AutoResizingTextarea } from 'oxide-components/components/autoresizingtextarea/AutoResizingTextarea';
 import { Button } from 'oxide-components/components/button/Button';
 import * as Card from 'oxide-components/components/card/Card';
@@ -15,10 +16,11 @@ import { renderVisual } from './utils/VisualTestUtils';
 // eslint-disable-next-line max-len
 const AVATAR_URL = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="36" height="36"%3E%3Ccircle cx="18" cy="18" r="18" fill="%234A90E2"/%3E%3Ctext x="18" y="24" text-anchor="middle" fill="white" font-size="14" font-family="sans-serif"%3EJM%3C/text%3E%3C/svg%3E';
 
+const allIcons = getAllIcons();
 const icons: Record<string, string> = {
-  close: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z"/></svg>',
-  checkmark: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.55 18L3.85 12.3L5.275 10.875L9.55 15.15L18.725 5.975L20.15 7.4L9.55 18Z"/></svg>',
-  feedback: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z"/></svg>'
+  close: allIcons.close,
+  checkmark: allIcons.checkmark,
+  feedback: allIcons.feedback
 };
 
 const mockUniverse = {

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-collapsed-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-collapsed-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea857a7655de76e6b210203b086412ce41bae1f594fd4b6f892fbfbc50255ecf
+size 10901

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-collapsed-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-collapsed-firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93d55275ea80cba3748cd8a56c60e7c38bf28e89046bce5f9b4ec018108302e2
+size 11085

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-collapsed-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-collapsed-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f42e37a6fb955ee1a9aaf0434dbb2241ac0cd2ccefc0b7e12692eab399d1ca0d
+size 10987

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-expanded-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-expanded-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:832a3b30fe44354aea3aad08283df8b9eea2fec4cc0e6a0c68a90cdc5373f92f
+size 16908

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-expanded-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-expanded-firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4c5d3b580b5bc163a260a3ec846073e591a44eb685a4e1098bc2b0b0b3d232f
+size 16965

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-expanded-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-expanded-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39dd30875921e06d8c8cc4667bdaa7326d28e68af7460edd600a473f4778e848
+size 16614

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-chromium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c79f48bf894aeef687ec37c334dfdd27579c4ef53790ed3e0f147a58bf6dee2
-size 38224
+oid sha256:7d4e71abb275ec3e5a79d9058d97469153717e80f33b68fd193cc8fc4c3de3c3
+size 38669

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c79f48bf894aeef687ec37c334dfdd27579c4ef53790ed3e0f147a58bf6dee2
+size 38224

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ed94804060931be1975b1f68d6c1c32c59757729e4f0b85bdd15ad5b91e9352
-size 39773
+oid sha256:fed319fbcf06f4c3af500c4bea022bd9883e55b76c48a51e04788bdebcbef747
+size 40270

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ed94804060931be1975b1f68d6c1c32c59757729e4f0b85bdd15ad5b91e9352
+size 39773

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce50b395d80c2ba312e5fbbe39054b0ade94d3b6b1cc0b90ac947cf30f23dc8b
+size 37217

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-feedback-thread-webkit.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce50b395d80c2ba312e5fbbe39054b0ade94d3b6b1cc0b90ac947cf30f23dc8b
-size 37217
+oid sha256:01a6a05ba15d1e411307ead4645e25e65f6575c724a80dbfb83c2f0aec0dee2a
+size 37683

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-chromium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6bc085c20e8e7f67ba5b79c0f70680a0f04bb9e3458a1da8b0fe64877e856e6a
-size 13652
+oid sha256:a68b6a9ff50da4ad560f994c90d293d75da1b3e28d4c2144a1a3b1ab8b734864
+size 13970

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bc085c20e8e7f67ba5b79c0f70680a0f04bb9e3458a1da8b0fe64877e856e6a
+size 13652

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b9b977cf705d6d6214badd209023a08e7c9a818b42ca1226e3aa0cabecc0d85
-size 14241
+oid sha256:9c278687b2c32cc6fa6a2729a69013d05e926160d87ed813598bd517d35b5ac8
+size 14714

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b9b977cf705d6d6214badd209023a08e7c9a818b42ca1226e3aa0cabecc0d85
+size 14241

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf5a55b8664e3cb64a9ccfc0f1e084650639c5f65a82b59496a0e4d29d756174
+size 13058

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-collapsed-webkit.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf5a55b8664e3cb64a9ccfc0f1e084650639c5f65a82b59496a0e4d29d756174
-size 13058
+oid sha256:4f6860d6238d4109eaaad739449c5fb200bab509a7e8b880d3dc815007678f2a
+size 13511

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-chromium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac713da6e11d659ab7a6e2ba1dcaa0b1ca3188473da007122d83739f108b1c9e
-size 30995
+oid sha256:a05cdb71265e7de438f508602d4b0473345908c2762282ae0fdd31e6a3712118
+size 31363

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac713da6e11d659ab7a6e2ba1dcaa0b1ca3188473da007122d83739f108b1c9e
+size 30995

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f2e0520bd575c9b060276f653738a58d8670263a6f1548c8baad3e6fc6baf68
+size 32077

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f2e0520bd575c9b060276f653738a58d8670263a6f1548c8baad3e6fc6baf68
-size 32077
+oid sha256:9c9b5de894253fd7a2c004abca95409e1f32be18c84cd7efc06a9b874f7ee86e
+size 32518

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02cfd5f34925f2d6d1c15b2f63a475e7c23eadb77370ceff5a983edfe1ed2215
+size 30295

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-nested-expanded-webkit.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02cfd5f34925f2d6d1c15b2f63a475e7c23eadb77370ceff5a983edfe1ed2215
-size 30295
+oid sha256:61b88f7f391f18c18871a9ce5207ff538555070d14e4b85cdaa6575e4904c294
+size 30758

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-trigger-hidden-chromium.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-trigger-hidden-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfc0bef44906f4aaafc87cd95aaa8215722cc2d4a0f4b098f92b6dab0bf9cd9b
+size 13986

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-trigger-hidden-firefox.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-trigger-hidden-firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a38147056e6726941237274c40f4084c27eeb02e3b9db1b7e6c662bf1f6a8c5a
+size 13856

--- a/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-trigger-hidden-webkit.png
+++ b/modules/oxide-components/src/test/ts/browser/components/__screenshots__/card-expansion-trigger-hidden-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd3169a04d8c5582cedf52caa34e3cd6933679e4066db79b7ee34940a6d354d
+size 13327

--- a/modules/oxide/src/less/theme/components/card/card.less
+++ b/modules/oxide/src/less/theme/components/card/card.less
@@ -195,6 +195,46 @@
       }
     }
 
+    &__expansion {
+      display: flex;
+      flex-direction: column;
+      gap: @card-section-gap;
+      width: 100%;
+    }
+
+    &__expansion-trigger {
+      width: 100%;
+    }
+
+    &__expansion-content {
+      display: grid;
+      grid-template-rows: 0fr;
+      transition: grid-template-rows 0.2s ease-in-out;
+
+      &--expanded {
+        grid-template-rows: 1fr;
+
+        // Direct child only — nested expansions must keep overflow:hidden when collapsed,
+        // otherwise their content spills out under the trigger.
+        > .tox-card__expansion-content-inner {
+          min-height: auto;
+          overflow: visible;
+        }
+      }
+
+      &--collapsed {
+        grid-template-rows: 0fr;
+      }
+    }
+
+    &__expansion-content-inner {
+      min-height: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      gap: @card-section-gap;
+    }
+
     &.tox-skeleton {
       cursor: default;
       pointer-events: none;

--- a/modules/oxide/src/less/theme/components/card/card.less
+++ b/modules/oxide/src/less/theme/components/card/card.less
@@ -195,6 +195,12 @@
       }
     }
 
+    &__divider {
+      margin: @card-section-gap 0;
+      border: none;
+      border-top: 1px solid @border-color;
+    }
+
     &__expansion {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
Related Ticket: [TINYMCE-14723](https://tiugotech.atlassian.net/browse/TINYMCE-14723)

Description of Changes:
* Added an `Card.Expansion` component for expandable content sections in feedback threads and comment replies. Support controlled mode, smooth animations, keyboard navigation and nested expansions for both Suggested Edits and Comments use cases.
* Most LOC added (~900 lines) are test coverage to ensure the component reliably handles both Suggested Edits and Comments plugin use cases.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINYMCE-14723]: https://tiugotech.atlassian.net/browse/TINYMCE-14723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ