### PR TITLE
TINYMCE-14765: Fix sidebar toggle scroll jumping when editor is unfocused

### DIFF
--- a/.changes/unreleased/tinymce-TINYMCE-14765-2026-08-14.yaml
+++ b/.changes/unreleased/tinymce-TINYMCE-14765-2026-08-14.yaml
@@ -1,0 +1,7 @@
+project: tinymce
+kind: Fixed
+body: Opening or closing sidebars from the toolbar no longer causes the editor to
+  scroll to the cursor when unfocused.
+time: 2026-08-14T22:59:00+10:00
+custom:
+  Issue: TINYMCE-14765

--- a/modules/tinymce/src/core/main/ts/api/Editor.ts
+++ b/modules/tinymce/src/core/main/ts/api/Editor.ts
@@ -401,7 +401,7 @@ class Editor implements EditorObservable {
    * @method focus
    * @param {Boolean} skipFocus Skip DOM focus. Just set is as the active editor.
    */
-  public focus(skipFocus?: boolean): void {
+  public focus(skipFocus?: EditorFocus.EditorFocusArg): void {
     this.execCommand('mceFocus', false, skipFocus);
   }
 

--- a/modules/tinymce/src/core/main/ts/api/commands/Commands.ts
+++ b/modules/tinymce/src/core/main/ts/api/commands/Commands.ts
@@ -29,8 +29,8 @@ const registerExecCommands = (editor: Editor): void => {
       editor.getWin().print();
     },
 
-    mceFocus: (_command, _ui, value?: boolean) => {
-      EditorFocus.focus(editor, value === true);
+    mceFocus: (_command, _ui, value?: EditorFocus.EditorFocusArg) => {
+      EditorFocus.focus(editor, value);
     },
 
     mceToggleVisualAid: () => {

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -127,10 +127,7 @@ const focusEditor = (editor: Editor, scrollToSelection: boolean) => {
   // Focus the window iframe
   if (!editor.inline) {
     // WebKit needs this call to fire focusin event properly see #5948
-    // But Opera pre Blink engine will produce an empty selection so skip Opera
-    if (!Env.browser.isOpera()) {
-      focusBody(body, preventScroll);
-    }
+    focusBody(body, preventScroll);
 
     if (preventScroll) {
       if (Type.isNonNullable(editor.iframeElement)) {

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -12,6 +12,12 @@ import * as SelectionBookmark from '../selection/SelectionBookmark';
 
 import * as FocusController from './FocusController';
 
+interface EditorFocusOptions {
+  readonly scrollToCursor?: boolean;
+}
+
+type EditorFocusArg = boolean | EditorFocusOptions;
+
 const getContentEditableHost = (editor: Editor, node: Node): HTMLElement | null =>
   editor.dom.getParent(node, (node): node is HTMLElement => editor.dom.getContentEditable(node) === 'true');
 
@@ -42,7 +48,12 @@ const normalizeSelection = (editor: Editor, rng: Range): void => {
   );
 };
 
-const focusBody = (body: HTMLElement & { setActive?: VoidFunction }) => {
+const focusBody = (body: HTMLElement & { setActive?: VoidFunction }, preventScroll = false) => {
+  if (preventScroll) {
+    body.focus({ preventScroll: true });
+    return;
+  }
+
   if (body.setActive) {
     // IE 11 sometimes throws "Invalid function" then fallback to focus
     // setActive is better since it doesn't scroll to the element being focused
@@ -79,9 +90,10 @@ const hasFocus = (editor: Editor): boolean => editor.inline ? hasInlineFocus(edi
 
 const hasEditorOrUiFocus = (editor: Editor): boolean => hasFocus(editor) || hasUiFocus(editor);
 
-const focusEditor = (editor: Editor) => {
+const focusEditor = (editor: Editor, scrollToCursor: boolean) => {
   const selection: EditorSelection = editor.selection;
   const body = editor.getBody();
+  const preventScroll = !scrollToCursor;
   let rng = selection.getRng();
   editor.quirks.refreshContentEditable();
 
@@ -100,10 +112,10 @@ const focusEditor = (editor: Editor) => {
   const contentEditableHost = getContentEditableHost(editor, selection.getNode());
   if (contentEditableHost && editor.dom.isChildOf(contentEditableHost, body)) {
     if (!hasContentEditableFalseParent(editor, contentEditableHost)) {
-      focusBody(body);
+      focusBody(body, preventScroll);
     }
 
-    focusBody(contentEditableHost);
+    focusBody(contentEditableHost, preventScroll);
     if (!editor.hasEditableRoot()) {
       restoreBookmark(editor);
     }
@@ -117,15 +129,21 @@ const focusEditor = (editor: Editor) => {
     // WebKit needs this call to fire focusin event properly see #5948
     // But Opera pre Blink engine will produce an empty selection so skip Opera
     if (!Env.browser.isOpera()) {
-      focusBody(body);
+      focusBody(body, preventScroll);
     }
 
-    editor.getWin().focus();
+    if (preventScroll) {
+      if (Type.isNonNullable(editor.iframeElement)) {
+        editor.iframeElement.focus({ preventScroll: true });
+      }
+    } else {
+      editor.getWin().focus();
+    }
   }
 
   // Focus the body as well since it's contentEditable
   if (Env.browser.isFirefox() || editor.inline) {
-    focusBody(body);
+    focusBody(body, preventScroll);
     normalizeSelection(editor, rng);
   }
 
@@ -134,20 +152,28 @@ const focusEditor = (editor: Editor) => {
 
 const activateEditor = (editor: Editor) => editor.editorManager.setActive(editor);
 
-const focus = (editor: Editor, skipFocus: boolean): void => {
+const focus = (editor: Editor, args?: EditorFocusArg): void => {
   if (editor.removed) {
     return;
   }
 
-  if (skipFocus) {
+  if (args === true) {
     activateEditor(editor);
-  } else {
-    focusEditor(editor);
+    return;
   }
+
+  if (Type.isNonNullable(args) && !Type.isBoolean(args)) {
+    focusEditor(editor, args.scrollToCursor !== false);
+    return;
+  }
+
+  focusEditor(editor, true);
 };
 
 export {
   focus,
   hasFocus,
-  hasEditorOrUiFocus
+  hasEditorOrUiFocus,
+  type EditorFocusOptions,
+  type EditorFocusArg
 };

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -13,7 +13,7 @@ import * as SelectionBookmark from '../selection/SelectionBookmark';
 import * as FocusController from './FocusController';
 
 interface EditorFocusOptions {
-  readonly scrollToCursor?: boolean;
+  readonly scrollToSelection?: boolean;
 }
 
 type EditorFocusArg = boolean | EditorFocusOptions;
@@ -90,10 +90,10 @@ const hasFocus = (editor: Editor): boolean => editor.inline ? hasInlineFocus(edi
 
 const hasEditorOrUiFocus = (editor: Editor): boolean => hasFocus(editor) || hasUiFocus(editor);
 
-const focusEditor = (editor: Editor, scrollToCursor: boolean) => {
+const focusEditor = (editor: Editor, scrollToSelection: boolean) => {
   const selection: EditorSelection = editor.selection;
   const body = editor.getBody();
-  const preventScroll = !scrollToCursor;
+  const preventScroll = !scrollToSelection;
   let rng = selection.getRng();
   editor.quirks.refreshContentEditable();
 
@@ -163,7 +163,7 @@ const focus = (editor: Editor, args?: EditorFocusArg): void => {
   }
 
   if (Type.isNonNullable(args) && !Type.isBoolean(args)) {
-    focusEditor(editor, args.scrollToCursor !== false);
+    focusEditor(editor, args.scrollToSelection !== false);
     return;
   }
 

--- a/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
+++ b/modules/tinymce/src/core/main/ts/focus/EditorFocus.ts
@@ -149,6 +149,14 @@ const focusEditor = (editor: Editor, scrollToSelection: boolean) => {
 
 const activateEditor = (editor: Editor) => editor.editorManager.setActive(editor);
 
+const normalizeFocusOptions = (args?: Exclude<EditorFocusArg, true>): EditorFocusOptions => {
+  if (Type.isNonNullable(args) && !Type.isBoolean(args)) {
+    return args;
+  }
+
+  return { scrollToSelection: true };
+};
+
 const focus = (editor: Editor, args?: EditorFocusArg): void => {
   if (editor.removed) {
     return;
@@ -159,12 +167,8 @@ const focus = (editor: Editor, args?: EditorFocusArg): void => {
     return;
   }
 
-  if (Type.isNonNullable(args) && !Type.isBoolean(args)) {
-    focusEditor(editor, args.scrollToSelection !== false);
-    return;
-  }
-
-  focusEditor(editor, true);
+  const options = normalizeFocusOptions(args);
+  focusEditor(editor, options.scrollToSelection !== false);
 };
 
 export {

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -103,13 +103,13 @@ describe('browser.tinymce.core.focus.EditorFocusTest', () => {
     });
   });
 
-  context('scrollToCursor option', () => {
+  context('scrollToSelection option', () => {
     const selectBody = () => {
       const body = SugarBody.body();
       Focus.focus(body);
     };
 
-    it('TINYMCE-14765: Focus with scrollToCursor false does not scroll the selection into view', async () => {
+    it('TINYMCE-14765: Focus with scrollToSelection false does not scroll the selection into view', async () => {
       const editor = await McEditor.pFromSettings<Editor>({
         menubar: false,
         height: 300,
@@ -120,7 +120,7 @@ describe('browser.tinymce.core.focus.EditorFocusTest', () => {
       editor.getWin().scrollTo(0, 0);
       selectBody();
       const scrollY = editor.getWin().scrollY;
-      editor.focus({ scrollToCursor: false });
+      editor.focus({ scrollToSelection: false });
       assert.isTrue(editor.hasFocus(), 'Editor should have focus');
       assert.equal(editor.getWin().scrollY, scrollY, 'Should not scroll the selection into view');
       McEditor.remove(editor);

--- a/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/focus/EditorFocusTest.ts
@@ -102,4 +102,28 @@ describe('browser.tinymce.core.focus.EditorFocusTest', () => {
       McEditor.remove(editor);
     });
   });
+
+  context('scrollToCursor option', () => {
+    const selectBody = () => {
+      const body = SugarBody.body();
+      Focus.focus(body);
+    };
+
+    it('TINYMCE-14765: Focus with scrollToCursor false does not scroll the selection into view', async () => {
+      const editor = await McEditor.pFromSettings<Editor>({
+        menubar: false,
+        height: 300,
+        base_url: '/project/tinymce/js/tinymce'
+      });
+      editor.setContent('<p>top</p><p style="height: 1000px">spacer</p><p>bottom</p>');
+      TinySelections.setCursor(editor, [ 2, 0 ], 0);
+      editor.getWin().scrollTo(0, 0);
+      selectBody();
+      const scrollY = editor.getWin().scrollY;
+      editor.focus({ scrollToCursor: false });
+      assert.isTrue(editor.hasFocus(), 'Editor should have focus');
+      assert.equal(editor.getWin().scrollY, scrollY, 'Should not scroll the selection into view');
+      McEditor.remove(editor);
+    });
+  });
 });

--- a/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/sidebar/Sidebar.ts
@@ -44,7 +44,7 @@ const setup = (editor: Editor): void => {
       icon: spec.icon,
       tooltip: spec.tooltip,
       onAction: (buttonApi) => {
-        editor.execCommand('ToggleSidebar', false, name);
+        editor.execCommand('ToggleSidebar', false, name, { skip_focus: true });
         buttonApi.setActive(isActive());
       },
       onSetup: (buttonApi) => {

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -5,8 +5,8 @@ import { SugarBody, SugarElement, Traverse } from '@ephox/sugar';
 import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
-import type { Sidebar } from 'tinymce/core/api/ui/Ui';
 import Env from 'tinymce/core/api/Env';
+import type { Sidebar } from 'tinymce/core/api/ui/Ui';
 
 interface EventLog {
   readonly name: string;

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -6,6 +6,7 @@ import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
 import type { Sidebar } from 'tinymce/core/api/ui/Ui';
+import Env from 'tinymce/core/api/Env';
 
 interface EventLog {
   readonly name: string;
@@ -225,6 +226,74 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarTest', () => {
       assertButtonEnabled('mysidebar1');
 
       editor.mode.set('design');
+    });
+  });
+
+  context('Sidebar toggle should not scroll to caret', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      height: 300,
+      toolbar: 'bold mysidebar1',
+      setup: (editor: Editor) => {
+        editor.ui.registry.addSidebar('mysidebar1', {
+          tooltip: 'My sidebar 1',
+          icon: 'comment',
+          onSetup: (api: Sidebar.SidebarInstanceApi) => {
+            api.element().appendChild(SugarElement.fromHtml('<div style="width: 200px;">Test</div>').dom);
+            return Fun.noop;
+          },
+          onShow: Fun.noop,
+          onHide: Fun.noop
+        });
+      }
+    });
+
+    const blurEditor = () => {
+      const body = SugarBody.body();
+      body.dom.focus();
+    };
+
+    it('TINYMCE-14765: Opening sidebar from toolbar does not scroll when editor unfocused', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p>top</p><p style="height: 1000px">spacer</p><p>bottom</p>');
+      editor.selection.select(editor.getBody().lastChild as Element);
+      editor.getWin().scrollTo(0, 0);
+      blurEditor();
+      const scrollY = editor.getWin().scrollY;
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="My sidebar 1"]');
+      await Waiter.pWait(100);
+      Assertions.assertEq('Should not scroll', scrollY, editor.getWin().scrollY);
+    });
+
+    it('TINYMCE-14765: Closing sidebar from toolbar does not scroll when editor unfocused', async () => {
+      const editor = hook.editor();
+      if (editor.queryCommandValue('ToggleSidebar') !== 'mysidebar1') {
+        TinyUiActions.clickOnToolbar(editor, 'button[aria-label="My sidebar 1"]');
+        await Waiter.pWait(100);
+      }
+      editor.selection.select(editor.getBody().lastChild as Element);
+      editor.getWin().scrollTo(0, 0);
+      blurEditor();
+      const scrollY = editor.getWin().scrollY;
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="My sidebar 1"]');
+      await Waiter.pWait(100);
+      Assertions.assertEq('Should not scroll', scrollY, editor.getWin().scrollY);
+    });
+
+    it('TINYMCE-14765: Bold from toolbar still scrolls when editor unfocused', async function () {
+      if (!Env.browser.isChromium()) {
+        this.skip();
+      }
+      const editor = hook.editor();
+      editor.setContent('<p>top</p><p style="height: 1000px">spacer</p><p>bottom</p>');
+      editor.selection.select(editor.getBody().lastChild as Element);
+      editor.getWin().scrollTo(0, 0);
+      blurEditor();
+      const scrollY = editor.getWin().scrollY;
+      TinyUiActions.clickOnToolbar(editor, 'button[aria-label="Bold"]');
+      await Waiter.pWait(100);
+      Assertions.assertEq('Should be focused', true, editor.hasFocus());
+      Assertions.assertEq('Should have scrolled', true, editor.getWin().scrollY > scrollY);
     });
   });
 });

--- a/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/sidebar/SidebarTest.ts
@@ -281,6 +281,8 @@ describe('browser.tinymce.themes.silver.sidebar.SidebarTest', () => {
     });
 
     it('TINYMCE-14765: Bold from toolbar still scrolls when editor unfocused', async function () {
+      // Scroll behavior works locally on Safari but CI Safari doesn't register the scroll change
+      // so we've agreed to keep chromium as a sanity check that we still attempt the scroll.
       if (!Env.browser.isChromium()) {
         this.skip();
       }


### PR DESCRIPTION
Related Ticket: [TINYMCE-14765](https://tiugotech.atlassian.net/browse/TINYMCE-14765)

Description of Changes:
* Opening or closing a sidebar from the toolbar no longer causes the editor to scroll to the cursor when the editor is unfocused. 
* Extended `editor.focus()` with a `scrollToCursor` option and updated Silver's sidebar buttons to pass `skip_focus: true` when toggling.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINYMCE-14765]: https://tiugotech.atlassian.net/browse/TINYMCE-14765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where opening or closing toolbar sidebars could scroll an unfocused editor to the cursor.
  * Sidebar toggling now preserves the current page scroll position.
  * Editor focus behavior now supports preventing automatic scrolling while retaining focus restoration.

* **Tests**
  * Added coverage confirming sidebar actions preserve scrolling and standard toolbar actions continue to focus and scroll the editor as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->