### PR TITLE
TINYMCE-14769: Added CSS rule to hide iframe when loading

### DIFF
--- a/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
+++ b/modules/oxide/src/less/theme/components/ai-preview/ai-preview.less
@@ -11,6 +11,13 @@
       inset: 0;
       display: flex;
       flex-direction: column;
+
+      &--loading {
+        .tox-ai__iframe {
+          visibility: hidden;
+          pointer-events: none;
+        }
+      }
     }
 
     .tox-ai__preview-frame-wrap {


### PR DESCRIPTION
Related Ticket: [TINYMCE-14769](https://tiugotech.atlassian.net/browse/TINYMCE-14769)

Description of Changes:
* During loading the preview iframe can show up empty and cover the editor with a blank grey panel. This hides the iframe (and blocks interaction with it) while the preview layer is in the loading state, so the editor stays visible under the dim overlay until content is ready.
* This is part of a larger effort to improve scroll persistence between the Preview iframe and editor content which is why we are temporarily pointing to `feature/TINYMCE-14765` which includes some other changes as well.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [x] Milestone set
* [x] Docs ticket created (if applicable)

GitHub issues (if applicable):


[TINYMCE-14769]: https://tiugotech.atlassian.net/browse/TINYMCE-14769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a loading state for the AI preview that hides the preview content and prevents interaction while it loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->