### PR TITLE
GH-11175: Fix table context toolbar jumping on keypress in small editors

### DIFF
--- a/.changes/unreleased/tinymce-GH-11175-2026-08-28.yaml
+++ b/.changes/unreleased/tinymce-GH-11175-2026-08-28.yaml
@@ -1,0 +1,6 @@
+project: tinymce
+kind: Fixed
+body: The table context toolbar no longer jumps up and down on every keypress when editing a small table in a small editor.
+time: 2026-08-28T09:00:00.000000000Z
+custom:
+  Issue: GH-11175

--- a/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/context/ContextToolbarAnchor.ts
@@ -70,12 +70,28 @@ const determineInsetLayout = (editor: Editor, contextbar: SugarElement<HTMLEleme
     // Preserve the position, get the bounds and then see if we have an overlap.
     // If overlapping and this wasn't triggered by a reposition then flip the placement
     return preservePosition(contextbar, data.getMode(), () => {
+      const contextbarBox = Boxes.box(contextbar);
       // TINY-8890: The negative 20px threshold here was arrived at by considering the use
       // case of a table with default heights for the rows. The threshold had to be
       // large enough so that the context toolbar would not prevent the user selecting
       // in the row containing the context toolbar.
-      const isOverlapping = isVerticalOverlap(selectionBounds, Boxes.box(contextbar), -20);
-      return isOverlapping && !data.isReposition() ? LayoutInset.flip : LayoutInset.preserve;
+      const isOverlapping = isVerticalOverlap(selectionBounds, contextbarBox, -20);
+      if (!isOverlapping || data.isReposition()) {
+        return LayoutInset.preserve;
+      }
+      // GH-11175: In a small editor (e.g. only a small table is visible) both the north
+      // and south inset placements can overlap the selection. Flipping then never moves the
+      // toolbar clear of the selection, so it would oscillate up and down on every keypress.
+      // Only flip when the opposite placement would actually avoid the overlap; otherwise
+      // preserve the current placement so the toolbar stays put.
+      const contextbarHeight = Height.get(contextbar) + bubbleSize;
+      const yBounds = data.getMode() === 'fixed' ? bounds.y + Scroll.get().top : bounds.y;
+      const northBox = Boxes.bounds(contextbarBox.x, yBounds, contextbarBox.width, contextbarHeight);
+      const southBox = Boxes.bounds(contextbarBox.x, yBounds + bounds.height - contextbarHeight, contextbarBox.width, contextbarHeight);
+      const currentIsNorth = Math.abs(contextbarBox.y - northBox.y) <= Math.abs(contextbarBox.y - southBox.y);
+      const oppositeBox = currentIsNorth ? southBox : northBox;
+      const oppositeOverlaps = isVerticalOverlap(selectionBounds, oppositeBox, -20);
+      return oppositeOverlaps ? LayoutInset.preserve : LayoutInset.flip;
     });
   } else {
     // Attempt to find the best layout to use that won't cause an overlap for the new anchor element

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarSmallEditorStabilityTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/contexttoolbar/ContextToolbarSmallEditorStabilityTest.ts
@@ -1,0 +1,61 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Arr, Fun } from '@ephox/katamari';
+import { Class, type SugarElement, SugarBody } from '@ephox/sugar';
+import { TinyContentActions, TinyHooks, TinySelections } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.contexttoolbar.ContextToolbarSmallEditorStability test', () => {
+  // GH-11175: A deliberately small editor with no chrome, so a small table fills the visible
+  // area and the table context toolbar is forced to use an inset layout for which both the
+  // north and south placements overlap the selection.
+  const hook = TinyHooks.bddSetup<Editor>({
+    menubar: false,
+    toolbar: false,
+    statusbar: false,
+    height: 100,
+    base_url: '/project/tinymce/js/tinymce',
+    content_style: 'html, body, p { margin: 0; padding: 0; } table { width: 100%; border-collapse: collapse; } td { border: 1px solid #ccc; } tr { height: 28px; }',
+    setup: (ed: Editor) => {
+      ed.ui.registry.addButton('alpha', { text: 'Alpha', onAction: Fun.noop });
+      ed.ui.registry.addContextToolbar('small-editor-table-toolbar', {
+        predicate: (node) => node.nodeName.toLowerCase() === 'table',
+        items: 'alpha',
+        position: 'node'
+      });
+    }
+  }, [], true);
+
+  const insetSelector = '.tox-pop.tox-pop--inset:not(.tox-pop--transition)';
+
+  const pWaitForSettledInsetSide = async (): Promise<'top' | 'bottom'> => {
+    const ele: SugarElement<HTMLElement> = await UiFinder.pWaitForVisible('Waiting for the settled inset context toolbar', SugarBody.body(), insetSelector);
+    return Class.has(ele, 'tox-pop--top') ? 'top' : 'bottom';
+  };
+
+  it('GH-11175: the table context toolbar should not oscillate between inset placements on repeated keypresses', async () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<table><tbody>' +
+      Arr.range(3, (i) => `<tr><td>Cell ${i + 1}</td></tr>`).join('') +
+      '</tbody></table>'
+    );
+
+    // Put the caret in the middle row so both inset placements overlap it.
+    TinySelections.setCursor(editor, [ 0, 0, 1, 0, 0 ], 0);
+    const initialSide = await pWaitForSettledInsetSide();
+
+    // Simulate typing. Each keyup re-triggers the context toolbar (via the throttled relaunch).
+    // Before the fix the inset placement flipped on every keyup because both placements overlap
+    // the selection, so it oscillated up and down. It should now stay on the same side.
+    for (let i = 0; i < 5; i++) {
+      TinyContentActions.keyup(editor, 32);
+      // Give a potential (unwanted) flip time to start transitioning before we re-check.
+      await Waiter.pWait(80);
+      const currentSide = await pWaitForSettledInsetSide();
+      assert.equal(currentSide, initialSide, `Inset placement should remain "${initialSide}" but became "${currentSide}" after keypress ${i + 1}`);
+    }
+  });
+});


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Fixed the table context toolbar oscillating up and down on every keypress when a small table filled a small editor.
* Root cause: in `ContextToolbarAnchor.ts`, when the selection overlapped the toolbar and it wasn't a reposition, the inset layout used `LayoutInset.flip`, which inverts the *current* placement. In a small editor both the north and south inset placements overlap the selection, so each keypress flipped to a side that still overlapped, flipping back on the next keypress.
* Fix: only flip when the opposite placement would actually clear the selection; otherwise preserve the current placement so the toolbar stays put. TINY-7192 (flip on overlap) and TINY-7545 (preserve on scroll) behaviour is unchanged.
* Added a regression test (`ContextToolbarSmallEditorStabilityTest.ts`) that fails without the fix and passes with it.

Pre-checks:
* [x] Changelog entry added
* [x] Tests have been added (if applicable)
* [x] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable): #11175
